### PR TITLE
Windows port using MSYS2 MINGW64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ stamp-h1
 tests/ddb/check-ddb.sh
 tests/test-filesys
 tests/test-gphoto2
+.vscode/

--- a/camlibs/pentax/pslr.c
+++ b/camlibs/pentax/pslr.c
@@ -1021,7 +1021,7 @@ static int ipslr_press_shutter(ipslr_handle_t *p)
     CHECK(ipslr_write_args(p, 1, 2));
     CHECK(command(p, 0x10, 0x05, 0x04));
     get_status(p);
-    DPRINT("shutter result code: 0x%x\n", r);
+    DPRINT("shutter result code: 0x%x\n", p->status);
     return PSLR_OK;
 }
 

--- a/camlibs/ptp2/ptpip.c
+++ b/camlibs/ptp2/ptpip.c
@@ -441,8 +441,11 @@ ptp_ptpip_init_command_request (PTPParams* params)
 	unsigned char	guid[16];
 	
 	ptp_nikon_getptpipguid(guid);
+	#if !defined (WIN32)
 	if (gethostname (hostname, sizeof(hostname)))
 		return PTP_RC_GeneralError;
+	#endif //!defined (WIN32)
+	
 	len = ptpip_initcmd_name + (strlen(hostname)+1)*2 + 4;
 
 	cmdrequest = malloc(len);

--- a/camlibs/sonydscf1/command.c
+++ b/camlibs/sonydscf1/command.c
@@ -141,8 +141,9 @@ char F1newstatus(GPPort *port, int verbose, char *return_buf)
   char tmp_buf[150]="";
   buf[0] = 0x03;
   buf[1] = 0x02;
+  int i=0;
   sendcommand(port,buf, 2);
-  recvdata(port, buf, 33);
+  i=recvdata(port, buf, 33);
 #ifdef DEBUG
   fprintf(stderr,"Status: %02x%02x:%02x(len = %d)\n", buf[0], buf[1], buf[2], i);
 #endif
@@ -196,8 +197,9 @@ int F1status(GPPort *port)
 
   buf[0] = 0x03;
   buf[1] = 0x02;
+  int i=0;
   sendcommand(port,buf, 2);
-  recvdata(port, buf, 33);
+  i=recvdata(port, buf, 33);
 #ifdef DEBUG
   fprintf(stderr,"Status: %02x%02x:%02x(len = %d)\n", buf[0], buf[1], buf[2], i);
 #endif
@@ -437,6 +439,7 @@ unsigned long F1finfo(GPPort *port,char *name)
   }
 
 #ifdef DEBUG
+  int i=0;
   fprintf(stderr,"info:");
   for(i = 0; i < len ; i++)
     fprintf(stderr,"%02x ", buf[i]);

--- a/examples/best-iso.c
+++ b/examples/best-iso.c
@@ -14,7 +14,12 @@
 #include <string.h>
 #include <gphoto2/gphoto2.h>
 
-#define DEBUG
+#if !defined (O_BINARY)
+    //To have portable open() on *nix and on Windows
+    #define O_BINARY 0
+#endif
+
+//#define DEBUG
 
 static int aperture;
 static float shutterspeed;

