### PR TITLE
Sony liveview support, sony capture reliability

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -2774,6 +2774,53 @@ enable_liveview:
 		SET_CONTEXT_P(params, NULL);
 		return GP_OK;
 	}
+	case PTP_VENDOR_SONY: {
+		uint32_t	preview_object = 0xffffc002; /* this is where the liveview image is accessed */
+
+		unsigned char *ximage = NULL;
+
+		C_PTP_REP (ptp_getobject_with_size(params, preview_object, &ximage, &size));
+
+		/* look for the JPEG SOI marker (0xFFD8) in data */
+		jpgStartPtr = (unsigned char*)memchr(ximage, 0xff, size);
+		while(jpgStartPtr && ((jpgStartPtr+1) < (ximage + size))) {
+			if(*(jpgStartPtr + 1) == 0xd8) { /* SOI found */
+				break;
+			} else { /* go on looking (starting at next byte) */
+				jpgStartPtr++;
+				jpgStartPtr = (unsigned char*)memchr(jpgStartPtr, 0xff, ximage + size - jpgStartPtr);
+			}
+		}
+		if(!jpgStartPtr) { /* no SOI -> no JPEG */
+			gp_context_error (context, _("Sorry, your Sony camera does not seem to return a JPEG image in LiveView mode"));
+			return GP_ERROR;
+		}
+		/* if SOI found, start looking for EOI marker (0xFFD9) one byte after SOI
+		   (just to be sure we will not go beyond the end of the data array) */
+		jpgEndPtr = (unsigned char*)memchr(jpgStartPtr+1, 0xff, ximage+size-jpgStartPtr-1);
+		while(jpgEndPtr && ((jpgEndPtr+1) < (ximage + size))) {
+			if(*(jpgEndPtr + 1) == 0xd9) { /* EOI found */
+				jpgEndPtr += 2;
+				break;
+			} else { /* go on looking (starting at next byte) */
+				jpgEndPtr++;
+				jpgEndPtr = (unsigned char*)memchr(jpgEndPtr, 0xff, ximage + size - jpgEndPtr);
+			}
+		}
+		if(!jpgEndPtr) { /* no EOI -> no JPEG */
+			gp_context_error (context, _("Sorry, your Sony camera does not seem to return a JPEG image in LiveView mode"));
+			return GP_ERROR;
+		}
+		gp_file_append (file, (char*)jpgStartPtr, jpgEndPtr-jpgStartPtr);
+		free (ximage); /* FIXME: perhaps handle the 128 byte header data too. */
+
+		gp_file_set_mime_type (file, GP_MIME_JPEG);
+		gp_file_set_name (file, "sony_preview.jpg");
+		gp_file_set_mtime (file, time(NULL));
+
+		SET_CONTEXT_P(params, NULL);
+		return GP_OK;
+	}
 	default:
 		break;
 	}

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -3774,6 +3774,7 @@ camera_sony_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pat
 	 * get focus, indicated by the 0xD213 property. But hold it for at most 1 second.
 	 */
 
+#if 0
 	GP_LOG_D ("holding down shutterbutton");
 	event_start = time_now();
 	do {
@@ -3801,6 +3802,9 @@ camera_sony_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pat
 		}
 
 	} while (time_since (event_start) < 1000);
+#endif
+	usleep(100);
+
 	GP_LOG_D ("releasing shutterbutton");
 
 	/* release full-press */
@@ -3857,7 +3861,6 @@ camera_sony_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pat
 		sprintf (path->name, "capt%04d.jpg", capcnt++);
 	return add_objectid_and_upload (camera, path, context, newobject, &oi);
 }
-
 static int
 camera_capture (Camera *camera, CameraCaptureType type, CameraFilePath *path,
 		GPContext *context)

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -1392,6 +1392,27 @@ ptp_getobject (PTPParams* params, uint32_t handle, unsigned char** object)
 }
 
 /**
+ * ptp_getobject_with_size:
+ * params:	PTPParams*
+ *		handle			- Object handle
+ *		object			- pointer to data area
+ *		size			- pointer to uint, returns size of object
+ *
+ * Get object 'handle' from device and store the data in newly
+ * allocated 'object'.
+ *
+ * Return values: Some PTP_RC_* code.
+ **/
+uint16_t
+ptp_getobject_with_size (PTPParams* params, uint32_t handle, unsigned char** object, unsigned int *size)
+{
+	PTPContainer ptp;
+
+	PTP_CNT_INIT(ptp, PTP_OC_GetObject, handle);
+	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, object, size);
+}
+
+/**
  * ptp_getobject_to_handler:
  * params:	PTPParams*
  *		handle			- Object handle

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -2641,6 +2641,8 @@ uint16_t ptp_getobjectinfo	(PTPParams *params, uint32_t handle,
 
 uint16_t ptp_getobject		(PTPParams *params, uint32_t handle,
 				unsigned char** object);
+uint16_t ptp_getobject_with_size	(PTPParams *params, uint32_t handle,
+				unsigned char** object, unsigned int *size);
 uint16_t ptp_getobject_tofd     (PTPParams* params, uint32_t handle, int fd);
 uint16_t ptp_getobject_to_handler (PTPParams* params, uint32_t handle, PTPDataHandler*);
 uint16_t ptp_getpartialobject	(PTPParams* params, uint32_t handle, uint32_t offset,


### PR DESCRIPTION
I've found out that liveview is indeed possible with many newer Sony Alpha cameras.  It simply requires fetching an object (jpeg) from 0xffffc002 (for comparison, captured images are fetched from 0xffffc001).

A challenge I ran into when implementing this was that objectinfo does not return anything useful for 0xffffc002, so I created a copy of ptp_getobject to include the size of the object fetched so that it can be handled correctly (ptp_getobject_with_size).  This seems to work well, however, feel free to take a different approach if something else will better fit the existing APIs.

Also, I have commented out the code in sony_capture for checking for the focus event -- in my testing, any use of events with the newest generation of Sony Alpha cameras causes it to occasionally hang (e.g., the Sony A7S seems ok, but the Sony A7SII hangs occasionally).  Based on the comments in the code, it seems this was necessary for older ones like the A58.  We might need to create a special case based on the presence of certain properties or something to handle this correctly. (Old camera case with events vs. new camera case without events).  For now, feel free to remove the #if 0..#endif found in this PR.