### PR TITLE
fix memory corruption in gp_log_remove_func

### DIFF
--- a/libgphoto2_port/libgphoto2_port/gphoto2-port-log.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port-log.c
@@ -141,7 +141,7 @@ gp_log_remove_func (int id)
 
 	for (i=0;i<log_funcs_count;i++) {
 		if (log_funcs[i].id == id) {
-			memmove (log_funcs + i - 1, log_funcs + i, log_funcs_count - i);
+			memmove (log_funcs + i, log_funcs + i + 1, sizeof(LogFunc) * (log_funcs_count - i - 1));
 			log_funcs_count--;
 			return GP_OK;
 		}


### PR DESCRIPTION
The gp_log_remove_func implementation had 2 severe issues:
* it moved way to few bytes
* it moved the wrong bytes to the wrong place, destroying libc memory
management structures (resulting in different types of crashes).

When the first item has to be removed, it moved a couple bytes from the
start of the array to the left (before the start of the array), instead
of moving the second and following items over the first one.

DISCLAMER: I had to quickly workaround the issues by disabling my gp_log_remove_func usage. This one-liner is untested. Please double check.