### PR TITLE
lumix: check req_acc return value

### DIFF
--- a/camlibs/lumix/lumix.c
+++ b/camlibs/lumix/lumix.c
@@ -1869,6 +1869,8 @@ camera_init (Camera *camera, GPContext *context)
 {
 	GPPortInfo      info;
 	int		ret;
+	int		tries;
+	char		*result;
 
 	camera->pl = calloc(sizeof(CameraPrivateLibrary),1);
 
@@ -1893,8 +1895,14 @@ camera_init (Camera *camera, GPContext *context)
 	}
 	gp_filesystem_set_funcs (camera->fs, &fsfuncs, camera);
 
-	loadCmd(camera,"cam.cgi?mode=accctrl&type=req_acc&value=0&value2=libgphoto2/lumix");
-	loadCmd(camera,"cam.cgi?mode=setsetting&type=device_name&value=libgphoto2/lumix");
+	tries = 3;
+	while (tries--) {
+		result = loadCmd(camera,"cam.cgi?mode=accctrl&type=req_acc&value=0&value2=libgphoto2/lumix");
+		if (strstr(result,"ok,")) {
+			loadCmd(camera,"cam.cgi?mode=setsetting&type=device_name&value=libgphoto2/lumix");
+			break;
+		}
+	}
 
 	if (switchToRecMode (camera) != NULL) {
 		int numpix;


### PR DESCRIPTION
In lumix camlib, the result of `cam.cgi?mode=accctrl&type=req_acc&value=0&value2=libgphoto/lumix` in `camera_init` can be

    ok_under_research_no_msg,GX9-XXXXXX,remote,encrypted

every alternate call for specific models. The same command should be called again to receive

    ok,GX9-XXXXXX,remote,encrypted

before proceeding. This logic has been implemented in [GMaster](https://github.com/Rambalac/GMaster/blob/e181ab1684c10d853989beb3bf9361fe6a760639/Core/Camera/Lumix.Internal.cs#L272).

A simplified version is implemented here with a maximum of 3 attempts.

See #409 for more context.