### PR TITLE
Improve error reporting when using the ptp2 lib 

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -139,6 +139,7 @@ translate_ptp_result (uint16_t result)
 	case PTP_RC_ParameterNotSupported:	return GP_ERROR_BAD_PARAMETERS;
 	case PTP_RC_OperationNotSupported:	return GP_ERROR_NOT_SUPPORTED;
 	case PTP_RC_DeviceBusy:			return GP_ERROR_CAMERA_BUSY;
+	case PTP_ERROR_NODEVICE:		return GP_ERROR_IO_USB_FIND;
 	case PTP_ERROR_TIMEOUT:			return GP_ERROR_TIMEOUT;
 	case PTP_ERROR_CANCEL:			return GP_ERROR_CANCEL;
 	case PTP_ERROR_BADPARAM:		return GP_ERROR_BAD_PARAMETERS;
@@ -146,6 +147,22 @@ translate_ptp_result (uint16_t result)
 	case PTP_ERROR_DATA_EXPECTED:
 	case PTP_ERROR_RESP_EXPECTED:		return GP_ERROR_IO;
 	default:				return GP_ERROR;
+	}
+}
+
+uint16_t
+translate_gp_result_to_ptp (int gp_result)
+{
+	switch (gp_result) {
+	case GP_OK:				return PTP_RC_OK;
+	case GP_ERROR_BAD_PARAMETERS:		return PTP_RC_ParameterNotSupported;
+	case GP_ERROR_NOT_SUPPORTED:		return PTP_RC_OperationNotSupported;
+	case GP_ERROR_CAMERA_BUSY:		return PTP_RC_DeviceBusy;
+	case GP_ERROR_IO_USB_FIND:		return PTP_ERROR_NODEVICE;
+	case GP_ERROR_TIMEOUT:			return PTP_ERROR_TIMEOUT;
+	case GP_ERROR_CANCEL:			return PTP_ERROR_CANCEL;
+	case GP_ERROR_IO:			return PTP_ERROR_IO;
+	default:				return PTP_RC_GeneralError;
 	}
 }
 

--- a/camlibs/ptp2/ptp-private.h
+++ b/camlibs/ptp2/ptp-private.h
@@ -38,6 +38,7 @@ int have_prop(Camera *camera, uint16_t vendor, uint16_t prop);
 
 /* library.c */
 int translate_ptp_result (uint16_t result);
+uint16_t translate_gp_result_to_ptp (int gp_result);
 int fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo*);
 
 int chdk_init(Camera*,GPContext*);

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -4235,6 +4235,7 @@ static struct {
 	{PTP_RC_CANON_BATTERY_LOW,	PTP_VENDOR_CANON, N_("Battery Low")},
 	{PTP_RC_CANON_NOT_READY,	PTP_VENDOR_CANON, N_("Camera Not Ready")},
 
+	{PTP_ERROR_NODEVICE,		0, N_("PTP No Device")},
 	{PTP_ERROR_TIMEOUT,		0, N_("PTP Timeout")},
 	{PTP_ERROR_CANCEL,		0, N_("PTP Cancel Request")},
 	{PTP_ERROR_BADPARAM,		0, N_("PTP Invalid Parameter")},

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -797,6 +797,7 @@ typedef struct _PTPIPHeader PTPIPHeader;
 #define PTP_RC_MTP_WFC_Version_Not_Supported	0xA122
 
 /* libptp2 extended ERROR codes */
+#define PTP_ERROR_NODEVICE		0x02F9
 #define PTP_ERROR_TIMEOUT		0x02FA
 #define PTP_ERROR_CANCEL		0x02FB
 #define PTP_ERROR_BADPARAM		0x02FC


### PR DESCRIPTION
My goal with this PR is to improve the error reporting when using ptp2 (usb).
A patch to gphotofs will follow that take usage of this improvement.

There are 3 points of this PR:
- raise usb errors that are currently masked with a generic "PTP_ERROR_IO".
- add a new PTP_ERROR_NODEVICE to be able to pass through the missing device error detected by libusb.
- reworked event manager async queue for multiple purpose. (Main one being to not hide errors)

Please see the description message of each commit for more details.