### PR TITLE
Use off_t when calculating read size

### DIFF
--- a/camlibs/directory/directory.c
+++ b/camlibs/directory/directory.c
@@ -516,7 +516,7 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 	int result = GP_OK;
 	struct stat stbuf;
 	int fd, id;
-	unsigned int curread, toread;
+	off_t curread, toread;
 	unsigned char *buf;
 #ifdef HAVE_LIBEXIF
 	ExifData *data;


### PR DESCRIPTION
When reading large files, above 4GiB size, get_file_func() would
eventually calculate a toread value of 0, when reaching size % 4GiB ==
0, and spin forever reading nothing.