### PR TITLE
Fixes for Canon 80D and 750D

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -2561,6 +2561,7 @@ camera_capture_preview (Camera *camera, CameraFile *file, GPContext *context)
 						continue;
 					case 9:
 					case 1:
+                    case 11:
 						if (len > (size-(xdata-data))) {
 							len = size;
 							GP_LOG_E ("len=%d larger than rest size %ld", len, (size-(xdata-data)));

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -1828,6 +1828,7 @@ ptp_unpack_CANON_changes (PTPParams *params, unsigned char* data, int datasize, 
 		ce[i].u.info = NULL;
 		switch (type) {
 		case  PTP_EC_CANON_EOS_ObjectAddedEx:
+        case  PTP_EC_CANON_EOS_ObjectAddedUnknown:
 			ce[i].type = PTP_CANON_EOS_CHANGES_TYPE_OBJECTINFO;
 			ce[i].u.object.oid    		= dtoh32a(&curdata[PTP_ece_OA_ObjectID]);
 			ce[i].u.object.oi.StorageID	= dtoh32a(&curdata[PTP_ece_OA_StorageID]);

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -806,6 +806,7 @@ typedef struct _PTPIPHeader PTPIPHeader;
 /* Canon EOS events */
 #define PTP_EC_CANON_EOS_RequestGetEvent		0xc101
 #define PTP_EC_CANON_EOS_ObjectAddedEx			0xc181
+#define PTP_EC_CANON_EOS_ObjectAddedUnknown     0xc1a7
 #define PTP_EC_CANON_EOS_ObjectRemoved			0xc182
 #define PTP_EC_CANON_EOS_RequestGetObjectInfoEx		0xc183
 #define PTP_EC_CANON_EOS_StorageStatusChanged		0xc184


### PR DESCRIPTION
Fix for Canon 80D: when adding objects, Canon 80D uses different event-code
Fix for Canon 750D: during live view, Canon 750D uses different blob code for JPG data