### PR TITLE
prevent redefining CAMLIBS and IOLIBS on WIN32

### DIFF
--- a/gphoto2/gphoto2.h
+++ b/gphoto2/gphoto2.h
@@ -38,8 +38,9 @@ extern "C" {
 #endif
 
 #ifdef WIN32
-#undef CAMLIBS
+#ifndef CAMLIBS
 #define CAMLIBS "."
+#endif
 #endif
 
 #include <gphoto2/gphoto2-port.h>

--- a/libgphoto2_port/gphoto2/gphoto2-port-portability.h
+++ b/libgphoto2_port/gphoto2/gphoto2-port-portability.h
@@ -37,10 +37,9 @@
 # include <stdio.h>
 # include <direct.h>
 
-# ifdef IOLIBS
-# undef IOLIBS
+# ifndef IOLIBS
+#  define IOLIBS			"."
 # endif
-# define IOLIBS			"."
 # define strcasecmp		_stricmp
 # ifndef snprintf
 #  define snprintf		_snprintf


### PR DESCRIPTION
This change enables WIN32 users (MinGW and also Visual Studio, for which I may add some more pull requests soon) to redefine CAMLIBS and IOLIBS in the config.h file. This is useful in order to place the camlibs and iolibs shared libraries in subfolders, so that the file system is more cleaned up. Comments welcome!