### PR TITLE
ax203: ax206_compress_jpeg can use only "defined(HAVE_LIBGD) && defined(HAVE_LIBJPEG)"

### DIFF
--- a/camlibs/ax203/ax203.c
+++ b/camlibs/ax203/ax203.c
@@ -1220,10 +1220,14 @@ ax203_encode_image(Camera *camera, int **src, char *dest, int dest_size)
 					camera->pl->height);
 		return size;
 	case AX206_COMPRESSION_JPEG:
+#if defined(HAVE_LIBGD) && defined(HAVE_LIBJPEG)
 		return ax206_compress_jpeg (camera, src,
 					    (uint8_t *)dest, dest_size,
 					    camera->pl->width,
 					    camera->pl->height);
+#else
+		return GP_ERROR_NOT_SUPPORTED;
+#endif
 	case AX3003_COMPRESSION_JPEG:
 #ifdef HAVE_LIBJPEG
 		cinfo.err = jpeg_std_error (&jcerr);

--- a/camlibs/ax203/ax203.h
+++ b/camlibs/ax203/ax203.h
@@ -195,8 +195,13 @@ ax203_decode_yuv_delta(char *src, int **dest, int width, int height);
 void
 ax203_encode_yuv_delta(int **src, char *dest, int width, int height);
 
+
+#if defined(HAVE_LIBGD) && defined(HAVE_LIBJPEG)
+
 int
 ax206_compress_jpeg(Camera *camera, int **in, uint8_t *outbuf, int out_size,
 	int width, int height);
+
+#endif
 
 #endif


### PR DESCRIPTION
ax206_compress_jpeg() is only defined in camlibs/ax203/ax203_compress_jpeg.c when "defined(HAVE_LIBGD) && defined(HAVE_LIBJPEG)".
But always, camlibs/ax203/ax203.h declares it and camlibs/ax203/ax203.c uses it.
