### PR TITLE
fixed spelling to read-only

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -9162,7 +9162,7 @@ _set_config (Camera *camera, const char *confname, CameraWidget *window, GPConte
 					if (dpd.GetSet == PTP_DPGS_GetSet) {
 						ret = cursub->putfunc (camera, widget, &propval, &dpd);
 					} else {
-						gp_context_error (context, _("Sorry, the property '%s' / 0x%04x is currently ready-only."), _(cursub->label), cursub->propid);
+						gp_context_error (context, _("Sorry, the property '%s' / 0x%04x is currently read-only."), _(cursub->label), cursub->propid);
 						ret = GP_ERROR_NOT_SUPPORTED;
 					}
 					if (ret == GP_OK) {
@@ -9253,7 +9253,7 @@ _set_config (Camera *camera, const char *confname, CameraWidget *window, GPConte
 		if (ret != PTP_RC_OK)
 			continue;
 		if (dpd.GetSet != PTP_DPGS_GetSet) {
-			gp_context_error (context, _("Sorry, the property '%s' / 0x%04x is currently ready-only."), _(label), propid);
+			gp_context_error (context, _("Sorry, the property '%s' / 0x%04x is currently read-only."), _(label), propid);
 			return GP_ERROR_NOT_SUPPORTED;
 		}
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -6644,7 +6644,7 @@ msgstr "PTP vlastnost 0x%04x"
 
 #: camlibs/ptp2/config.c:5967 camlibs/ptp2/config.c:6040
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr "Vlastnost „%s“ / 0x%04x lze nyní pouze číst."
 
 #: camlibs/ptp2/config.c:5973 camlibs/ptp2/config.c:5994

--- a/po/da.po
+++ b/po/da.po
@@ -7582,7 +7582,7 @@ msgstr "PTP ejerforhold 0x%04x"
 
 #: camlibs/ptp2/config.c:8914 camlibs/ptp2/config.c:9005
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr "Beklager, egenskaben for »%s« / 0x%04x er pt skrivebeskyttet."
 
 #: camlibs/ptp2/config.c:8920

--- a/po/de.po
+++ b/po/de.po
@@ -7998,7 +7998,7 @@ msgstr "PTP Setting 0x%04x"
 
 #: camlibs/ptp2/config.c:9165 camlibs/ptp2/config.c:9256
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr "Die Property »%s« / 0x%04x is derzeit read-only."
 
 #: camlibs/ptp2/config.c:9171

--- a/po/es.po
+++ b/po/es.po
@@ -7699,7 +7699,7 @@ msgstr " Error %04x de PTP peticionado"
 
 #: camlibs/ptp2/config.c:7970 camlibs/ptp2/config.c:8061
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr ""
 
 #: camlibs/ptp2/config.c:7976

--- a/po/fr.po
+++ b/po/fr.po
@@ -7485,7 +7485,7 @@ msgstr "Propriété PTP 0x%04x"
 
 #: camlibs/ptp2/config.c:7970 camlibs/ptp2/config.c:8061
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr "La propriété « %s » sur 0x%04x est actuellement en lecture seule."
 
 #: camlibs/ptp2/config.c:7976

--- a/po/it.po
+++ b/po/it.po
@@ -7047,7 +7047,7 @@ msgstr "Proprietà PTP 0x%04x"
 
 #: camlibs/ptp2/config.c:7147 camlibs/ptp2/config.c:7218
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr "Spiacenti, la proprietà '%s' / 0x%04x è di sola lettura."
 
 #: camlibs/ptp2/config.c:7153

--- a/po/ja.po
+++ b/po/ja.po
@@ -5433,7 +5433,7 @@ msgstr "PTP プロパティ 0x%04x"
 
 #: camlibs/ptp2/config.c:3845 camlibs/ptp2/config.c:3906
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr ""
 
 #: camlibs/ptp2/config.c:3851 camlibs/ptp2/config.c:3941

--- a/po/nl.po
+++ b/po/nl.po
@@ -7053,7 +7053,7 @@ msgstr "PTP-eigenschap 0x%04x"
 
 #: camlibs/ptp2/config.c:6695 camlibs/ptp2/config.c:6768
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr "Eigenschap '%s' / 0x%04x is momenteel alleen-lezen."
 
 #: camlibs/ptp2/config.c:6701 camlibs/ptp2/config.c:6722

--- a/po/pl.po
+++ b/po/pl.po
@@ -7688,7 +7688,7 @@ msgstr "Ustawienie PTP 0x%04x"
 
 #: camlibs/ptp2/config.c:9037 camlibs/ptp2/config.c:9128
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr "Niestety właściwość '%s' / 0x%04x jest aktualnie tylko do odczytu."
 
 #: camlibs/ptp2/config.c:9043

--- a/po/ru.po
+++ b/po/ru.po
@@ -6805,7 +6805,7 @@ msgstr ""
 
 #: camlibs/ptp2/config.c:5707 camlibs/ptp2/config.c:5780
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr ""
 
 #: camlibs/ptp2/config.c:5713 camlibs/ptp2/config.c:5734

--- a/po/sv.po
+++ b/po/sv.po
@@ -7588,7 +7588,7 @@ msgstr "PTP-egenskap 0x%04x"
 
 #: camlibs/ptp2/config.c:8914 camlibs/ptp2/config.c:9005
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr "Egenskapen ”%s” / 0x%04x är för närvarande skrivskyddad."
 
 #: camlibs/ptp2/config.c:8920

--- a/po/uk.po
+++ b/po/uk.po
@@ -7693,7 +7693,7 @@ msgstr "Властивість PTP 0x%04x"
 
 #: camlibs/ptp2/config.c:9037 camlibs/ptp2/config.c:9128
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr "Вибачте, зараз можливе лише читання властивості «%s» / 0x%04x."
 
 #: camlibs/ptp2/config.c:9043

--- a/po/vi.po
+++ b/po/vi.po
@@ -7489,7 +7489,7 @@ msgstr "Thuộc tính PTP 0x%04x"
 
 #: camlibs/ptp2/config.c:7970 camlibs/ptp2/config.c:8061
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr "Tiếc là thuộc tính “%s” / 0x%04x hiện tại là chỉ-đọc."
 
 #: camlibs/ptp2/config.c:7976

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8938,7 +8938,7 @@ msgstr ""
 
 #: camlibs/ptp2/config.c:7970 camlibs/ptp2/config.c:8061
 #, c-format
-msgid "Sorry, the property '%s' / 0x%04x is currently ready-only."
+msgid "Sorry, the property '%s' / 0x%04x is currently read-only."
 msgstr ""
 
 #: camlibs/ptp2/config.c:7976


### PR DESCRIPTION
Some lines printed output "Sorry, the property ... is currently ready-only." - this patch changes this to say: "Sorry, the property ... is currently read-only."