### PR TITLE
print-camera-list: fix gip_enum_to_string() usage

### DIFF
--- a/packaging/generic/print-camera-list.c
+++ b/packaging/generic/print-camera-list.c
@@ -883,22 +883,14 @@ ddb_delayed_head(const func_params_t *params,
 	printf("device \"%s\" {\n", a->model);
 
 	printf("    device_type");
-	first = 1;
-	gpi_enum_to_string(a->device_type, 
-			   gpi_gphoto_device_type_map,
-			   ddb_list_out_func,
-			   (void *) &first);
-	printf(";\n");
+	printf(" %s;\n", gpi_enum_to_string(a->device_type,
+					    gpi_gphoto_device_type_map);
 
 	printf("    driver \"%s\";\n", camlib_basename);
 
 	printf("    driver_status");
-	first = 1;
-	gpi_enum_to_string(a->status, 
-			   gpi_camera_driver_status_map,
-			   ddb_list_out_func,
-			   (void *) &first);
-	printf(";\n");
+	printf(" %s;\n", gpi_enum_to_string(a->status,
+					    gpi_camera_driver_status_map);
 
 	printf("    operations");
 	first = 1;


### PR DESCRIPTION
```c
print-camera-list.c: In function 'ddb_delayed_head':
print-camera-list.c:887:2: error: too many arguments to function 'gpi_enum_to_string'
  gpi_enum_to_string(a->device_type,
  ^~~~~~~~~~~~~~~~~~
In file included from ../../libgphoto2_port/gphoto2/gphoto2-port-info-list.h:63:0,
                 from ../../gphoto2/gphoto2-abilities-list.h:30,
                 from ../../gphoto2/gphoto2-camera.h:50,
                 from print-camera-list.c:53:
../../libgphoto2_port/gphoto2/gphoto2-port-log.h:185:3: note: declared here
   gpi_enum_to_string(const unsigned int _enum,
   ^~~~~~~~~~~~~~~~~~
print-camera-list.c:897:2: error: too many arguments to function 'gpi_enum_to_string'
  gpi_enum_to_string(a->status,
  ^~~~~~~~~~~~~~~~~~
In file included from ../../libgphoto2_port/gphoto2/gphoto2-port-info-list.h:63:0,
                 from ../../gphoto2/gphoto2-abilities-list.h:30,
                 from ../../gphoto2/gphoto2-camera.h:50,
                 from print-camera-list.c:53:
../../libgphoto2_port/gphoto2/gphoto2-port-log.h:185:3: note: declared here
   gpi_enum_to_string(const unsigned int _enum,
   ^~~~~~~~~~~~~~~~~~
```

Fixes: 43d9449161d1 ("New syntax for print-camera-list's udev output")
Closes: #109
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>