### PR TITLE
More fixes for support 64bit getpartialobject for Android in read_file_func

### DIFF
--- a/libgphoto2/gphoto2-camera.c
+++ b/libgphoto2/gphoto2-camera.c
@@ -1705,7 +1705,7 @@ gp_camera_file_get (Camera *camera, const char *folder, const char *file,
  * @param type the #CameraFileType
  * @param offset the offset into the camera file
  * @param data the buffer receiving the data
- * @param size the size to be read and that was read
+ * @param size the size to be read and that was read. (Note: size should not exceed 32 bits)
  * @param context a #GPContext
  * @return a gphoto2 error code
  *

--- a/libgphoto2/gphoto2-filesys.c
+++ b/libgphoto2/gphoto2-filesys.c
@@ -1780,8 +1780,10 @@ gp_filesystem_read_file (CameraFilesystem *fs, const char *folder,
 			offset, buf, size, fs->data, context);
 		if (r == GP_OK)
 			return r;
+	} else {
+		return GP_ERROR_NOT_SUPPORTED;
 	}
-	return GP_ERROR_NOT_SUPPORTED;
+	return r;
 	/* fallback code */
 	CR (gp_file_new (&file));
 	CR (gp_filesystem_get_file (fs, folder, filename, type,


### PR DESCRIPTION
Fixes the assert that was in "C_PARAM_MSG" to be correct.
Added more checks.
Return GP_ERROR_NOT_SUPPORTED only if the "partialread" feature is not supported and so fallback should kick in upper level. Otherwise raise errors.

IMPORTANT NOTE: Currently this is not enough to read large files (>64 bits).
Because we are looking at the "compressedSize" that is limited to 32 bits.