### PR TITLE
Support for Fujifilm ISO extension

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -2543,6 +2543,54 @@ _put_ISO32(CONFIG_PUT_ARGS)
 }
 
 static int
+_get_Fuji_ISO(CONFIG_GET_ARGS) {
+	int i;
+
+	if (!(dpd->FormFlag & PTP_DPFF_Enumeration))
+		return GP_ERROR;
+	if (dpd->DataType != PTP_DTC_INT32 && /* most camera return INT32 */
+		dpd->DataType != PTP_DTC_UINT16)  /* ensure compatibility with UINT16 */
+		return GP_ERROR;
+
+	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
+	gp_widget_set_name (*widget, menu->name);
+	for (i=0;i<dpd->FORM.Enum.NumberOfValues; i++) {
+		char	buf[20];
+
+		sprintf(buf,"%d",dpd->FORM.Enum.SupportedValue[i].i32);
+		gp_widget_add_choice (*widget,buf);
+		if (dpd->FORM.Enum.SupportedValue[i].i32 == dpd->CurrentValue.i32)
+			gp_widget_set_value (*widget,buf);
+	}
+	return GP_OK;
+}
+
+static int
+_put_Fuji_ISO(CONFIG_PUT_ARGS)
+{
+	char *value;
+
+	CR (gp_widget_get_value(widget, &value));
+
+	/* most camera return INT32 */
+	if (dpd->DataType == PTP_DTC_INT32) {
+		int i;
+		if (sscanf(value, "%d", &i)) {
+			propval->i32 = i;
+			return GP_OK;
+		}
+	/* ensure compatibility with UINT16 */
+	} else if (dpd->DataType == PTP_DTC_UINT16) {
+		unsigned int u;
+		if (sscanf(value, "%d", &u)) {
+			propval->u16 = u;
+			return GP_OK;
+		}
+	}
+	return GP_ERROR;
+}
+
+static int
 _get_Sony_ISO(CONFIG_GET_ARGS) {
 	int	i,isset=0;
 	char	buf[50];
@@ -8241,6 +8289,7 @@ static struct submenu image_settings_menu[] = {
 	{ N_("Image Size"),             "imagesize",            PTP_DPC_SONY_ImageSize,                 PTP_VENDOR_SONY,    PTP_DTC_UINT8,  _get_Sony_ImageSize,            _put_Sony_ImageSize },
 	{ N_("Image Size"),             "imagesize",            PTP_DPC_CANON_ImageSize,                PTP_VENDOR_CANON,   PTP_DTC_UINT8,  _get_Canon_Size,                _put_Canon_Size },
 	{ N_("ISO Speed"),              "iso",                  PTP_DPC_CANON_ISOSpeed,                 PTP_VENDOR_CANON,   PTP_DTC_UINT16, _get_Canon_ISO,                 _put_Canon_ISO },
+	{ N_("ISO Speed"),              "iso",                  PTP_DPC_ExposureIndex,                  PTP_VENDOR_FUJI,    PTP_DTC_INT32,  _get_Fuji_ISO,                  _put_Fuji_ISO },
 	{ N_("ISO Speed"),              "iso",                  PTP_DPC_ExposureIndex,                  0,                  PTP_DTC_UINT16, _get_ISO,                       _put_ISO },
 	{ N_("Movie ISO Speed"),        "movieiso",             PTP_DPC_NIKON_MovieISO,                 PTP_VENDOR_NIKON,   PTP_DTC_UINT32, _get_ISO32,                     _put_ISO32 },
 	{ N_("ISO Speed"),              "iso",                  PTP_DPC_CANON_EOS_ISOSpeed,             PTP_VENDOR_CANON,   PTP_DTC_UINT16, _get_Canon_ISO,                 _put_Canon_ISO },


### PR DESCRIPTION
I tested with Fujifilm X-T3.

PTP ExposureIndex (0x500F) DataType is defined UINT16 (0x0004).
But Fujifilm X-T3 return INT32 (0x0005).

```
Type of property 'ISO Speed' expected: 0x0004 got: 0x0005
Failed to parse value of property 'ISO Speed' / 0x500f: error code -1
```

Looks like it has been extended to return large (> ISO 51200?) numbers.
