### PR TITLE
camlibs: canon_int_get_zoom - work with shorter response from S45

### DIFF
--- a/camlibs/canon/canon.c
+++ b/camlibs/canon/canon.c
@@ -2050,7 +2050,8 @@ canon_int_set_zoom (Camera *camera, unsigned char zoom_level,
  * @zoom_max: pointer to hold zoom upper bound
  * @context: context for error reporting
  *
- * Gets the camera's zoom. Only tested for G1 via USB.
+ * Gets the camera's zoom.
+ * Tested only for G1 and S45 via USB.
  *
  * Returns: gphoto2 error code
  *
@@ -2088,7 +2089,7 @@ canon_int_get_zoom (Camera *camera,
                 msg = canon_usb_dialogue ( camera,
                                            CANON_USB_FUNCTION_CONTROL_CAMERA,
                                            &datalen, payload, payloadlen );
-        if ( msg == NULL  || datalen != 0x1c) {
+        if ( msg == NULL  || datalen < 15) {
                 /* ERROR */
                 GP_DEBUG ("%s datalen=%x",
                           desc, datalen);


### PR DESCRIPTION
Relax datalen check so it accepts the minimum reqired for referenced data
(15th element).  Canon S45 returns 16 bytes for this query, and failed
the previous requirement for 28 bytes returned.
--
I have tested this change and it allows reading and control of zoom on my Canon S45