### PR TITLE
Cleanup of camera_summary()

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -5047,16 +5047,6 @@ snprintf_ptp_property (char *txt, int spaceleft, PTPPropertyValue *data, uint16_
 	return 0;
 }
 
-static const char *
-_get_getset(uint8_t gs) {
-	switch (gs) {
-	case PTP_DPGS_Get: return N_("read only");
-	case PTP_DPGS_GetSet: return N_("readwrite");
-	default: return N_("Unknown");
-	}
-	return N_("Unknown");
-}
-
 #if 0 /* leave out ... is confusing -P downloads */
 #pragma pack(1)
 struct canon_theme_entry {
@@ -5431,7 +5421,11 @@ camera_summary (Camera* camera, CameraText* summary, GPContext *context)
 		memset (&dpd, 0, sizeof (dpd));
 		ret = ptp_generic_getdevicepropdesc (params, dpc, &dpd);
 		if (ret == PTP_RC_OK) {
-			APPEND_TXT ("(%s) ",_get_getset(dpd.GetSet));
+			switch (dpd.GetSet) {
+			case PTP_DPGS_Get:    APPEND_TXT ("(%s) ", N_("read only")); break;
+			case PTP_DPGS_GetSet: APPEND_TXT ("(%s) ", N_("readwrite")); break;
+			default:              APPEND_TXT ("(%s) ", N_("Unknown"));
+			}
 			APPEND_TXT ("(type=0x%x) ",dpd.DataType);
 			switch (dpd.FormFlag) {
 			case PTP_DPFF_None:	break;

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -5278,36 +5278,38 @@ camera_summary (Camera* camera, CameraText* summary, GPContext *context)
 		switch (params->deviceinfo.VendorExtensionID) {
 		case PTP_VENDOR_CANON:
 			if (ptp_operation_issupported(params, PTP_OC_CANON_ViewfinderOn))
-				APPEND_TXT (_("Canon Capture"));
+				APPEND_TXT (_("Canon Capture, "));
 			if (ptp_operation_issupported(params, PTP_OC_CANON_EOS_RemoteRelease))
-				APPEND_TXT (_("Canon EOS Capture"));
+				APPEND_TXT (_("Canon EOS Capture, "));
 			if (ptp_operation_issupported(params, PTP_OC_CANON_EOS_RemoteReleaseOn))
-				APPEND_TXT (_("%sCanon EOS Shutter Button"),txt_marker != txt?", ":"");
-			if (txt_marker != txt)
-				APPEND_TXT ("\n");
+				APPEND_TXT (_("Canon EOS Shutter Button, "));
 			break;
 		case PTP_VENDOR_NIKON:
 			if (ptp_operation_issupported(params, PTP_OC_NIKON_Capture))
-				APPEND_TXT (_("Nikon Capture 1"));
+				APPEND_TXT (_("Nikon Capture 1, "));
 			if (ptp_operation_issupported(params, PTP_OC_NIKON_AfCaptureSDRAM))
-				APPEND_TXT (_("%sNikon Capture 2"),txt_marker != txt?", ":"");
+				APPEND_TXT (_("Nikon Capture 2, "));
 			if (ptp_operation_issupported(params, PTP_OC_NIKON_InitiateCaptureRecInMedia))
-				APPEND_TXT (_("%sNikon Capture 3 "),txt_marker != txt?", ":"");
-			if (txt_marker != txt)
-				APPEND_TXT ("\n");
+				APPEND_TXT (_("Nikon Capture 3, "));
 			break;
 		case PTP_VENDOR_SONY:
 			if (ptp_operation_issupported(params, PTP_OC_SONY_SetControlDeviceB))
-				APPEND_TXT (_("Sony Capture"));
+				APPEND_TXT (_("Sony Capture, "));
 			break;
 		default:
 			/* does not belong to good vendor ... needs another detection */
 			if (params->device_flags & DEVICE_FLAG_OLYMPUS_XML_WRAPPED)
-				APPEND_TXT (_("Olympus E XML Capture\n"));
+				APPEND_TXT (_("Olympus E XML Capture, "));
 			break;
 		}
 		if (txt_marker == txt)
 			APPEND_TXT (_("No vendor specific capture\n"));
+		else
+		{
+			/* replace the trailing ", " with a "\n" */
+			txt -= 2;
+			APPEND_TXT ("\n");
+		}
 
 	/* Third line for Wifi support, but just leave it out if not there. */
 		if ((params->deviceinfo.VendorExtensionID == PTP_VENDOR_NIKON) &&


### PR DESCRIPTION
A set of 4 patches implementing some code cleanup/cosmetic related to the `camera_summary()` function in ptp2/library.c. It is mainly about reducing code duplication and noise (removing 100+ lines of code), improving maintainability. Tested with a EOS 5Dm4 -> outputs the exact same (English) text as before.