### PR TITLE
ptp2: Correctly decode and set cRAW image format for Canon EOS

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -2469,9 +2469,10 @@ GENERIC16TABLE(Canon_ISO,canon_isospeed)
 
 /* see ptp-pack.c:ptp_unpack_EOS_ImageFormat */
 static struct deviceproptableu16 canon_eos_image_format[] = {
-	{ N_("RAW"),				0x0400, 0 },
-	{ N_("mRAW"),				0x1400, 0 },
-	{ N_("sRAW"),				0x2400, 0 },
+	{ N_("RAW"),				0x0c00, 0 },
+	{ N_("mRAW"),				0x1c00, 0 },
+	{ N_("sRAW"),				0x2c00, 0 },
+	{ N_("cRAW"),				0x0b00, 0 },
 	{ N_("Large Fine JPEG"),		0x0300, 0 },
 	{ N_("Large Normal JPEG"),		0x0200, 0 },
 	{ N_("Medium Fine JPEG"),		0x1300, 0 },
@@ -2482,43 +2483,43 @@ static struct deviceproptableu16 canon_eos_image_format[] = {
 	{ N_("Small Normal JPEG"),		0xd200, 0 },
 	{ N_("Smaller JPEG"),			0xe300, 0 },
 	{ N_("Tiny JPEG"),			0xf300, 0 },
-	{ N_("RAW + Large Fine JPEG"),		0x0403, 0 },
-	{ N_("mRAW + Large Fine JPEG"),		0x1403, 0 },
-	{ N_("sRAW + Large Fine JPEG"),		0x2403, 0 },
-	{ N_("cRAW + Large Fine JPEG"),		0x0303, 0 },
-	{ N_("RAW + Medium Fine JPEG"),		0x0413, 0 },
-	{ N_("mRAW + Medium Fine JPEG"),	0x1413, 0 },
-	{ N_("sRAW + Medium Fine JPEG"),	0x2413, 0 },
-	{ N_("cRAW + Medium Fine JPEG"),	0x0313, 0 },
-	{ N_("RAW + Small Fine JPEG"),		0x0423, 0 },
-	{ N_("RAW + Small Fine JPEG"),		0x04d3, 0 }, /*Canon EOS 5D Mark III*/
-	{ N_("mRAW + Small Fine JPEG"),		0x1423, 0 },
-	{ N_("mRAW + Small Fine JPEG"),		0x14d3, 0 }, /*Canon EOS 5D Mark III*/
-	{ N_("sRAW + Small Fine JPEG"),		0x2423, 0 },
-	{ N_("sRAW + Small Fine JPEG"),		0x24d3, 0 }, /*Canon EOS 5D Mark III*/
-	{ N_("cRAW + Small Fine JPEG"),		0x03d3, 0 },
-	{ N_("RAW + Large Normal JPEG"),	0x0402, 0 },
-	{ N_("mRAW + Large Normal JPEG"),	0x1402, 0 },
-	{ N_("sRAW + Large Normal JPEG"),	0x2402, 0 },
-	{ N_("cRAW + Large Normal JPEG"),	0x0302, 0 },
-	{ N_("RAW + Medium Normal JPEG"),	0x0412, 0 },
-	{ N_("mRAW + Medium Normal JPEG"),	0x1412, 0 },
-	{ N_("sRAW + Medium Normal JPEG"),	0x2412, 0 },
-	{ N_("cRAW + Medium Normal JPEG"),	0x0312, 0 },
-	{ N_("RAW + Small Normal JPEG"),	0x0422, 0 },
-	{ N_("RAW + Small Normal JPEG"),	0x04d2, 0 }, /*Canon EOS 5D Mark III*/
-	{ N_("mRAW + Small Normal JPEG"),	0x1422, 0 },
-	{ N_("mRAW + Small Normal JPEG"),	0x14d2, 0 }, /*Canon EOS 5D Mark III*/
-	{ N_("sRAW + Small Normal JPEG"),	0x2422, 0 },
-	{ N_("sRAW + Small Normal JPEG"),	0x24d2, 0 }, /*Canon EOS 5D Mark III*/
-	{ N_("cRAW + Small Normal JPEG"),	0x03d2, 0 },
-	{ N_("RAW + Smaller JPEG"),		0x04e3, 0 }, /*Canon EOS 5D Mark III*/
-	{ N_("mRAW + Smaller JPEG"),		0x14e3, 0 }, /*Canon EOS 5D Mark III*/
-	{ N_("sRAW + Smaller JPEG"),		0x24e3, 0 }, /*Canon EOS 5D Mark III*/
-	{ N_("cRAW + Smaller JPEG"),		0x03e3, 0 }, /*Canon EOS M50*/
-	{ N_("RAW + Tiny JPEG"),		0x04f3, 0 }, /*Canon EOS 5D Mark III*/
-	{ N_("mRAW + Tiny JPEG"),		0x14f3, 0 }, /*Canon EOS 5D Mark III*/
-	{ N_("sRAW + Tiny JPEG"),		0x24f3, 0 }, /*Canon EOS 5D Mark III*/
+	{ N_("RAW + Large Fine JPEG"),		0x0c03, 0 },
+	{ N_("mRAW + Large Fine JPEG"),		0x1c03, 0 },
+	{ N_("sRAW + Large Fine JPEG"),		0x2c03, 0 },
+	{ N_("cRAW + Large Fine JPEG"),		0x0b03, 0 },
+	{ N_("RAW + Medium Fine JPEG"),		0x0c13, 0 },
+	{ N_("mRAW + Medium Fine JPEG"),	0x1c13, 0 },
+	{ N_("sRAW + Medium Fine JPEG"),	0x2c13, 0 },
+	{ N_("cRAW + Medium Fine JPEG"),	0x0b13, 0 },
+	{ N_("RAW + Small Fine JPEG"),		0x0c23, 0 },
+	{ N_("RAW + Small Fine JPEG"),		0x0cd3, 0 }, /*Canon EOS 5D Mark III*/
+	{ N_("mRAW + Small Fine JPEG"),		0x1c23, 0 },
+	{ N_("mRAW + Small Fine JPEG"),		0x1cd3, 0 }, /*Canon EOS 5D Mark III*/
+	{ N_("sRAW + Small Fine JPEG"),		0x2c23, 0 },
+	{ N_("sRAW + Small Fine JPEG"),		0x2cd3, 0 }, /*Canon EOS 5D Mark III*/
+	{ N_("cRAW + Small Fine JPEG"),		0x0bd3, 0 },
+	{ N_("RAW + Large Normal JPEG"),	0x0c02, 0 },
+	{ N_("mRAW + Large Normal JPEG"),	0x1c02, 0 },
+	{ N_("sRAW + Large Normal JPEG"),	0x2c02, 0 },
+	{ N_("cRAW + Large Normal JPEG"),	0x0b02, 0 },
+	{ N_("RAW + Medium Normal JPEG"),	0x0c12, 0 },
+	{ N_("mRAW + Medium Normal JPEG"),	0x1c12, 0 },
+	{ N_("sRAW + Medium Normal JPEG"),	0x2c12, 0 },
+	{ N_("cRAW + Medium Normal JPEG"),	0x0b12, 0 },
+	{ N_("RAW + Small Normal JPEG"),	0x0c22, 0 },
+	{ N_("RAW + Small Normal JPEG"),	0x0cd2, 0 }, /*Canon EOS 5D Mark III*/
+	{ N_("mRAW + Small Normal JPEG"),	0x1c22, 0 },
+	{ N_("mRAW + Small Normal JPEG"),	0x1cd2, 0 }, /*Canon EOS 5D Mark III*/
+	{ N_("sRAW + Small Normal JPEG"),	0x2c22, 0 },
+	{ N_("sRAW + Small Normal JPEG"),	0x2cd2, 0 }, /*Canon EOS 5D Mark III*/
+	{ N_("cRAW + Small Normal JPEG"),	0x0bd2, 0 },
+	{ N_("RAW + Smaller JPEG"),		0x0ce3, 0 }, /*Canon EOS 5D Mark III*/
+	{ N_("mRAW + Smaller JPEG"),		0x1ce3, 0 }, /*Canon EOS 5D Mark III*/
+	{ N_("sRAW + Smaller JPEG"),		0x2ce3, 0 }, /*Canon EOS 5D Mark III*/
+	{ N_("cRAW + Smaller JPEG"),		0x0be3, 0 }, /*Canon EOS M50*/
+	{ N_("RAW + Tiny JPEG"),		0x0cf3, 0 }, /*Canon EOS 5D Mark III*/
+	{ N_("mRAW + Tiny JPEG"),		0x1cf3, 0 }, /*Canon EOS 5D Mark III*/
+	{ N_("sRAW + Tiny JPEG"),		0x2cf3, 0 }, /*Canon EOS 5D Mark III*/
 	/* There are more RAW + 'smallish' JPEG combinations for at least the 5DM3 possible.
 	   Axel was simply to lazy to exercise the combinatorial explosion. :-/ */
 };

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -1655,8 +1655,12 @@ ptp_unpack_EOS_ImageFormat (PTPParams* params, unsigned char** data )
 
 	  The idea is to simply 'condense' these values to just one uint16 to be able to conveniently
 	  use the available enumeration facilities (look-up table). The image size and compression
-	  values fully describe the image format. Hence we generate a uint16 with the four nibles set
-	  as follows: entry 1 size | entry 1 compression | entry 2 size | entry 2 compression.
+	  values used to fully describe the image format, but at least since EOS M50 (with cRAW)
+	  it is no longer true - we need to store RAW flag (8).
+	  Hence we generate a uint16 with the four nibles set as follows:
+
+	  entry 1 size | entry 1 compression & RAW flag | entry 2 size | entry 2 compression & RAW flag.
+
 	  The above example would result in the value 0x1400.
 
 	  The EOS 5D Mark III (and possibly other high-end EOS as well) added the extra fancy S1, S2
@@ -1665,7 +1669,7 @@ ptp_unpack_EOS_ImageFormat (PTPParams* params, unsigned char** data )
 
 	const unsigned char* d = *data;
 	uint32_t n = dtoh32a( d );
-	uint32_t l, s1, c1, s2 = 0, c2 = 0;
+	uint32_t l, t1, s1, c1, t2 = 0, s2 = 0, c2 = 0;
 
 	if (n != 1 && n !=2) {
 		ptp_debug (params, "parsing EOS ImageFormat property failed (n != 1 && n != 2: %d)", n);
@@ -1678,7 +1682,7 @@ ptp_unpack_EOS_ImageFormat (PTPParams* params, unsigned char** data )
 		return 0;
 	}
 
-	d+=4; /* skip type */
+	t1 = dtoh32a( d+=4 );
 	s1 = dtoh32a( d+=4 );
 	c1 = dtoh32a( d+=4 );
 
@@ -1688,7 +1692,7 @@ ptp_unpack_EOS_ImageFormat (PTPParams* params, unsigned char** data )
 			ptp_debug (params, "parsing EOS ImageFormat property failed (l != 0x10: 0x%x)", l);
 			return 0;
 		}
