### PR TITLE
Change PTP waif_for_event() timeout management for standard cameras

### DIFF
--- a/camlibs/ptp2/usb.c
+++ b/camlibs/ptp2/usb.c
@@ -534,7 +534,8 @@ ptp_usb_event (PTPParams* params, PTPContainer* event, int wait)
 		return PTP_ERROR_BADPARAM;
 	}
 	if (result < 0) {
-		GP_LOG_E ("Reading PTP event failed: %s (%d)", gp_port_result_as_string(result), result);
+		if ((result != GP_ERROR_TIMEOUT) || (wait != PTP_EVENT_CHECK_FAST))
+			GP_LOG_E ("Reading PTP event failed: %s (%d)", gp_port_result_as_string(result), result);
 		if (result == GP_ERROR_TIMEOUT)
 			return PTP_ERROR_TIMEOUT;
 		return PTP_ERROR_IO;


### PR DESCRIPTION
Hi,

I just wanted to share some modifications I've done in the timeout management in PTP wait_for_event function : 
 7c95ede - to avoid error printed when the gp_port_check_int() return a timeout during check_fast. I suppose it isn't an error since the check_fast purpose is a non-blocking check on interrupt endpoint.
 ae93b58 - I checked the timeout value if the function fallback in "sonyout" (others than Canon and Nikon ?) as it is done for Canon and Nikon cameras.

Do not hesitate to comment.

Cheers,