### PR TITLE
use SetObjectAttributes to remove new flag on cameras that support it

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -6067,6 +6067,15 @@ read_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 			ret = LOG_ON_PTP_E (ptp_canon_setobjectarchive (params, oid, ob->canon_flags & ~0x20));
 			if (ret == PTP_RC_OK)
 				ob->canon_flags &= ~0x20;
+		} else if (	(params->deviceinfo.VendorExtensionID == PTP_VENDOR_CANON) &&
+			(ob->canon_flags & 0x20) &&
+			ptp_operation_issupported(params,PTP_OC_CANON_EOS_SetObjectAttributes)
+		) {
+			/* seems just a byte (0x20 - new) */
+			/* can fail on some models, like S5. Ignore errors. */
+			ret = LOG_ON_PTP_E (ptp_canon_eos_setobjectattributes(params, oid, ob->canon_flags & ~0x20));
+			if (ret == PTP_RC_OK)
+				ob->canon_flags &= ~0x20;
 		}
 		}
 		break;
@@ -6249,6 +6258,17 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 			/* seems just a byte (0x20 - new) */
 			/* can fail on some models, like S5. Ignore errors. */
 			ret = LOG_ON_PTP_E (ptp_canon_setobjectarchive (params, oid, ob->canon_flags & ~0x20));
+			if (ret == PTP_RC_OK)
+				ob->canon_flags &= ~0x20;
+		} else if (	(params->deviceinfo.VendorExtensionID == PTP_VENDOR_CANON) &&
+			(ob->canon_flags & 0x20) &&
+			ptp_operation_issupported(params,PTP_OC_CANON_EOS_SetObjectAttributes)
+		) {
+			uint16_t	ret;
+
+			/* seems just a byte (0x20 - new) */
+			/* can fail on some models, like S5. Ignore errors. */
+			ret = LOG_ON_PTP_E (ptp_canon_eos_setobjectattributes(params, oid, ob->canon_flags & ~0x20));
 			if (ret == PTP_RC_OK)
 				ob->canon_flags &= ~0x20;
 		}

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -2924,6 +2924,7 @@ uint16_t ptp_canon_get_directory (PTPParams* params, PTPObjectHandles *handles, 
  *
  **/
 #define ptp_canon_setobjectarchive(params,oid,flags) ptp_generic_no_data(params,PTP_OC_CANON_SetObjectArchive,2,oid,flags)
+#define ptp_canon_eos_setobjectattributes(params,oid,flags) ptp_generic_no_data(params,PTP_OC_CANON_EOS_SetObjectAttributes,2,oid,flags)
 uint16_t ptp_canon_get_customize_data (PTPParams* params, uint32_t themenr,
 				unsigned char **data, unsigned int *size);
 uint16_t ptp_canon_getpairinginfo (PTPParams* params, uint32_t nr, unsigned char**, unsigned int*);


### PR DESCRIPTION
Here is a pull request for the proposed change. Let me know if i can fix something to bring the code up to your standards, and if this is a useful way to provide patches.