### PR TITLE
Remove duplicate Sony A7s entry with reduced functionality

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -1046,9 +1046,6 @@ static struct {
 	/* Nick Clarke <nick.clarke@gmail.com> */
 	{"Sony:Alpha-A77 M2 (Control)", 0x054c, 0x0953, PTP_CAP|PTP_CAP_PREVIEW},
 
-	/* Elijah Parker <mail@timelapseplus.com> */
-	{"Sony:Alpha-A7s (Control)", 0x054c, 0x0954, PTP_CAP},
-
 	/* Markus Oertel */
 	/* Preview confirmed by Adrian Schroeter, preview might need the firmware getting updated */
 	{"Sony:Alpha-A5100 (Control)",  0x054c, 0x0957, PTP_CAP|PTP_CAP_PREVIEW},


### PR DESCRIPTION
Was surprised to find that I had lost capture preview functionality on my A7s between versions 2.5.23 and 2.5.24. Tracked the regression down to f61a9d965. This PR removes the duplicate and reactivates the original entry at line 1057.