### PR TITLE
Fix incomplete EXIF data extraction

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -6831,7 +6831,7 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 			free (ximage);
 			return (GP_ERROR_NOT_SUPPORTED);
 		}
-		if (!((ximage[2] == 0xff) && (ximage[3] == 0xe1))) {	/* App0 */
+		if (!((ximage[2] == 0xff) && (ximage[3] == 0xe1))) {	/* App1 */
 			free (ximage);
 			return (GP_ERROR_NOT_SUPPORTED);
 		}
@@ -6840,7 +6840,7 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 			return (GP_ERROR_NOT_SUPPORTED);
 		}
 		offset = 2;
-		maxbytes = (ximage[4] << 8 ) + ximage[5];
+		maxbytes = (ximage[4] << 8) + ximage[5] + 2;
 		free (ximage);
 		ximage = NULL;
 		C_PTP_REP (ptp_getpartialobject (params,


### PR DESCRIPTION
If the GP_FILE_TYPE_EXIF flag is supplied to get_file_func,
the extracted data is missing two bytes. The value for the maxbytes
variable is read from the APP segment size, which does not account
for the two bytes of the marker that is included in the extracted data.