--- a/examples/best-iso.c
+++ b/examples/best-iso.c
@@ -229,7 +229,7 @@ camera_tether(Camera *camera, GPContext *context) {
 			path = (CameraFilePath*)evtdata;
 			printf("File added on the camera: %s/%s\n", path->folder, path->name);
 
-			fd = open(path->name, O_CREAT | O_WRONLY, 0644);
+			fd = open(path->name, O_CREAT | O_WRONLY | O_BINARY, 0644);
 			retval = gp_file_new_from_fd(&file, fd);
 			printf("  Downloading %s...\n", path->name);
 			retval = gp_camera_file_get(camera, path->folder, path->name,

--- a/examples/lunkwill-canon-capture.c
+++ b/examples/lunkwill-canon-capture.c
@@ -107,7 +107,7 @@ capture_to_file(Camera *canon, GPContext *canoncontext, char *fn) {
 
 	printf("Pathname on the camera: %s/%s\n", camera_file_path.folder, camera_file_path.name);
 
-	fd = open(fn, O_CREAT | O_WRONLY, 0644);
+	fd = open(fn, O_CREAT | O_WRONLY | O_BINARY, 0644);
 	retval = gp_file_new_from_fd(&canonfile, fd);
 	printf("  Retval: %d\n", retval);
 	retval = gp_camera_file_get(canon, camera_file_path.folder, camera_file_path.name,

--- a/examples/sample-capture.c
+++ b/examples/sample-capture.c
@@ -77,13 +77,15 @@ capture_to_file(Camera *camera, GPContext *context, char *fn) {
 
 	printf("Pathname on the camera: %s/%s\n", camera_file_path.folder, camera_file_path.name);
 
-	fd = open(fn, O_CREAT | O_WRONLY, 0644);
+	fd = open(fn, O_CREAT | O_WRONLY | O_BINARY, 0644);
 	retval = gp_file_new_from_fd(&file, fd);
 	printf("  Retval: %d\n", retval);
 	retval = gp_camera_file_get(camera, camera_file_path.folder, camera_file_path.name,
 		     GP_FILE_TYPE_NORMAL, file, context);
 	printf("  Retval: %d\n", retval);
 
+	if (fd) close(fd);
+	
 	printf("Deleting.\n");
 	retval = gp_camera_file_delete(camera, camera_file_path.folder, camera_file_path.name,
 			context);

--- a/examples/sample-photobooth.c
+++ b/examples/sample-photobooth.c
@@ -43,7 +43,7 @@ capture_to_file(Camera *camera, GPContext *context, char *fn) {
 		strcpy (s+1, t+1);
 	}
 
-	fd = open(fn, O_CREAT | O_WRONLY, 0644);
+	fd = open(fn, O_CREAT | O_WRONLY | O_BINARY, 0644);
 	retval = gp_file_new_from_fd(&file, fd);
 	if (retval < GP_OK) {
 		close(fd);
@@ -67,15 +67,19 @@ capture_to_file(Camera *camera, GPContext *context, char *fn) {
 static void
 sig_handler_capture_now (int sig_num)
 {
-        signal (SIGUSR1, sig_handler_capture_now);
+        #if !defined (WIN32)
+		signal (SIGUSR1, sig_handler_capture_now);
         capture_now = 1;
+		#endif //!defined (WIN32)
 }
 
 static void
 sig_handler_read_config (int sig_num)
 {
-        signal (SIGUSR2, sig_handler_read_config);
+        #if !defined (WIN32)
+		signal (SIGUSR2, sig_handler_read_config);
         read_config = 1;
+		#endif //!defined (WIN32)
 }
 
 int
@@ -91,9 +95,11 @@ main(int argc, char **argv) {
 	printf("kill -USR2 %d to read the 'config.txt'.\n", getpid());
 	printf("kill -TERM %d to finish.\n", getpid());
 
+	#if !defined (WIN32)
         signal (SIGUSR1, sig_handler_capture_now);
         signal (SIGUSR2, sig_handler_read_config);
-
+	#endif //!defined (WIN32)
+	
 	gp_log_add_func(GP_LOG_ERROR, errordumper, 0);
 	gp_camera_new(&camera);
 
@@ -202,7 +208,7 @@ main(int argc, char **argv) {
 					sprintf(output_file, "image-%04d.jpg", capturecnt++);
 				}
 
-				fd = open(output_file, O_CREAT | O_WRONLY, 0644);
+				fd = open(output_file, O_CREAT | O_WRONLY | O_BINARY, 0644);
 				retval = gp_file_new_from_fd(&file, fd);
 				retval = gp_camera_file_get(camera, path->folder, path->name,
 					     GP_FILE_TYPE_NORMAL, file, context);

--- a/examples/sample-tether.c
+++ b/examples/sample-tether.c
@@ -41,7 +41,7 @@ camera_tether(Camera *camera, GPContext *context) {
 			path = (CameraFilePath*)evtdata;
 			printf("File added on the camera: %s/%s\n", path->folder, path->name);
 
-			fd = open(path->name, O_CREAT | O_WRONLY, 0644);
+			fd = open(path->name, O_CREAT | O_WRONLY | O_BINARY, 0644);
 			retval = gp_file_new_from_fd(&file, fd);
 			printf("  Downloading %s...\n", path->name);
 			retval = gp_camera_file_get(camera, path->folder, path->name,

--- a/examples/samples.h
+++ b/examples/samples.h
@@ -13,4 +13,9 @@ int canon_enable_capture (Camera *camera, int onoff, GPContext *context);
 extern int camera_auto_focus (Camera *list, GPContext *context, int onoff);
 extern int camera_eosviewfinder (Camera *list, GPContext *context, int onoff);
 extern int camera_manual_focus (Camera *list, int tgt, GPContext *context);
+
+#if !defined (O_BINARY)
+    //To have portable open() on *nix and on Windows
+    #define O_BINARY 0
+#endif
 #endif

--- a/libgphoto2/gphoto2-setting.c
+++ b/libgphoto2/gphoto2-setting.c
@@ -34,6 +34,10 @@
 #include <gphoto2/gphoto2-port-log.h>
 #include <gphoto2/gphoto2-port-portability.h>
 
+#ifdef WIN32
+#include <Shlobj.h>
+#endif
+
 /**
  * Internal struct to store settings.
  */
@@ -169,21 +173,22 @@ load_settings (void)
 
 	/* Make sure the directories are created */
 #ifdef WIN32
-	GetWindowsDirectory (buf, sizeof(buf));
-	strcat (buf, "\\gphoto");
+	//GetWindowsDirectory (buf, sizeof(buf));
+	SHGetFolderPath(NULL, CSIDL_PROFILE, NULL, 0, buf);
+	strcat (buf, "\\.gphoto");
 #else
 	snprintf (buf, sizeof(buf), "%s/.gphoto", getenv ("HOME"));
-#endif
+#endif //WIN32
 	GP_LOG_D ("Creating gphoto config directory ('%s')", buf);
 	(void)gp_system_mkdir (buf);
 
 	glob_setting_count = 0;
 #ifdef WIN32
-	GetWindowsDirectory(buf, sizeof(buf));
-	strcat(buf, "\\gphoto\\settings");
+	SHGetFolderPath(NULL, CSIDL_PROFILE, NULL, 0, buf);
+	strcat(buf, "\\.gphoto\\settings");
 #else
 	snprintf(buf, sizeof(buf), "%s/.gphoto/settings", getenv("HOME"));
-#endif
+#endif //WIN32
 
 	if (verify_settings(buf) != GP_OK)
 		/* verify_settings will unlink and recreate the settings file */
@@ -225,7 +230,14 @@ save_settings (void)
 	char buf[1024];
 	int x=0;
 
-	snprintf (buf, sizeof(buf), "%s/.gphoto/settings", getenv ("HOME"));
+	#ifdef WIN32
+		//GetWindowsDirectory (buf, sizeof(buf));
+		SHGetFolderPath(NULL, CSIDL_PROFILE, NULL, 0, buf);
+		strcat(buf, "\\.gphoto\\settings");
+	#else
+		snprintf (buf, sizeof(buf), "%s/.gphoto/settings", getenv ("HOME"));
+	#endif //WIN32
+
 
 	GP_LOG_D ("Saving %i setting(s) to file \"%s\"", glob_setting_count, buf);
 

--- a/libgphoto2_port/libgphoto2_port/gphoto2-port-portability.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port-portability.c
@@ -44,11 +44,14 @@ void gp_port_win_convert_path (char *path) {
                 /* already converted */
                 return;
 
-        if (path[0] != '.') {
+        //What was the purpose of this?
+        //copying the second character to the first place if path does not start with "."?
+/*        if (path[0] != '.') {
                 path[0] = path[1];
                 path[1] = ':';
                 path[2] = '\\';
         }
+*/
 
         for (x=0; x<strlen(path); x++)
                 if (path[x] == '/')

--- a/libgphoto2_port/usb/libusb.c
+++ b/libgphoto2_port/usb/libusb.c
@@ -34,6 +34,10 @@
 #include <dirent.h>
 #include <string.h>
 
+#ifndef ENODATA
+#   define ENODATA	120	/* No data available */
+#endif
+
 #include <usb.h>
 
 #include <gphoto2/gphoto2-port.h>

--- a/libgphoto2_port/vusb/vcamera.c
+++ b/libgphoto2_port/vusb/vcamera.c
@@ -391,16 +391,16 @@ read_directories(char *path, struct ptp_dirent *parent) {
 	dir = gp_system_opendir(path);
 	if (!dir) return;
 	while ((de=gp_system_readdir(dir))) {
-		if (!strcmp(de->d_name,".")) continue;
-		if (!strcmp(de->d_name,"..")) continue;
+		if (!strcmp(gp_system_filename(de),".")) continue;
+		if (!strcmp(gp_system_filename(de),"..")) continue;
 
 		cur = malloc(sizeof(struct ptp_dirent));
 		if (!cur) break;
-		cur->name = strdup(de->d_name);
-		cur->fsname = malloc(strlen(path)+1+strlen(de->d_name)+1);
+		cur->name = strdup(gp_system_filename(de));
+		cur->fsname = malloc(strlen(path)+1+strlen(gp_system_filename(de))+1);
 		strcpy(cur->fsname,path);
 		strcat(cur->fsname,"/");
-		strcat(cur->fsname,de->d_name);
+		strcat(cur->fsname,gp_system_filename(de));
 		cur->id = ptp_objectid++;
 		cur->next = first_dirent;
 		cur->parent = parent;


### PR DESCRIPTION
This is a basic port of the library to Windows. I have used the MSYS2 environment to compile the source. I have made only minimal changes necessary, please check whether the *nix builds are still working after the changes. The gphoto setting file should be placed in Windows under the current users profile folder, the existing code tried to save the settings file to the WIndows System directory which is was not working, as system prohibits that since a few years. Along the way I have fixed some undeclared variable errors.

The following functions are working:
- **gp_camera_init** and **gp_camera_get_summary** and **get_config_value_string**, tested by sample-autodetect.exe
- **gp_camera_capture**, tested by sample-capture.exe

The sample-trigger-capture.exe does not work yet, I'll open a question on that one separately.
I'm also going to port the gphoto2 as well, just need more testing.

I have used my Nikon D5000 to test, it is really fun working with this libary.

Peter
