### PR TITLE
Added PTP-IP support for Canon G7X "MK 1"

### DIFF
--- a/camlibs/ptp2/cameras/canon-powershot-g7x.txt
+++ b/camlibs/ptp2/cameras/canon-powershot-g7x.txt
@@ -1,0 +1,359 @@
+Camera summary:
+Manufacturer: Canon Inc.
+Model: Canon PowerShot G7 X
+  Version: 1-14.0.1.0
+  Serial Number: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Vendor Extension ID: 0xb (1.0)
+
+Capture Formats: JPEG
+Display Formats: Association/Directory, Script, DPOF, MS Wave, JPEG, Defined Type, Unknown(b103), Unknown(b982), Unknown(b105), Unknown(bf01)
+
+Device Capabilities:
+	File Download, File Deletion, File Upload
+	No Image Capture, No Open Capture, Canon EOS Capture 2
+
+Storage Devices Summary:
+store_00010001:
+	StorageDescription: SD
+	VolumeLabel: None
+	Storage Type: Removable RAM (memory card)
+	Filesystemtype: Digital Camera Layout (DCIM)
+	Access Capability: Read-Write
+	Maximum Capability: 64005144576 (61040 MB)
+	Free Space (Bytes): 52043284480 (49632 MB)
+	Free Space (Images): -1
+
+Device Property Summary:
+Event Emulate Mode(0xd045):(readwrite) (type=0x4) Enumeration [1,2,3,4,5,6,7] value: 2
+Property 0xd04a:(readwrite) (type=0x2) Enumeration [0,1,2,3] value: 3
+Size of Output Data from Camera(0xd02e):(read only) (type=0x6) 262144
+Size of Input Data to Camera(0xd02f):(read only) (type=0x6) 262144
+Battery Level(0x5001):(read only) (type=0x2) Enumeration [0,1,2,3] value: 2% (2)
+Battery Type(0xd002):(read only) (type=0x4) Enumeration [0,1,2,3,4,5] value: Unknown (0)
+Battery Mode(0xd003):(read only) (type=0x6) Enumeration [0,1,2,3] value: Warning Level 0 (4)
+UNIX Time(0xd034):(readwrite) (type=0x6) 1549385802
+Type of Slideshow(0xd047):(read only) (type=0x4) 0
+DPOF Version(0xd046):(read only) (type=0x4) 257
+Remote API Version(0xd030):(read only) (type=0x6) 256
+Model ID(0xd049):(read only) (type=0x6) 58195968
+Camera Model(0xd032):(read only) (type=0xffff) 'Canon PowerShot G7 X'
+Camera Owner(0xd033):(readwrite) (type=0x4002) a[0] 
+Firmware Version(0xd031):(read only) (type=0x6) 16777216
+Property 0xd050:(read only) (type=0x2) 0
+Property 0xd051: error 201b on query.
+Property 0xd052:(read only) (type=0x2) 0
+Property 0xd053: error 201b on query.
+Property 0xd054: error 201b on query.
+Property 0xd402:(read only) (type=0xffff) 'Canon PowerShot G7 X'
+Property 0xd406:(readwrite) (type=0xffff) 'Windows'
+Property 0xd407:(read only) (type=0x6) 1
+Property 0xd303:(read only) (type=0x2) 0
+Property 0xd055:(readwrite) (type=0x2) 0
+Property 0xd056:(readwrite) (type=0x2) 0
+Property 0xd106:(readwrite) (type=0x2) 0
+Property 0xd1b0:(readwrite) (type=0x2) 0
+Property 0xd111: error 201b on query.
+Property 0xd112: error 201b on query.
+
+/main/actions/viewfinder                                                       
+Label: Canon EOS Viewfinder
+Readonly: 0
+Type: TOGGLE
+Current: 2
+END
+/main/actions/eosremoterelease
+Label: Canon EOS Remote Release
+Readonly: 0
+Type: RADIO
+Current: None
+Choice: 0 None
+Choice: 1 Press Half
+Choice: 2 Press Full
+Choice: 3 Release Half
+Choice: 4 Release Full
+Choice: 5 Immediate
+Choice: 6 Press 1
+Choice: 7 Press 2
+Choice: 8 Press 3
+Choice: 9 Release 1
+Choice: 10 Release 2
+Choice: 11 Release 3
+END
+/main/actions/opcode
+Label: PTP Opcode
+Readonly: 0
+Type: TEXT
+Current: 0x1001,0xparam1,0xparam2
+END
+/main/settings/datetime
+Label: Camera Date and Time
+Readonly: 0
+Type: DATE
+Current: 1549406458
+Printable: Tue 05 Feb 2019 23:40:58 CET
+Help: Use 'now' as the current time when setting.
+
+END
+/main/settings/ownername
+Label: Owner Name
+Readonly: 0
+Type: TEXT
+Current: 
+END
+/main/settings/capturetarget
+Label: Capture Target
+Readonly: 0
+Type: RADIO
+Current: Internal RAM
+Choice: 0 Internal RAM
+Choice: 1 Memory card
+END
+/main/settings/capture
+Label: Capture
+Readonly: 0
+Type: TOGGLE
+Current: 0
+END
+/main/status/serialnumber
+Label: Serial Number
+Readonly: 0
+Type: TEXT
+Current: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+END
+/main/status/manufacturer
+Label: Camera Manufacturer
+Readonly: 0
+Type: TEXT
+Current: Canon Inc.
+END
+/main/status/cameramodel
+Label: Camera Model
+Readonly: 0
+Type: TEXT
+Current: Canon PowerShot G7 X
+END
+/main/status/deviceversion
+Label: Device Version
+Readonly: 0
+Type: TEXT
+Current: 1-14.0.1.0
+END
+/main/status/vendorextension
+Label: Vendor Extension
+Readonly: 0
+Type: TEXT
+Current: None
+END
+/main/status/model
+Label: Camera Model
+Readonly: 1
+Type: TEXT
+Current: Canon PowerShot G7 X
+END
+/main/status/model
+Label: Camera Model
+Readonly: 0
+Type: TEXT
+Current: 58195968
+END
+/main/status/firmwareversion
+Label: Firmware Version
+Readonly: 1
+Type: TEXT
+Current: 1.0.0.0
+END
+/main/status/Battery Level
+Label: Battery Level
+Readonly: 1
+Type: TEXT
+Current: 3%
+END
+/main/status/availableshots
+Label: Available Shots
+Readonly: 0
+Type: TEXT
+Current: 8921
+END
+/main/capturesettings/zoom
+Label: Zoom
+Readonly: 0
+Type: TEXT
+Current: 0
+END
+/main/other/d045
+Label: Event Emulate Mode
+Readonly: 0
+Type: MENU
+Current: 9
+Choice: 0 1
+Choice: 1 2
+Choice: 2 3
+Choice: 3 4
+Choice: 4 5
+Choice: 5 6
+Choice: 6 7
+END
+/main/other/d04a
+Label: PTP Property 0xd04a
+Readonly: 0
+Type: MENU
+Current: 3
+Choice: 0 0
+Choice: 1 1
+Choice: 2 2
+Choice: 3 3
+END
+/main/other/d02e
+Label: Size of Output Data from Camera
+Readonly: 1
+Type: TEXT
+Current: 262144
+END
+/main/other/d02f
+Label: Size of Input Data to Camera
+Readonly: 1
+Type: TEXT
+Current: 262144
+END
+/main/other/5001
+Label: Battery Level
+Readonly: 1
+Type: MENU
+Current: 3
+Choice: 0 0
+Choice: 1 1
+Choice: 2 2
+Choice: 3 3
+END
+/main/other/d002
+Label: Battery Type
+Readonly: 1
+Type: MENU
+Current: 0
+Choice: 0 0
+Choice: 1 1
+Choice: 2 2
+Choice: 3 3
+Choice: 4 4
+Choice: 5 5
+END
+/main/other/d003
+Label: Battery Mode
+Readonly: 1
+Type: MENU
+Current: 4
+Choice: 0 0
+Choice: 1 1
+Choice: 2 2
+Choice: 3 3
+END
+/main/other/d034
+Label: UNIX Time
+Readonly: 0
+Type: TEXT
+Current: 1549410058
+END
+/main/other/d047
+Label: Type of Slideshow
+Readonly: 1
+Type: TEXT
+Current: 0
+END
+/main/other/d046
+Label: DPOF Version
+Readonly: 1
+Type: TEXT
+Current: 257
+END
+/main/other/d030
+Label: Remote API Version
+Readonly: 1
+Type: TEXT
+Current: 256
+END
+/main/other/d049
+Label: Model ID
+Readonly: 1
+Type: TEXT
+Current: 58195968
+END
+/main/other/d032
+Label: Camera Model
+Readonly: 1
+Type: TEXT
+Current: Canon PowerShot G7 X
+END
+/main/other/d033
+Label: Camera Owner
+Readonly: 0
+Type: TEXT
+Current: (null)
+END
+/main/other/d031
+Label: Firmware Version
+Readonly: 1
+Type: TEXT
+Current: 16777216
+END
+/main/other/d050
+Label: PTP Property 0xd050
+Readonly: 1
+Type: TEXT
+Current: 0
+END
+/main/other/d052
+Label: PTP Property 0xd052
+Readonly: 1
+Type: TEXT
+Current: 0
+END
+/main/other/d402
+Label: PTP Property 0xd402
+Readonly: 1
+Type: TEXT
+Current: Canon PowerShot G7 X
+END
+/main/other/d406
+Label: PTP Property 0xd406
+Readonly: 0
+Type: TEXT
+Current: Windows
+END
+/main/other/d407
+Label: PTP Property 0xd407
+Readonly: 1
+Type: TEXT
+Current: 1
+END
+/main/other/d303
+Label: PTP Property 0xd303
+Readonly: 1
+Type: TEXT
+Current: 0
+END
+/main/other/d055
+Label: PTP Property 0xd055
+Readonly: 0
+Type: TEXT
+Current: 0
+END
+/main/other/d056
+Label: PTP Property 0xd056
+Readonly: 0
+Type: TEXT
+Current: 0
+END
+/main/other/d106
+Label: PTP Property 0xd106
+Readonly: 0
+Type: TEXT
+Current: 0
+END
+/main/other/d1b0
+Label: PTP Property 0xd1b0
+Readonly: 0
+Type: TEXT
+Current: 0
+END
+
+

