### PR TITLE
print-camera-list: Fix udev rules for linux-4.14+

### DIFF
--- a/packaging/generic/print-camera-list.c
+++ b/packaging/generic/print-camera-list.c
@@ -399,13 +399,13 @@ udev_parse_params (const func_params_t *params, void **data)
 	 */
 	static const char * const begin_strings[] = {
 		/* UDEV_PRE_0_98 */
-		"ACTION!=\"add\", GOTO=\"libgphoto2_rules_end\"\n"
+		"ACTION!=\"add|bind\", GOTO=\"libgphoto2_rules_end\"\n"
 		"BUS!=\"usb_device\", GOTO=\"libgphoto2_usb_end\"\n\n",
 		/* UDEV_0_98 */
-		"ACTION!=\"add\", GOTO=\"libgphoto2_rules_end\"\n"
+		"ACTION!=\"add|bind\", GOTO=\"libgphoto2_rules_end\"\n"
 		"SUBSYSTEM!=\"usb|usb_device\", GOTO=\"libgphoto2_usb_end\"\n\n",
 		/* UDEV_136 */
-		"ACTION!=\"add\", GOTO=\"libgphoto2_rules_end\"\n"
+		"ACTION!=\"add|bind\", GOTO=\"libgphoto2_rules_end\"\n"
 		"SUBSYSTEM!=\"usb\", GOTO=\"libgphoto2_usb_end\"\n"
 		"ENV{DEVTYPE}!=\"usb_device\", GOTO=\"libgphoto2_usb_end\"\n\n"
 		"ENV{ID_USB_INTERFACES}==\"\", IMPORT{program}=\"usb_id --export %%p\"\n"
@@ -415,7 +415,7 @@ udev_parse_params (const func_params_t *params, void **data)
 		 * more rules . It will be completed in udev_begin_func() */
 		"ENV{ID_USB_INTERFACES}==\"*:060101:*\", ENV{ID_GPHOTO2}=\"1\", ENV{GPHOTO2_DRIVER}=\"PTP\", ",
 		/* UDEV_175 */
-		"ACTION!=\"add\", GOTO=\"libgphoto2_rules_end\"\n"
+		"ACTION!=\"add|bind\", GOTO=\"libgphoto2_rules_end\"\n"
 		"SUBSYSTEM!=\"usb\", GOTO=\"libgphoto2_usb_end\"\n"
 		"ENV{DEVTYPE}!=\"usb_device\", GOTO=\"libgphoto2_usb_end\"\n\n"
 		"ENV{ID_USB_INTERFACES}==\"\", IMPORT{builtin}=\"usb_id\"\n"
@@ -426,7 +426,7 @@ udev_parse_params (const func_params_t *params, void **data)
 		"ENV{ID_USB_INTERFACES}==\"*:060101:*\", ENV{ID_GPHOTO2}=\"1\", ENV{GPHOTO2_DRIVER}=\"PTP\", ",
 
 		/* UDEV_201 ... regular stuff is done via hwdb, only scsi generic here. */
-		"ACTION!=\"add\", GOTO=\"libgphoto2_rules_end\"\n"
+		"ACTION!=\"add|bind\", GOTO=\"libgphoto2_rules_end\"\n"
 		"SUBSYSTEM!=\"usb\", GOTO=\"libgphoto2_usb_end\"\n"
 		"ENV{ID_USB_INTERFACES}==\"\", IMPORT{builtin}=\"usb_id\"\n"
 		/* shortcut the most common camera driver, ptp class, so we avoid parsing 1000


### PR DESCRIPTION
Since commit 1455cf8dbfd0 ("driver core: emit uevents when
device is bound to a driver") the kernel started emitting
"bind" and "unbind" uevents which confuse the libgphoto2
udev rules.

This caused ID_GPHOTO2 and GPHOTO2_DRIVER udev properties not being set
on devices, causing them not to be visible to user-space that uses those
properties (such as gvfs' gphoto2 backend).

See https://github.com/systemd/systemd/issues/8221