### PR TITLE
Speed up Sony shutterspeed changes

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -4285,7 +4285,7 @@ _get_Sony_ShutterSpeed(CONFIG_GET_ARGS) {
 
 static int
 _put_Sony_ShutterSpeed(CONFIG_PUT_ARGS) {
-	int			x,y,a,b,direction,num_items,position_current,position_new;
+	int			x,y,a,b,direction,position_current,position_new;
 	const char		*val;
 	float 			old,new,current;
 	PTPPropertyValue	value;
@@ -4293,8 +4293,6 @@ _put_Sony_ShutterSpeed(CONFIG_PUT_ARGS) {
 	PTPParams		*params = &(camera->pl->params);
 	GPContext 		*context = ((PTPData *) params->data)->context;
 	time_t			start,end;
-	
-	num_items = sizeof(sony_shuttertable)/sizeof(sony_shuttertable[0]);
 
 	CR (gp_widget_get_value (widget, &val));
 

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -4285,7 +4285,7 @@ _get_Sony_ShutterSpeed(CONFIG_GET_ARGS) {
 
 static int
 _put_Sony_ShutterSpeed(CONFIG_PUT_ARGS) {
-	int			x,y,a,b,direction;
+	int			x,y,a,b,direction,num_items,position_current,position_new;
 	const char		*val;
 	float 			old,new,current;
 	PTPPropertyValue	value;
@@ -4293,6 +4293,8 @@ _put_Sony_ShutterSpeed(CONFIG_PUT_ARGS) {
 	PTPParams		*params = &(camera->pl->params);
 	GPContext 		*context = ((PTPData *) params->data)->context;
 	time_t			start,end;
+	
+	num_items = sizeof(sony_shuttertable)/sizeof(sony_shuttertable[0]);
 
 	CR (gp_widget_get_value (widget, &val));
 
@@ -4303,6 +4305,7 @@ _put_Sony_ShutterSpeed(CONFIG_PUT_ARGS) {
 		y = dpd->CurrentValue.u32&0xffff;
 	}
 	old = ((float)x)/(float)y;
+	current = old;
 
 	if (!strcmp(val,_("Bulb"))) {
 		new32 = 0;
@@ -4327,11 +4330,49 @@ _put_Sony_ShutterSpeed(CONFIG_PUT_ARGS) {
 		value.u8 = 0xff;
 		direction = -1;
 	}
+	
+	if (direction == 1) {	
+		for (unsigned int i=0;i<sizeof(sony_shuttertable)/sizeof(sony_shuttertable[0]);i++) {
+			a = sony_shuttertable[i].dividend;
+			b = sony_shuttertable[i].divisor;
+			position_new = i;
+			if (new >= ((float)a)/(float)b) {
+				break;
+			}
+		}
+	}
+	else {
+		for (unsigned int i=sizeof(sony_shuttertable)/sizeof(sony_shuttertable[0])-1;i>=0;i--) {
+			a = sony_shuttertable[i].dividend;
+			b = sony_shuttertable[i].divisor;
+			position_new = i;
+			if (new <= ((float)a)/(float)b) {
+				break;
+			}
+		}
+	}
 		
 	do {
 		origval = dpd->CurrentValue.u32;
 		if (old == new)
 			break;
+		
+		for (unsigned int i=0;i<sizeof(sony_shuttertable)/sizeof(sony_shuttertable[0]);i++) {
+			a = sony_shuttertable[i].dividend;
+			b = sony_shuttertable[i].divisor;
+			position_current = i;
+			if (current >= ((float)a)/(float)b) {
+				break;
+			}
+		}
+		
+		// Calculating jump width 
+		if (direction > 0) {
+			value.u8 = 0x00 + position_new - position_current;
+		}
+		else {
+			value.u8 = 0x100 + position_new - position_current;
+		}
 			
 		a = dpd->CurrentValue.u32>>16;
 		b = dpd->CurrentValue.u32&0xffff;
@@ -4345,14 +4386,13 @@ _put_Sony_ShutterSpeed(CONFIG_PUT_ARGS) {
 			C_PTP_REP (ptp_sony_getalldevicepropdesc (params));
 			C_PTP_REP (ptp_generic_getdevicepropdesc (params, PTP_DPC_SONY_ShutterSpeed, dpd));
 
-			a = dpd->CurrentValue.u32>>16;
-			b = dpd->CurrentValue.u32&0xffff;
-			current = ((float)a)/((float)b);
-
 			if (dpd->CurrentValue.u32 == new32) {
 				GP_LOG_D ("Value matched!");
 				break;
 			}
+			a = dpd->CurrentValue.u32>>16;
+			b = dpd->CurrentValue.u32&0xffff;
+			current = ((float)a)/((float)b);
 			
 			if ((a*y != 0) && (a*y == b*x)) {
 				GP_LOG_D ("Value matched via math(tm) %d/%d == %d/%d!",x,y,a,b);


### PR DESCRIPTION
This change implements larger steps when changing the shutterspeed. Before the values were changed by the smallest steps possible. Now the the "jump" is calculated according to the distance between current and new value. 
Not all Sony cameras reach the goal. Therefore, we will still need the loop.
Example: Sony a6400 from 30s to 1/4000s took over 40s before and takes now 2.5 seconds.
Even better: For example, Sony a9 can do all changes with only the initial step, so, reaching the goal instantaneously.