### PR TITLE
Remove gphoto2 symlink loop in /usr/include/gphoto2

### DIFF
--- a/libgphoto2_port/Makefile.am
+++ b/libgphoto2_port/Makefile.am
@@ -91,20 +91,3 @@ nobase_include_HEADERS =	\
 	gphoto2/gphoto2-port-result.h
 
 EXTRA_DIST += gphoto2/gphoto2-port-library.h
-
-
-# Compatibility for header inclusions.
-#
-# - Old code has -I/usr/include/gphoto2
-#   #include <gphoto2-camera.h>
-#
-# - New code has -I/usr/include
-#   #include <gphoto2/gphoto2-camera.h>
-
-install-data-local:
-	rm -f $(DESTDIR)$(includedir)/gphoto2/gphoto2
-	$(INSTALL) -m 0755 -d $(DESTDIR)$(includedir)/gphoto2
-	$(LN_S) . $(DESTDIR)$(includedir)/gphoto2/gphoto2
-
-uninstall-local:
-	rm -f $(DESTDIR)$(includedir)/gphoto2/gphoto2


### PR DESCRIPTION
Stop creating the gphoto2 symlink loop in /usr/include/gphoto2/.

The /usr/include/gphoto2/gphoto2 symlink pointing to `.`, i.e.
to /usr/include/gphoto2 was added in 2006 to solve an source
compatibility issue from back then. Fedora have been removing
that symlink from their packaged libgphoto2 packages since 2009,
so it appears those compatibility issues have been solved since
2009.

We should thus be able to remove the symlink now (in 2019).

Resolves: https://github.com/gphoto/libgphoto2/issues/444