### PR TITLE
scripts: remove bashisms.

### DIFF
--- a/packaging/generic/check-ptp-camera
+++ b/packaging/generic/check-ptp-camera
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -20,13 +20,13 @@ INTERFACE="${1:-06/01/01}"
 
 BASENAME=${DEVPATH##*/}
 for d in /sys/${DEVPATH}/${BASENAME}:*; do
-	[[ -d ${d} ]] || continue
-	INTERFACEID="$(< ${d}/bInterfaceClass)"
-	INTERFACEID="${INTERFACEID}/$(< ${d}/bInterfaceSubClass)"
-	INTERFACEID="${INTERFACEID}/$(< ${d}/bInterfaceProtocol)"
+	[ -d "${d}" ] || continue
+	INTERFACEID="$(cat "${d}"/bInterfaceClass)"
+	INTERFACEID="${INTERFACEID}/$(cat "${d}"/bInterfaceSubClass)"
+	INTERFACEID="${INTERFACEID}/$(cat "${d}"/bInterfaceProtocol)"
 
 	#echo ${d}: ${INTERFACEID}
-	if [[ ${INTERFACE} == ${INTERFACEID} ]]; then
+	if [ "${INTERFACE}" = "${INTERFACEID}" ]; then
 		# Found interface
 		exit 0
 	fi

--- a/packaging/linux-hotplug/gphoto-set-procperm
+++ b/packaging/linux-hotplug/gphoto-set-procperm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -18,22 +18,22 @@
 # This is taken from Fedora Core gphoto2 package.
 # http://cvs.fedora.redhat.com/viewcvs/*checkout*/devel/gphoto2/gphoto-set-procperm
 
-console_user=`cat /var/run/console/console.lock` 
+console_user=$(cat /var/run/console/console.lock)
 
 if [ -z "$console_user" ] ; then
   exit 1 
 fi
 
-if [ -z "$HAL_PROP_USB_BUS_NUMBER" -o -z "$HAL_PROP_USB_LINUX_DEVICE_NUMBER" ] ; then
+if [ -z "$HAL_PROP_USB_BUS_NUMBER" ] || [ -z "$HAL_PROP_USB_LINUX_DEVICE_NUMBER" ] ; then
   exit 1 
 fi
 
-if [ $HAL_PROP_USB_BUS_NUMBER -lt 0 -o  $HAL_PROP_USB_LINUX_DEVICE_NUMBER -lt 0 ] ; then
+if [ "$HAL_PROP_USB_BUS_NUMBER" -lt 0 ] || [ "$HAL_PROP_USB_LINUX_DEVICE_NUMBER" -lt 0 ] ; then
   exit 1 
 fi
 
 
-bus_num=`printf %.3u $HAL_PROP_USB_BUS_NUMBER`
-dev_num=`printf %.3u $HAL_PROP_USB_LINUX_DEVICE_NUMBER`
+bus_num=$(printf %.3u "$HAL_PROP_USB_BUS_NUMBER")
+dev_num=$(printf %.3u "$HAL_PROP_USB_LINUX_DEVICE_NUMBER")
 
-chown $console_user /proc/bus/usb/$bus_num/$dev_num 
+chown "$console_user" /proc/bus/usb/"$bus_num"/"$dev_num"

--- a/packaging/linux-hotplug/usbcam.console
+++ b/packaging/linux-hotplug/usbcam.console
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -50,7 +50,7 @@ then
         /var/lock/console.lock
     do
         if [ -f "$conlock" ]; then
-	    CONSOLEOWNER=`cat $conlock`
+            CONSOLEOWNER=$(cat $conlock)
         fi
     done
     if [ -n "$CONSOLEOWNER" ]

--- a/packaging/linux-hotplug/usbcam.group
+++ b/packaging/linux-hotplug/usbcam.group
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/packaging/linux-hotplug/usbcam.user
+++ b/packaging/linux-hotplug/usbcam.user
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/packaging/linux-hotplug/usbcam.x11-app
+++ b/packaging/linux-hotplug/usbcam.x11-app
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -69,7 +69,7 @@ then
     if [ "${USER}" != "root" ]
     then
 	# we don't want to run this as root. definitely not.
-	cd "${DIRECTORY}"
+	cd "${DIRECTORY}" || exit 1
 	usrhome=~${USER}
 	"${SU}" "${USER}" -c "${ENV} DISPLAY=${DISPLAY} HOME=${usrhome} ${X11_APP}"
     fi


### PR DESCRIPTION
Convert bash scripts to more generic shell scripts. This removes the strict bash dependency and the scripts should now run with any posix shell. Also fix the issues reported by shellcheck while at it.

This wasn't tested too much because I didn't quite know how to trigger the various hotplug events. Any help on that front is appreciated.