### PR TITLE
jpeg_memsrcdest: extend feature check

### DIFF
--- a/camlibs/ax203/jpeg_memsrcdest.c
+++ b/camlibs/ax203/jpeg_memsrcdest.c
@@ -25,8 +25,8 @@
 #include "jpeg_memsrcdest.h"
 
 /* libjpeg8 and later come with their own (API compatible) memory source
-   and dest */
-#if JPEG_LIB_VERSION < 80
+   and dest, and older versions may have it backported */
+#if JPEG_LIB_VERSION < 80 && !defined(MEM_SRCDST_SUPPORTED)
 
 /* Expanded data source object for memory input */
 

--- a/camlibs/ax203/jpeg_memsrcdest.h
+++ b/camlibs/ax203/jpeg_memsrcdest.h
@@ -1,5 +1,7 @@
 #include <jpeglib.h>
 
+#if JPEG_LIB_VERSION < 80 && !defined(MEM_SRCDST_SUPPORTED)
+
 void
 jpeg_mem_src (j_decompress_ptr cinfo, unsigned char * buffer,
 	unsigned long bufsize);
@@ -7,3 +9,5 @@ jpeg_mem_src (j_decompress_ptr cinfo, unsigned char * buffer,
 void
 jpeg_mem_dest (j_compress_ptr cinfo, unsigned char ** outbuffer,
 	unsigned long * outsize);
+
+#endif

--- a/camlibs/jl2005c/jpeg_memsrcdest.c
+++ b/camlibs/jl2005c/jpeg_memsrcdest.c
@@ -25,8 +25,8 @@
 #include "jpeg_memsrcdest.h"
 
 /* libjpeg8 and later come with their own (API compatible) memory source
-   and dest */
-#if JPEG_LIB_VERSION < 80
+   and dest, and older versions may have it backported */
+#if JPEG_LIB_VERSION < 80 && !defined(MEM_SRCDST_SUPPORTED)
 
 /* Expanded data source object for memory input */
 

--- a/camlibs/jl2005c/jpeg_memsrcdest.h
+++ b/camlibs/jl2005c/jpeg_memsrcdest.h
@@ -1,5 +1,7 @@
 #include <jpeglib.h>
 
+#if JPEG_LIB_VERSION < 80 && !defined(MEM_SRCDST_SUPPORTED)
+
 void
 jpeg_mem_src (j_decompress_ptr cinfo, unsigned char * buffer,
 	unsigned long bufsize);
@@ -7,3 +9,5 @@ jpeg_mem_src (j_decompress_ptr cinfo, unsigned char * buffer,
 void
 jpeg_mem_dest (j_compress_ptr cinfo, unsigned char ** outbuffer,
 	unsigned long * outsize);
+
+#endif


### PR DESCRIPTION
libjpeg.h in OpenEmbedded master (from libjpeg-turbo 1.5.0) provides
these methods if "JPEG_LIB_VERSION >= 80 ||
defined(MEM_SRCDST_SUPPORTED)".

The support for the jpeg_mem functions was added even when not
emulating the libjpeg8 API, controlled via the MEM_SRCDST_SUPPORTED
define, so checking for the version alone is not enough anymore.

See https://github.com/libjpeg-turbo/libjpeg-turbo/commit/ab70623eb29e09e67222be5b9e1ea320fe5aa0e9

This fixes errors about conflicting declarations (signed vs. unsigned
char).

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>