### PR TITLE
Fixed including Win32 shlobj.h header when compiling using Visual Studio

### DIFF
--- a/libgphoto2/gphoto2-setting.c
+++ b/libgphoto2/gphoto2-setting.c
@@ -35,7 +35,10 @@
 #include <gphoto2/gphoto2-port-portability.h>
 
 #ifdef WIN32
+/* Win32 headers may use interface as a define; temporarily correct this */
+#define interface struct
 #include <Shlobj.h>
+#undef interface
 #endif
 
 /**


### PR DESCRIPTION
Here's another PR; gphoto2-port-portability.h undefines the "interface" definition, since "interface" is used throughout libgphoto2, but the Shlobj.h included from gphoto2-setting.c relies on this define. This all only occurs when compiling using Visual Studio and the Windows SDK 8.1 only. I guess MinGW doesn't have this define.