### PR TITLE
Fixed sony capture reliability issues. Tested with Sony A7SII

### DIFF
--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -2068,6 +2068,7 @@ typedef struct _PTPCanonEOSDeviceInfo {
 #define PTP_DPC_SONY_ColorTemp				0xD20F
 #define PTP_DPC_SONY_CCFilter				0xD210
 #define PTP_DPC_SONY_AspectRatio			0xD211
+#define PTP_DPC_SONY_ObjectInMemory     	0xD215 /* used to signal when to retrieve new object */
 #define PTP_DPC_SONY_ExposeIndex			0xD216
 #define PTP_DPC_SONY_PictureEffect			0xD21B
 #define PTP_DPC_SONY_ABFilter				0xD21C


### PR DESCRIPTION
Rather than waiting for the new object event (which often is simply not emitted by the camera), the previously undocumented property 0xD215 is used.  When no image is in the camera's RAM, 0xD215 has a u16 value of 0x0. However, when an image is in RAM for download, the u16 value is 0x8001.  If two images are available, it's 0x8002, etc.  After the images are retrieved (downloaded), the 0xD215 property returns to 0x0.

The sony_capture method has been updated to use this new method instead of the unreliable new object event.  The timing for the capture commands has also been modified to reflect how the Sony RemoteCameraControl app initiates it.  This should also fix issue #87 .

Some background on the fix is provided here: https://www.kickstarter.com/projects/elijahparker/view-intervalometer-auto-ramping-and-wifi-camera-r/posts/1677561

This has been tested with the Sony A7SII only.  I certainly hope this fix applies to the other models, but nothing can be certain.  More testing should be done if possible.

Thanks for the great software!