### PR TITLE
Avoid overlinking of libexif

### DIFF
--- a/libgphoto2-uninstalled.pc.in
+++ b/libgphoto2-uninstalled.pc.in
@@ -16,7 +16,8 @@ Name: libgphoto2
 Description: Library for easy access to digital cameras
 URL: http://gphoto.org/proj/libgphoto2/
 Version: ${VERSION}
-Requires: libgphoto2_port >= 0.7.2, @REQUIREMENTS_FOR_LIBEXIF@
+Requires: libgphoto2_port >= 0.7.2
+Requires.private: @REQUIREMENTS_FOR_LIBEXIF@
 # This is what works for gphoto-suite
 Libs: ${pcfiledir}/libgphoto2/libgphoto2.la -lm
 Cflags: -I${pcfiledir}/@srcdir@

--- a/libgphoto2.pc.in
+++ b/libgphoto2.pc.in
@@ -9,6 +9,7 @@ Name: libgphoto2
 Description: Library for easy access to digital cameras
 URL: http://gphoto.org/proj/libgphoto2/
 Version: @VERSION@
-Requires: libgphoto2_port >= 0.10.0 @REQUIREMENTS_FOR_LIBEXIF@
+Requires: libgphoto2_port >= 0.10.0
+Requires.private: @REQUIREMENTS_FOR_LIBEXIF@
 Libs: -L${libdir} -lgphoto2 -lm
 Cflags: -I${includedir}/gphoto2


### PR DESCRIPTION
The dependency on libexif need not be exposed to consumers of this
library.  This is fixed by moving libexif from Requires to
Requires.private in the pkg-config files.