### PR TITLE
Fixed compiler error when using #warning on Visual Studio compiler

### DIFF
--- a/libgphoto2_port/libgphoto2_port/gphoto2-port-info-list.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port-info-list.c
@@ -31,6 +31,8 @@
 #include <stdio.h>
 #ifdef HAVE_REGEX
 #include <regex.h>
+#elif defined(_MSC_VER)
+#pragma message("We need regex.h, but it has not been detected.")
 #else
 #warning We need regex.h, but it has not been detected.
 #endif


### PR DESCRIPTION
When compiling libgphoto2 using Visual Studio, in one place the compiler chokes on the #warning statement in gphoto2-port-info-list.c. This PR fixes that by checking for _MSC_VER (which should be only set for Visual Studio and maybe MinGW) and uses #pragma warning instead.