-		d+=4; /* skip type */
+		t2 = dtoh32a( d+=4 );
 		s2 = dtoh32a( d+=4 );
 		c2 = dtoh32a( d+=4 );
 	}
@@ -1700,6 +1704,10 @@ ptp_unpack_EOS_ImageFormat (PTPParams* params, unsigned char** data )
 		s1--;
 	if( s2 >= 0xe )
 		s2--;
+
+	/* encode RAW flag */
+	c1 |= (t1 == 6) ? 8 : 0;
+	c2 |= (t2 == 6) ? 8 : 0;
 
 	return ((s1 & 0xF) << 12) | ((c1 & 0xF) << 8) | ((s2 & 0xF) << 4) | ((c2 & 0xF) << 0);
 }
@@ -1717,15 +1725,15 @@ ptp_pack_EOS_ImageFormat (PTPParams* params, unsigned char* data, uint16_t value
 
 	htod32a(data+=0, n);
 	htod32a(data+=4, 0x10);
-	htod32a(data+=4, ((value >> 8) & 0xF) == 4 ? 6 : 1);
+	htod32a(data+=4, (((value >> 8) & 0xF) >> 3) ? 6 : 1);
 	htod32a(data+=4, PACK_5DM3_SMALL_JPEG_SIZE((value >> 12) & 0xF));
-	htod32a(data+=4, (value >> 8) & 0xF);
+	htod32a(data+=4, ((value >> 8) & 0xF) & ~8);
 
 	if (n==2) {
 		htod32a(data+=4, 0x10);
-		htod32a(data+=4, ((value >> 0) & 0xF) == 4 ? 6 : 1);
+		htod32a(data+=4, (((value >> 0) & 0xF) >> 3) ? 6 : 1);
 		htod32a(data+=4, PACK_5DM3_SMALL_JPEG_SIZE((value >> 4) & 0xF));
-		htod32a(data+=4, (value >> 0) & 0xF);
+		htod32a(data+=4, ((value >> 0) & 0xF) & ~8);
 	}
 
 #undef PACK_5DM3_SMALL_JPEG_SIZE


### PR DESCRIPTION
Since at least Canon EOS M50, image size and compression does not
fully describe used image format.
This patch encodes RAW flag (0x8) into image compression value
to correctly decode/encode image format.