### PR TITLE
Convert README files to UTF-8

### DIFF
--- a/camlibs/konica/README.konica
+++ b/camlibs/konica/README.konica
@@ -33,5 +33,5 @@ If you find any, please report them to <gphoto-devel@lists.sourceforge.net>.
 
 Author
 ------
-Lutz Müller <lutz@users.sourceforge.net>
+Lutz MÃ¼ller <lutz@users.sourceforge.net>
 

--- a/camlibs/panasonic/README.panasonic
+++ b/camlibs/panasonic/README.panasonic
@@ -20,9 +20,9 @@ Overview
 Copyright
 ---------
 
-	Copyright © 2000 Mariusz Zynel <mariusz@mizar.org> (gPhoto port)
-	Copyright © 2000 Fredrik Roubert <roubert@df.lth.se> (idea)
-	Copyright © 1999 Galen Brooks <galen@nine.com> (DC1580 code)
+	Copyright Â© 2000 Mariusz Zynel <mariusz@mizar.org> (gPhoto port)
+	Copyright Â© 2000 Fredrik Roubert <roubert@df.lth.se> (idea)
+	Copyright Â© 1999 Galen Brooks <galen@nine.com> (DC1580 code)
 	
 Changes
 -------	


### PR DESCRIPTION
Nowadays it's much more widespread than ISO-8859-1, providing
a better chance for proper display.