### PR TITLE
Add Nikon 1 S2

### DIFF
--- a/camlibs/ptp2/cameras/nikon-s2.txt
+++ b/camlibs/ptp2/cameras/nikon-s2.txt
@@ -1,0 +1,402 @@
+Camera summary:
+Manufacturer: Nikon Corporation
+Model: S2
+  Version: Ver.1.0100
+  Serial Number: 000000000000000000000000nnnnnnnn
+Vendor Extension ID: 0xa (1.0)
+Vendor Extension Description: microsoft.com: 1.0
+
+Capture Formats: JPEG Undefined Type
+Display Formats: Undefined Type, Association/Directory, Script, DPOF, Apple Quicktime, JPEG, TIFF
+
+Device Capabilities:
+	File Download, File Deletion, File Upload
+	Generic Image Capture, No Open Capture, Nikon Capture 1, Nikon Capture 3 
+
+Storage Devices Summary:
+store_00010001:
+	StorageDescription: None
+	VolumeLabel: NIKON 1 S2 [Slot 1]
+
+	Storage Type: Removable RAM (memory card)
+	Filesystemtype: Digital Camera Layout (DCIM)
+	Access Capability: Read Only with Object deletion
+	Maximum Capability: 15923150848 (15185 MB)
+	Free Space (Bytes): 15911616512 (15174 MB)
+	Free Space (Images): 1752
+
+Device Property Summary:
+Battery Level(0x5001):(read only) (type=0x2) Range [0 - 100, step 1] value: 100% (100)
+Compression Setting(0x5004):(read only) (type=0x2) Enumeration [0,1,2,4,7] value: JPEG Fine (2)
+F-Number(0x5007):(read only) (type=0x4) Enumeration [100,110,120,130,140,150,160,170,180,190,200,220,240,250,270,280,300,320,350,380,400,420,450,480,500,530,560,600,630,670,710,760,800,850,900,950,1000,1100,1200,1300,1400,1500,1600,1700,1800,1900,2000,2100,2200,2400,2500,2760,2900,3000,3200,0] value: f/5.6 (560)
+Exposure Program Mode(0x500e):(read only) (type=0x4) Enumeration [32784,32785,32786,32787,32788] value: Auto (32784)
+Date & Time(0x5011):(readwrite) (type=0xffff) '20150924T102832'
+Property 0xd303:(read only) (type=0x2) 1
+Property 0xd406:(readwrite) (type=0xffff) 'Windows/6.0.5330.0 MTPClassDriver/6.0.5330.0'
+Property 0xd407:(read only) (type=0x6) 1
+Live View AF Area(0xd05d):(readwrite) (type=0x2) Range [0 - 2, step 1] value: 0
+Bracketing Enable(0xd0c0):(read only) (type=0x2) Range [0 - 0, step 1] value: Off (0)
+Lens Sort(0xd0e1):(read only) (type=0x2) Range [0 - 1, step 1] value: 1
+Property 0xd038:(readwrite) (type=0x2) Enumeration [0,1,2,3,8,9,10,11,12,13,14] value: 12
+Nikon Exposure Time(0xd100):(read only) (type=0x6) Enumeration [4294967295,1966081,1638401,1310721,983041,851969,655361,524289,393217,327681,262145,196609,1638410,131073,1048586,983050,851978,65537,655373,655375,655376,65538,655385,65539,65540,65541,65542,65544,65546,65549,65551,65556,65561,65566,65576,65581,65586,65596,65616,65626,65636,65661,65696,65716,65736,65786,65856,65886,65936,66036,66176,66286,66336,66536,66786,67036,67136,67536,68036,68536,68736,69536,70536,71536,71936,73536,74536,75536,78036,78536,80536,81536] value: 65786
+AC Power(0xd101):(read only) (type=0x2) Range [0 - 1, step 1] value: Yes (1)
+Warning Status(0xd102):(read only) (type=0x2) 0
+Flash Open(0xd1c0):(read only) (type=0x2) Range [0 - 1, step 1] value: No (0)
+Live View Status(0xd1a2):(read only) (type=0x2) Range [0 - 1, step 1] value: Yes (1)
+Live View Prohibit Condition(0xd1a4):(read only) (type=0x6) 8388608
+Property 0xf001:(readwrite) (type=0x2) Enumeration [0,1,2,3,4] value: 0
+ISO(0xf002):(readwrite) (type=0x2) Range [0 - 52, step 1] value: 1
+Property 0xf003:(readwrite) (type=0x2) Range [0 - 60, step 1] value: 0
+Property 0xf004:(readwrite) (type=0x2) Range [224 - 84, step 1] value: 0
+Property 0xf005:(read only) (type=0x2) Range [30 - 72, step 1] value: 0
+Property 0xf006:(readwrite) (type=0x2) Range [0 - 60, step 1] value: 0
+Property 0xf007:(readwrite) (type=0x2) Range [224 - 84, step 1] value: 0
+Property 0xf008:(read only) (type=0x2) Range [30 - 60, step 1] value: 0
+Image Compression(0xf009):(readwrite) (type=0x2) Enumeration [0,1,2,3,6] value: 1
+Image Size(0xf00a):(readwrite) (type=0x2) Range [0 - 2, step 1] value: 2
+White Balance(0xf00c):(readwrite) (type=0x2) Enumeration [0,1,2,3,4,5,6,9] value: 0
+Long Exposure Noise Reduction(0xf00d):(readwrite) (type=0x2) Range [0 - 1, step 1] value: 0
+High ISO Noise Reduction(0xf00e):(readwrite) (type=0x2) Enumeration [0,3] value: 0
+Active D-Lighting(0xf00f):(readwrite) (type=0x2) Enumeration [0,5] value: 5
+Property 0xf010:(readwrite) (type=0x2) Range [0 - 1, step 1] value: 0
+Property 0xf011:(read only) (type=0x4) Enumeration [4,1,2,0] value: 3
+Property 0xf012:(readwrite) (type=0x2) Range [0 - 2, step 1] value: 0
+Property 0xf013:(readwrite) (type=0x2) Range [0 - 1, step 1] value: 1
+Property 0xf015:(readwrite) (type=0x2) Range [0 - 2, step 1] value: 0
+Property 0xf016:(readwrite) (type=0x2) Range [0 - 1, step 1] value: 0
+Property 0xf018:(readwrite) (type=0x4) Enumeration [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31] value: 3
+Property 0xf019:(readwrite) (type=0x2) Range [0 - 1, step 1] value: 0
+Property 0xf01a:(readwrite) (type=0x2) Range [0 - 1, step 1] value: 0
+Property 0xf01b:(readwrite) (type=0x2) Enumeration [0,1,2,3,4,5] value: 0
+Movie Quality(0xf01c):(readwrite) (type=0x2) Enumeration [0,1,2,3] value: 1
+Property 0xf00b:(readwrite) (type=0x2) Enumeration [0,1] value: 1
+Property 0xf014:(readwrite) (type=0x2) Range [1 - 254, step 1] value: 68
+
+/main/actions/autofocusdrive
+Label: Drive Nikon DSLR Autofocus
+Type: TOGGLE
+Current: 0
+/main/actions/controlmode
+Label: Set Nikon Control Mode
+Type: TEXT
+Current: 0
+/main/actions/viewfinder
+Label: Nikon Viewfinder
+Type: TOGGLE
+Current: 1
+/main/settings/datetime
+Label: Camera Date and Time
+Type: DATE
+Current: 1443086757
+Printable: Thu 24 Sep 2015 11:25:57 AM CEST
+/main/settings/fastfs
+Label: Fast Filesystem
+Type: TOGGLE
+Current: 1
+/main/settings/capturetarget
+Label: Capture Target
+Type: RADIO
+Current: Internal RAM
+Choice: 0 Internal RAM
+Choice: 1 Memory card
+/main/status/serialnumber
+Label: Serial Number
+Type: TEXT
+Current: 000000000000000000000000nnnnnnnn
+/main/status/manufacturer
+Label: Camera Manufacturer
+Type: TEXT
+Current: Nikon Corporation
+/main/status/cameramodel
+Label: Camera Model
+Type: TEXT
+Current: S2
+/main/status/deviceversion
+Label: Device Version
+Type: TEXT
+Current: Ver.1.0100
+/main/status/vendorextension
+Label: Vendor Extension
+Type: TEXT
+Current: microsoft.com: 1.0
+/main/status/batterylevel
+Label: Battery Level
+Type: TEXT
+Current: 100%
+/main/capturesettings/f-number
+Label: F-Number
+Type: RADIO
+Current: f/5.6
+Choice: 0 f/1
+Choice: 1 f/1.1
+Choice: 2 f/1.2
+Choice: 3 f/1.3
+Choice: 4 f/1.4
+Choice: 5 f/1.5
+Choice: 6 f/1.6
+Choice: 7 f/1.7
+Choice: 8 f/1.8
+Choice: 9 f/1.9
+Choice: 10 f/2
+Choice: 11 f/2.2
+Choice: 12 f/2.4
+Choice: 13 f/2.5
+Choice: 14 f/2.7
+Choice: 15 f/2.8
+Choice: 16 f/3
+Choice: 17 f/3.2
+Choice: 18 f/3.5
+Choice: 19 f/3.8
+Choice: 20 f/4
+Choice: 21 f/4.2
+Choice: 22 f/4.5
+Choice: 23 f/4.8
+Choice: 24 f/5
+Choice: 25 f/5.3
+Choice: 26 f/5.6
+Choice: 27 f/6
+Choice: 28 f/6.3
+Choice: 29 f/6.7
+Choice: 30 f/7.1
+Choice: 31 f/7.6
+Choice: 32 f/8
+Choice: 33 f/8.5
+Choice: 34 f/9
+Choice: 35 f/9.5
+Choice: 36 f/10
+Choice: 37 f/11
+Choice: 38 f/12
+Choice: 39 f/13
+Choice: 40 f/14
+Choice: 41 f/15
+Choice: 42 f/16
+Choice: 43 f/17
+Choice: 44 f/18
+Choice: 45 f/19
+Choice: 46 f/20
+Choice: 47 f/21
+Choice: 48 f/22
+Choice: 49 f/24
+Choice: 50 f/25
+Choice: 51 f/27.6
+Choice: 52 f/29
+Choice: 53 f/30
+Choice: 54 f/32
+Choice: 55 f/0
+/main/capturesettings/imagequality
+Label: Image Quality
+Type: RADIO
+Current: JPEG Fine
+Choice: 0 JPEG Basic
+Choice: 1 JPEG Normal
+Choice: 2 JPEG Fine
+Choice: 3 NEF (Raw)
+Choice: 4 NEF+Fine
+/main/capturesettings/expprogram
+Label: Exposure Program
+Type: RADIO
+Current: Auto
+Choice: 0 Auto
+Choice: 1 Portrait
+Choice: 2 Landscape
+Choice: 3 Macro
+Choice: 4 Sports
+/main/other/5001
+Label: Battery Level
+Type: MENU
+Current: 100
+Choice: 0 0
+Choice: 1 1
+Choice: 2 2
+Choice: 3 3
+Choice: 4 4
+Choice: 5 5
+Choice: 6 6
+Choice: 7 7
+Choice: 8 8
+Choice: 9 9
+Choice: 10 10
+Choice: 11 11
+Choice: 12 12
+Choice: 13 13
+Choice: 14 14
+Choice: 15 15
+Choice: 16 16
+Choice: 17 17
+Choice: 18 18
+Choice: 19 19
+Choice: 20 20
+Choice: 21 21
+Choice: 22 22
+Choice: 23 23
+Choice: 24 24
+Choice: 25 25
+Choice: 26 26
+Choice: 27 27
+Choice: 28 28
+Choice: 29 29
+Choice: 30 30
+Choice: 31 31
+Choice: 32 32
+Choice: 33 33
+Choice: 34 34
+Choice: 35 35
+Choice: 36 36
+Choice: 37 37
+Choice: 38 38
+Choice: 39 39
+Choice: 40 40
+Choice: 41 41
+Choice: 42 42
+Choice: 43 43
+Choice: 44 44
+Choice: 45 45
+Choice: 46 46
+Choice: 47 47
+Choice: 48 48
+Choice: 49 49
+Choice: 50 50
+Choice: 51 51
+Choice: 52 52
+Choice: 53 53
+Choice: 54 54
+Choice: 55 55
+Choice: 56 56
+Choice: 57 57
+Choice: 58 58
+Choice: 59 59
+Choice: 60 60
+Choice: 61 61
+Choice: 62 62
+Choice: 63 63
+Choice: 64 64
+Choice: 65 65
+Choice: 66 66
+Choice: 67 67
+Choice: 68 68
+Choice: 69 69
+Choice: 70 70
+Choice: 71 71
+Choice: 72 72
+Choice: 73 73
+Choice: 74 74
+Choice: 75 75
+Choice: 76 76
+Choice: 77 77
+Choice: 78 78
+Choice: 79 79
+Choice: 80 80
+Choice: 81 81
+Choice: 82 82
+Choice: 83 83
+Choice: 84 84
+Choice: 85 85
+Choice: 86 86
+Choice: 87 87
+Choice: 88 88
+Choice: 89 89
+Choice: 90 90
+Choice: 91 91
+Choice: 92 92
+Choice: 93 93
+Choice: 94 94
+Choice: 95 95
+Choice: 96 96
+Choice: 97 97
+Choice: 98 98
+Choice: 99 99
+Choice: 100 100
+/main/other/5004
+Label: Compression Setting
+Type: MENU
+Current: 2
+Choice: 0 0
+Choice: 1 1
+Choice: 2 2
+Choice: 3 4
+Choice: 4 7
+/main/other/5007
+Label: F-Number
+Type: MENU
+Current: 560
+Choice: 0 100
+Choice: 1 110
+Choice: 2 120
+Choice: 3 130
+Choice: 4 140
+Choice: 5 150
+Choice: 6 160
+Choice: 7 170
+Choice: 8 180
+Choice: 9 190
+Choice: 10 200
+Choice: 11 220
+Choice: 12 240
+Choice: 13 250
+Choice: 14 270
+Choice: 15 280
+Choice: 16 300
+Choice: 17 320
+Choice: 18 350
+Choice: 19 380
+Choice: 20 400
+Choice: 21 420
+Choice: 22 450
+Choice: 23 480
+Choice: 24 500
+Choice: 25 530
+Choice: 26 560
+Choice: 27 600
+Choice: 28 630
+Choice: 29 670
+Choice: 30 710
+Choice: 31 760
+Choice: 32 800
+Choice: 33 850
+Choice: 34 900
+Choice: 35 950
+Choice: 36 1000
+Choice: 37 1100
+Choice: 38 1200
+Choice: 39 1300
+Choice: 40 1400
+Choice: 41 1500
+Choice: 42 1600
+Choice: 43 1700
+Choice: 44 1800
+Choice: 45 1900
+Choice: 46 2000
+Choice: 47 2100
+Choice: 48 2200
+Choice: 49 2400
+Choice: 50 2500
+Choice: 51 2760
+Choice: 52 2900
+Choice: 53 3000
+Choice: 54 3200
+Choice: 55 0
+/main/other/500e
+Label: Exposure Program Mode
+Type: MENU
+Current: 32784
+Choice: 0 32784
+Choice: 1 32785
+Choice: 2 32786
+Choice: 3 32787
+Choice: 4 32788
+/main/other/5011
+Label: Date & Time
+Type: TEXT
+Current: 20150924T102557
+/main/other/d303
+Label: PTP Property 0xd303
+Type: TEXT
+Current: 1
+/main/other/d406
+Label: PTP Property 0xd406
+Type: TEXT
+Current: Windows/6.0.5330.0 MTPClassDriver/6.0.5330.0
+/main/other/d407
+Label: PTP Property 0xd407
+Type: TEXT
+Current: 1

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -1209,6 +1209,8 @@ static struct {
 	{"Nikon:J3",    		  0x04b0, 0x0605, PTP_CAP|PTP_NIKON_1},
 	/* Markus Karlhuber <markus.karlhuber@gmail.com> */
 	{"Nikon:S1",    		  0x04b0, 0x0606, PTP_CAP|PTP_NIKON_1},
+	/* Tarjei Husøy <git@thusoy.com> */
+	{"Nikon:S2",              0x04b0, 0x0608, PTP_CAP|PTP_NIKON_1},
 	/* Raj Kumar <raj@archive.org> */
 	{"Nikon:J4",    		  0x04b0, 0x0609, PTP_CAP|PTP_NIKON_1},
 


### PR DESCRIPTION
I'm not sure if I'm including all the details you're after, but this is what I did:
  - Identified the usb id of the camera with `lsusb`
  - Added the id to `ptp2/library.c` with the same capabilities as the previous model (S1)
  - Compiled
  - Ran `--summary` and `--list-all-config` and added the results as cameras/nikon-s2.txt
  - Removed the serial number of the camera

Scream and shout if you need me to add anything else.