--- a/camlibs/ptp2/chdk.c
+++ b/camlibs/ptp2/chdk.c
@@ -1,3 +1,4 @@
+
 /* chdk.c
  *
  * Copyright (C) 2015 Marcus Meissner <marcus@jet.franken.de>

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -381,8 +381,10 @@ camera_prepare_canon_eos_capture(Camera *camera, GPContext *context) {
 	if (is_canon_eos_m(params)) {
 		int mode = 0x15;	/* default for EOS M and newer Powershot SX */
 
-		if (!strcmp(params->deviceinfo.Model,"Canon PowerShot G5 X")) mode = 0x11;
-		C_PTP (ptp_canon_eos_setremotemode(params, mode));
+        if (!strcmp(params->deviceinfo.Model,"Canon PowerShot G5 X")) mode = 0x11;
+        /* G7 X seems to crashe when an extra setremote is done*/
+        if (strcmp(params->deviceinfo.Model,"Canon PowerShot G7 X"))
+            C_PTP (ptp_canon_eos_setremotemode(params, mode));
 	} else {
 		C_PTP (ptp_canon_eos_setremotemode(params, 1));
 	}
@@ -541,7 +543,9 @@ camera_unprepare_canon_eos_capture(Camera *camera, GPContext *context) {
 	PTPParams		*params = &camera->pl->params;
 
 	/* just in case we had autofocus running */
-	CR (ptp_canon_eos_afcancel(params));
+    /* This and other focus setting are not supported by Canon G7X, the support detection doesn't seem to work */
+    if (strcmp(params->deviceinfo.Model,"Canon PowerShot G7 X"))
+        CR (ptp_canon_eos_afcancel(params));
 
 	if (is_canon_eos_m (params)) {
 		PTPPropertyValue    ct_val;
@@ -558,7 +562,9 @@ camera_unprepare_canon_eos_capture(Camera *camera, GPContext *context) {
 
 	/* Drain the rest set of the event data */
 	C_PTP (ptp_check_eos_events (params));
-	C_PTP (ptp_canon_eos_setremotemode(params, 0));
+    /* G7 X seems to crashe when an extra setremote is done*/
+    if (strcmp(params->deviceinfo.Model,"Canon PowerShot G7 X"))
+        C_PTP (ptp_canon_eos_setremotemode(params, 0));
 	C_PTP (ptp_canon_eos_seteventmode(params, 0));
 	params->eos_captureenabled = 0;
 	return GP_OK;

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -2038,8 +2038,8 @@ static struct {
 	/* pravsripad@gmail.com */
 	{"Canon:PowerShot SX520 HS",		0x04a9, 0x329b, PTPBUG_DELETE_SENDS_EVENT},
 
-    /* sparkycoladev@gmail.com, PID from CHDK Wiki at http://chdk.wikia.com/wiki/P-ID_(Table) */
-    {"Canon:PowerShot G7 X",			0x04a9, 0x329d, PTP_CAP|PTP_CAP_PREVIEW},
+    /* sparkycoladev@gmail.com */
+    {"Canon:PowerShot G7 X",			0x04a9, 0x329d, PTP_CAP|PTP_CAP_PREVIEW|PTP_DONT_CLOSE_SESSION},
 
 	/* Marcus Meissner <marcus@jet.franken.de> */
 	{"Canon:EOS M10",			0x04a9, 0x32a0, PTP_CAP|PTP_CAP_PREVIEW},

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -2038,7 +2038,7 @@ static struct {
 	/* pravsripad@gmail.com */
 	{"Canon:PowerShot SX520 HS",		0x04a9, 0x329b, PTPBUG_DELETE_SENDS_EVENT},
 
-    /* sparkycoladev@gmail.com   */
+    /* sparkycoladev@gmail.com */
     {"Canon:PowerShot G7 X",			0x04a9, 0x329d, PTP_CAP|PTP_CAP_PREVIEW|PTP_DONT_CLOSE_SESSION},
 
 	/* Marcus Meissner <marcus@jet.franken.de> */
@@ -3747,7 +3747,7 @@ camera_canon_eos_capture (Camera *camera, CameraCaptureType type, CameraFilePath
 		gp_context_idle (context);
 	} while (waiting_for_timeout (&back_off_wait, capture_start, EOS_CAPTURE_TIMEOUT));
 
-	if (newobject == 0)
+    if (newobject == 0)
 		return GP_ERROR;
 	GP_LOG_D ("object has OFC 0x%x", oi.ObjectFormat);
 
@@ -5085,8 +5085,13 @@ camera_trigger_canon_eos_capture (Camera *camera, GPContext *context)
 			ptp_check_eos_events (params);
 			/* NB: no error is returned in case of button == 7, which means
 			 * the timer is still working, but no AF fail has been reported */
-			if (button < 4)
-				return GP_ERROR;
+            if (button < 4){
+                if(!(strcmp(params->deviceinfo.Model,"Canon PowerShot G7 X") && button == 0)){
+                    //button=0 seems to be no error on G7 X, at least there are no apparent issues
+                    gp_context_error (context, ("button error Canon EOS M button=%d"),button);
+                    return GP_ERROR;
+                }
+            }
 		}
 	} else {
 		C_PTP_REP_MSG (ptp_canon_eos_capture (params, &result),

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -2038,7 +2038,7 @@ static struct {
 	/* pravsripad@gmail.com */
 	{"Canon:PowerShot SX520 HS",		0x04a9, 0x329b, PTPBUG_DELETE_SENDS_EVENT},
 
-    /* sparkycoladev@gmail.com */
+    /* sparkycoladev@gmail.com   */
     {"Canon:PowerShot G7 X",			0x04a9, 0x329d, PTP_CAP|PTP_CAP_PREVIEW|PTP_DONT_CLOSE_SESSION},
 
 	/* Marcus Meissner <marcus@jet.franken.de> */
@@ -2681,7 +2681,7 @@ camera_exit (Camera *camera, GPContext *context)
 					}
 					camera->pl->checkevents = 0;
 				}
-				if (params->inliveview)
+                if (params->inliveview && ptp_operation_issupported(params, PTP_OC_CANON_EOS_TerminateViewfinder))
 					ptp_canon_eos_end_viewfinder (params);
 				camera_unprepare_capture (camera, context);
 			}
@@ -2840,7 +2840,7 @@ camera_capture_preview (Camera *camera, CameraFile *file, GPContext *context)
             }
 			ptp_free_devicepropdesc (&dpd);
 			/* do not set it everytime, it will cause delays */
-            /* G7X doesn't seem to support PTP_DPC_CANON_EOS_EVFMode or at least setting it at this point crashes it */
+            /* G7X doesn't seem to support PTP_DPC_CANON_EOS_EVFOutputDevice or at least setting it at this point crashes it */
             if (strcmp(params->deviceinfo.Model,"Canon PowerShot G7 X")) {
                 ret = ptp_canon_eos_getdevicepropdesc (params, PTP_DPC_CANON_EOS_EVFOutputDevice, &dpd);
                 if ((ret != PTP_RC_OK) || (dpd.CurrentValue.u32 != 2)) {

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -436,7 +436,7 @@ typedef struct _PTPIPHeader PTPIPHeader;
 #define PTP_OC_CANON_EOS_SetCTGInfo		0x913C
 #define PTP_OC_CANON_EOS_SetRequestOLCInfoGroup	0x913D
 #define PTP_OC_CANON_EOS_SetRequestRollingPitchingLevel	0x913E /* 1 arg: onoff? */
-/* 3 args, 0x21201020, 0x110, 0x1000000 (potentially reverse order) */
+/* 3 args, 0x21201020, 0, 0x1000000 (potentially reverse order) */
 #define PTP_OC_CANON_EOS_GetCameraSupport	0x913F
 #define PTP_OC_CANON_EOS_SetRating		0x9140 /* 2 args, objectid, rating? */
 #define PTP_OC_CANON_EOS_RequestInnerDevelopStart	0x9141 /* 2 args: 1 type, 1 object? */


### PR DESCRIPTION
Successfully tested remote capture, remote file system, remote viewfinder.
However it looks like the change in  camlibs/ptp2/ptp.h is accidental and should be ignored.