### PR TITLE
Add Docupen camlib

### DIFF
--- a/camlibs/Makefile.am
+++ b/camlibs/Makefile.am
@@ -93,6 +93,7 @@ include digigr8/Makefile-files
 include digita/Makefile-files
 include dimera/Makefile-files
 include directory/Makefile-files
+include docupen/Makefile-files
 include enigma13/Makefile-files
 include fuji/Makefile-files
 include gsmart300/Makefile-files

--- a/camlibs/docupen/Makefile-files
+++ b/camlibs/docupen/Makefile-files
@@ -1,0 +1,14 @@
+# -*- Makefile -*-
+
+EXTRA_DIST += docupen/ChangeLog
+
+EXTRA_DIST  += docupen/README.docupen
+camlibdoc_DATA += docupen/README.docupen
+
+EXTRA_LTLIBRARIES += docupen.la
+
+docupen_la_SOURCES = docupen/docupen.c docupen/cache.c docupen/huffman.c docupen/image.c docupen/calibration.c docupen/docupen.h docupen/huffman.h
+docupen_la_CFLAGS = $(AM_CFLAGS) $(NO_UNUSED_CFLAGS) $(CFLAGS) @LIBGD_CFLAGS@
+docupen_la_LDFLAGS = $(camlib_ldflags)
+docupen_la_DEPENDENCIES = $(camlib_dependencies)
+docupen_la_LIBADD = $(camlib_libadd) @LIBGD_LIBS@

--- a/camlibs/docupen/cache.c
+++ b/camlibs/docupen/cache.c
@@ -1,0 +1,105 @@
+/* cache.c
+ *
+ * Copyright 2020 Ondrej Zary <ondrej@zary.sk>
+ * based on Docupen tools by Florian Heinz <fh@cronon-ag.de>
+ */
+#include <gphoto2/gphoto2-library.h>
+#include <gphoto2-endian.h>
+#include "docupen.h"
+
+static char cmd_datalen[]  = { 0x55, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1a };
+static char cmd_unknown[]  = { 0x54, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1a };
+static char cmd_get_all[]  = { 0x51, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x1a };
+
+static bool fill_cache(Camera *camera)
+{
+	char *buf;
+	int ret;
+	size_t pktsize = camera->pl->info.packetsize[2] |
+			 camera->pl->info.packetsize[1] << 8|
+			 camera->pl->info.packetsize[0] << 16;
+
+	buf = malloc(pktsize);
+	if (!buf)
+		return false;
+
+	/* truncate file */
+	fclose(camera->pl->cache);
+	camera->pl->cache = fopen(camera->pl->cache_file, "w+");
+	if (!camera->pl->cache) {
+		perror("fopen");
+		GP_LOG_E("unable to trunate cache file %s", camera->pl->cache_file);
+		free(buf);
+		return false;
+	}
+
+	dp_cmd(camera->port, cmd_unknown);
+	dp_cmd(camera->port, cmd_get_all);
+
+	uint32_t done = 0;
+	while (done < camera->pl->datalen) {
+		ret = gp_port_read(camera->port, buf, (camera->pl->datalen - done < pktsize) ? camera->pl->datalen-done : pktsize);
+		if (ret < 0)
+			break;
+		fwrite(buf, 1, ret, camera->pl->cache);
+		done += ret;
+		if (ret < pktsize)
+			break;
+	}
+	free(buf);
+	return true;
+}
+
+bool dp_init_cache(Camera *camera)
+{
+	if (camera->pl->cache_file)
+		return true;
+
+	camera->pl->cache_file = malloc(64 + strlen(getenv("HOME")));
+	if (!camera->pl->cache_file)
+		return false;
+	sprintf(camera->pl->cache_file, "%s/.cache", getenv("HOME"));
+
+	if (!gp_system_is_dir(camera->pl->cache_file) && gp_system_mkdir(camera->pl->cache_file) != GP_OK) {
+		GP_LOG_E("unable to create directory %s", camera->pl->cache_file);
+		goto err_free;
+	}
+
+	sprintf(camera->pl->cache_file, "%s/.cache/docupen-%s.bin", getenv("HOME"), camera->pl->info.serialno);
+	camera->pl->cache = fopen(camera->pl->cache_file, "a+");
+	if (!camera->pl->cache) {
+		perror("fopen");
+		GP_LOG_E("unable to open cache file %s", camera->pl->cache_file);
+		goto err_free;
+	}
+
+	dp_cmd(camera->port, cmd_datalen);
+	gp_port_read(camera->port, (void *)&camera->pl->datalen, sizeof(camera->pl->datalen));
+	camera->pl->datalen = le32toh(camera->pl->datalen);
+	fseek(camera->pl->cache, 0, SEEK_END);
+	if (ftell(camera->pl->cache) == camera->pl->datalen) {	/* cache is valid */
+		if (!dp_init_calibration(camera, false))
+			goto err_free;
+		return true;
+	}
+
+	if (!dp_init_calibration(camera, true)) /* if cache is invalid, update LUT too */
+		goto err_free;
+
+	if (fill_cache(camera))
+		return true;
+
+err_free:
+	free(camera->pl->cache_file);
+	camera->pl->cache_file = NULL;
+	return false;
+}
+
+bool dp_delete_cache(Camera *camera)
+{
+	if (camera->pl->cache)
+		fclose(camera->pl->cache);
+	camera->pl->cache = NULL;
+
+	return !unlink(camera->pl->cache_file);
+}

--- a/camlibs/docupen/calibration.c
+++ b/camlibs/docupen/calibration.c
@@ -1,0 +1,176 @@
+/* calibration.c
+ *
+ * Copyright 2020 Ondrej Zary <ondrej@zary.sk>
+ */
+#include <math.h>
+#include <gphoto2/gphoto2-library.h>
+#include "docupen.h"
+
+#define NUM_POINTS 5
+struct pixel_cal {
+	unsigned char data[NUM_POINTS];
+};
+
+#define CAL_SIZE (1600 * 3)
+#define LUT_FILE_DUMMY_END 0x800
+#define LUT_FILE_SIZE (2 * (CAL_SIZE * NUM_POINTS + CAL_SIZE * 2 + CAL_SIZE * sizeof(struct lut)) + LUT_FILE_DUMMY_END + SERIALNO_LEN + 2)	/* 2526866 */
+
+static char cmd_get_cal[]  = { 0x56, 0x00, 0x00, 0xc0, 0x5d, 0x00, 0x00, 0x1a };
+static char cmd_get_cal1[] = { 0x56, 0x01, 0x00, 0xc0, 0x61, 0x00, 0x00, 0x1a };
+
+/* VALUES (y) at which data points (x) are stored */
+static unsigned char cal_points[] = { 0, 32, 38, 106, 192, 252, 255 };
+
+static unsigned char empty[] = { 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+/* build look-up table (LUT) from calibration data */
+static void make_lut(unsigned char lut[], unsigned char p[]) {
+	unsigned char points[] = { 0, p[0], p[1], p[2], p[3], p[4], p[4] + 8 };
+	float slope = (float)cal_points[1] / points[1];
+	int cur_point = 0;
+	for (unsigned int i = 0; i < sizeof(struct lut); i++) {
+		unsigned int val = floorf((i - points[cur_point]) * slope + cal_points[cur_point]);
+		lut[i] = (val <= 255) ? val : 255;
+		if (lut[i] < 255 && lut[i] >= cal_points[cur_point + 1]) {
+			cur_point++;
+			slope = (float)(cal_points[cur_point + 1] - cal_points[cur_point]) / (points[cur_point + 1] - points[cur_point]);
+		}
+	}
+}
+
+static bool lut_from_cal(struct pixel_cal cal[], FILE *out) {
+	/* input data */
+	if (fwrite(cal, 1, CAL_SIZE * sizeof(struct pixel_cal), out) != CAL_SIZE * sizeof(struct pixel_cal))
+		return false;
+
+	/* fake ??? table */
+	unsigned char table2[CAL_SIZE * 2];
+	memset(table2, 0x00, sizeof(table2));
+	table2[0] = 0x18;
+	if (fwrite(table2, 1, sizeof(table2), out) != sizeof(table2))
+		return false;
+
+	/* lookup tables */
+	for (int i = 0; i < CAL_SIZE; i++) {
+		unsigned char lut[sizeof(struct lut)];
+		if (i == 0) {
+			memset(lut, 0xff, sizeof(lut));
+			lut[0] = 0x18;
+		} else if (memcmp(cal[i].data, empty, NUM_POINTS) == 0)
+			memset(lut, 0xff, sizeof(lut));
+		else
+			make_lut(lut, cal[i].data);
+		if (fwrite(lut, 1, sizeof(lut), out) != sizeof(lut))
+			return false;
+	}
+
+	return true;
+}
+
+/* create a calibration LUT file, same format as PenLut.raw in Windows SW */
+static bool make_lut_file(Camera *camera, FILE *lut)
+{
+	struct pixel_cal cal[CAL_SIZE];
+	char dummy[0x400];
+
+	/* first calibration data */
+	dp_cmd(camera->port, cmd_get_cal);
+	if (gp_port_read(camera->port, (void *)cal, sizeof(cal)) != sizeof(cal))
+		return false;
+	if (!lut_from_cal(cal, lut))
+		return false;
+	/* second calibration data */
+	dp_cmd(camera->port, cmd_get_cal1);
+	if (gp_port_read(camera->port, (void *)cal, sizeof(cal)) != sizeof(cal))
+		return false;
+	if (gp_port_read(camera->port, dummy, sizeof(dummy)) != sizeof(dummy))
+		return false;
+	if (!lut_from_cal(cal, lut))
+		return false;
+	/* 0x800 zero bytes (LUT_FILE_DUMMY_END) */
+	memset(dummy, 0, sizeof(dummy));
+	if (fwrite(dummy, 1, sizeof(dummy), lut) != sizeof(dummy))
+		return false;
+	if (fwrite(dummy, 1, sizeof(dummy), lut) != sizeof(dummy))
+		return false;
+	/* serial number */
+	if (fwrite(camera->pl->info.serialno, 1, sizeof(camera->pl->info.serialno), lut) != sizeof(camera->pl->info.serialno))
+		return false;
+	/* 2 zero bytes */
+	if (fwrite(dummy, 1, 2, lut) != 2)
+		return false;
+
+	return true;
+}
+
+bool dp_init_calibration(Camera *camera, bool force)
+{
+	char *lut_file;
+	bool ret = false;
+	int i, j;
+
+	if (camera->pl->lut)
+                return true;
+
+	lut_file = malloc(64 + strlen(getenv("HOME")));
+	if (!lut_file)
+		return false;
+	sprintf(lut_file, "%s/.cache/docupen-%s.lut", getenv("HOME"), camera->pl->info.serialno);
+
+	FILE *lut = fopen(lut_file, "a+");
+	if (!lut) {
+		perror("fopen");
+		GP_LOG_E("unable to open LUT file %s", lut_file);
+		goto err_free;
+	}
+	fseek(lut, 0, SEEK_END);
+	if (force || ftell(lut) != LUT_FILE_SIZE) {
+		/* truncate file */
+		fclose(lut);
+		lut = fopen(lut_file, "w+");
+		if (!lut) {
+			perror("fopen");
+			GP_LOG_E("unable to trunate cache file %s", lut_file);
+			goto err_free;
+		}
+		if (!make_lut_file(camera, lut))
+			goto err_close;
+		fflush(lut);
+	}
+	/* read first LUT into memory, the 2nd one seems unused? */
+	fseek(lut, CAL_SIZE * NUM_POINTS + CAL_SIZE * 2, SEEK_SET); /* 0x8340 */
+	camera->pl->lut = malloc(CAL_SIZE * sizeof(struct lut));
+	if (!camera->pl->lut)
+		goto err_close;
+
+	if (fread(camera->pl->lut, 1, CAL_SIZE * sizeof(struct lut), lut) != (CAL_SIZE * sizeof(struct lut))) {
+		GP_LOG_E("error reading LUT from file");
+		goto err_close;
+	}
+	/**
+	 * There are empty (0xff) LUTs at the beginning and end (left and right edge of the scanner).
+	 * Windows SW crops the image there. We can use full width of the scanner at the cost of
+	 * edges not having properly calibrated colors.
+	 * Find first and last non-empty LUTs and copy over the empty ones.
+	 */
+	for (i = 0; i < CAL_SIZE; i++)
+		if (camera->pl->lut[i].data[1] != 0xff)	/* [1] because first byte of first LUT is always 0x18 */
+			break;
+	for (j = 0; j < i; j += 3)	/* copy in 3-LUT (RGB) chunks */
+		memcpy(camera->pl->lut[j].data, camera->pl->lut[i].data, 3 * sizeof(struct lut));
+
+	for (i = CAL_SIZE - 1; i >= 0; i--)
+		if (camera->pl->lut[i].data[1] != 0xff)
+			break;
+	i -= 2;
+	for (j = i + 3; j < CAL_SIZE; j += 3) /* copy in 3-LUT (RGB) chunks */
+		memcpy(camera->pl->lut[j].data, camera->pl->lut[i].data, 3 * sizeof(struct lut));
+
+	ret = true;
+
+err_close:
+	fclose(lut);
+err_free:
+	free(lut_file);
+	return ret;
+}

--- a/camlibs/docupen/docupen.c
+++ b/camlibs/docupen/docupen.c
@@ -1,0 +1,696 @@
+/* docupen.c
+ * Docupen camera driver (camlib).
+ *
+ * Copyright 2020 Ondrej Zary <ondrej@zary.sk>
+ * based on Docupen tools by Florian Heinz <fh@cronon-ag.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+#include "config.h"
+
+#include <gphoto2/gphoto2-library.h>
+#include <gphoto2/gphoto2-result.h>
+#include <gphoto2-endian.h>
+
+#include "docupen.h"
+
+#ifdef ENABLE_NLS
+#  include <libintl.h>
+#  undef _
+#  define _(String) dgettext (GETTEXT_PACKAGE, String)
+#  ifdef gettext_noop
+#    define N_(String) gettext_noop (String)
+#  else
+#    define N_(String) (String)
+#  endif
+#else
+#  define _(String) (String)
+#  define N_(String) (String)
+#endif
+
+
+static const struct {
+	char *model;
+	int usb_vendor;
+	int usb_product;
+} models[] = {
+	{ "Planon DocuPen RC800", 0x18dd, 0x1000 },
+	{ NULL, 0, 0 }
+};
+
+#define DP_ACK 0xD1
+#define DP_CMD_LEN 8
+
+static char cmd_query[]		= { 0x1f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1a };
+static char cmd_inquiry[]	= { 0x7f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1a };
+static char cmd_turnoff[]	= { 0x0f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1a };
+static char cmd_del_all[]	= { 0x7a, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x1a };
+static char cmd_get_profile[]	= { 0x58, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x1a }; /* length = 0x400 */
+static char cmd_set_profile[]	= { 0x59, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x1a }; /* length = 0x400 */
+
+#define RAW_HEADER_SERIAL_OFFSET 0x4e
+static char raw_header[] = {
+/*  0 */ 0x53, 0x53, 0x08, 0x5f, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x40, 0xc0, /* SS._..........@. */
+/* 10 */ 0x12, 0x00, 0x20, 0x48, 0x88, 0x00, 0x00, 0x68, 0x1e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* .. H...h........ */
+/* 20 */ 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* ................ */
+/* 30 */ 0x0d, 0x0d, 0x0c, 0x0d, 0x0d, 0x0d, 0x0c, 0x0e, 0x67, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* ........g....... */
+/* 40 */ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x31, 0x32, /* ..............12 */
+/* 50 */ 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x50        /* 34567890......P  */
+};
+
+bool dp_cmd(GPPort *port, const char *cmd)
+{
+	unsigned char reply[64];
+
+	if (gp_port_write(port, cmd, DP_CMD_LEN) != DP_CMD_LEN) {
+		GP_LOG_E("command write failed");
+		return false;
+	}
+	int ret = gp_port_read(port, (void *)reply, sizeof(reply));
+	if (ret < 1 || reply[0] != DP_ACK) {
+		GP_LOG_E("command failed: ret=%d reply[0]=%02hhx", ret, reply[0]);
+		return false;
+	}
+	return true;
+}
+
+static bool inquiry_read(Camera *camera)
+{
+	if (gp_port_read(camera->port, (void *)&camera->pl->info, 4) != 4) {	/* read header */
+		GP_LOG_E("error reading info header");
+		return false;
+	}
+	if (camera->pl->info.len > sizeof(struct dp_info)) {
+		GP_LOG_E("camera info too long: %d bytes", camera->pl->info.len);
+		return false;
+	}
+	int ret = gp_port_read(camera->port, (void *)&camera->pl->info + 4, camera->pl->info.len - 4);
+	if (ret != camera->pl->info.len - 4) {
+		GP_LOG_E("camera info length error: expected %d bytes, got %d", camera->pl->info.len - 4, ret);
+		return false;
+	}
+
+	return true;
+}
+
+
+int camera_exit (Camera *camera, GPContext *context);
+int
+camera_exit (Camera *camera, GPContext *context)
+{
+	if (camera->pl) {
+		if (camera->pl->cache)
+			fclose(camera->pl->cache);
+		free(camera->pl->cache_file);
+		free(camera->pl->lut);
+		free(camera->pl);
+		camera->pl = NULL;
+	}
+	dp_cmd(camera->port, cmd_turnoff);
+	return GP_OK;
+}
+
+
+static bool dp_get_profile(Camera *camera)
+{
+	if (!camera->pl->profile)
+		camera->pl->profile = malloc(PROFILE_LEN);
+	if (!camera->pl->profile)
+		return false;
+
+	dp_cmd(camera->port, cmd_get_profile);
+	if (gp_port_read(camera->port, camera->pl->profile, PROFILE_LEN) != PROFILE_LEN)
+		return false;
+
+	return true;
+}
+
+static bool dp_set_profile(Camera *camera)
+{
+	if (!camera->pl->profile)
+		return false;
+
+	dp_cmd(camera->port, cmd_set_profile);
+	if (gp_port_write(camera->port, camera->pl->profile, PROFILE_LEN) != PROFILE_LEN)
+		return false;
+
+	return true;
+}
+
+
+int camera_config_get (Camera *camera, CameraWidget **window, GPContext *context);
+int
+camera_config_get (Camera *camera, CameraWidget **window, GPContext *context)
+{
+	CameraWidget *section, *widget;
+
+	if (!dp_get_profile(camera))
+		return GP_ERROR;
+
+	gp_widget_new (GP_WIDGET_WINDOW, _("Scanner Profile Configuration"), window);
+
+	gp_widget_new (GP_WIDGET_SECTION, _("Mono mode"), &section);
+	gp_widget_append (*window, section);
+
+        gp_widget_new (GP_WIDGET_RADIO, _("Depth"), &widget);
+        gp_widget_append (section, widget);
+        gp_widget_add_choice (widget, _("Mono (b/w)"));
+        gp_widget_add_choice (widget, _("Grey (4bpp)"));
+        gp_widget_add_choice (widget, _("Grey (8bpp)"));
+        switch(camera->pl->profile[0x80]) {
+        case 0x00: gp_widget_set_value (widget, _("Mono (b/w)")); break;
+        case 0x01: gp_widget_set_value (widget, _("Grey (4bpp)")); break;
+        case 0x02: gp_widget_set_value (widget, _("Grey (8bpp)")); break;
+        }
+
+        gp_widget_new (GP_WIDGET_RADIO, _("Lo Resolution"), &widget);
+        gp_widget_append (section, widget);
+        gp_widget_add_choice (widget, _("100 DPI"));
+        gp_widget_add_choice (widget, _("200 DPI"));
+        switch(camera->pl->profile[0x81]) {
+        case RES_100DPI: gp_widget_set_value (widget, _("100 DPI")); break;
+        case RES_200DPI: gp_widget_set_value (widget, _("200 DPI")); break;
+        }
+
+        gp_widget_new (GP_WIDGET_RADIO, _("Hi Resolution"), &widget);
+        gp_widget_append (section, widget);
+        gp_widget_add_choice (widget, _("200 DPI"));
+        gp_widget_add_choice (widget, _("400 DPI"));
+        switch(camera->pl->profile[0x82]) {
+        case RES_200DPI: gp_widget_set_value (widget, _("200 DPI")); break;
+        case RES_400DPI: gp_widget_set_value (widget, _("400 DPI")); break;
+        }
+
+	gp_widget_new (GP_WIDGET_SECTION, _("Color Document mode"), &section);
+	gp_widget_append (*window, section);
+
+        gp_widget_new (GP_WIDGET_RADIO, _("Depth"), &widget);
+        gp_widget_append (section, widget);
+        gp_widget_add_choice (widget, _("NQ (12bpp)"));
+        switch(camera->pl->profile[0x83]) {
+        case 0x04: gp_widget_set_value (widget, _("NQ (12bpp)")); break;
+        }
+
+        gp_widget_new (GP_WIDGET_RADIO, _("Lo Resolution"), &widget);
+        gp_widget_append (section, widget);
+        gp_widget_add_choice (widget, _("100 DPI"));
+        gp_widget_add_choice (widget, _("200 DPI"));
+        switch(camera->pl->profile[0x84]) {
+        case RES_100DPI: gp_widget_set_value (widget, _("100 DPI")); break;
+        case RES_200DPI: gp_widget_set_value (widget, _("200 DPI")); break;
+        }
+
+        gp_widget_new (GP_WIDGET_RADIO, _("Hi Resolution"), &widget);
+        gp_widget_append (section, widget);
+        gp_widget_add_choice (widget, _("200 DPI"));
+        gp_widget_add_choice (widget, _("400 DPI"));
+        switch(camera->pl->profile[0x85]) {
+        case RES_200DPI: gp_widget_set_value (widget, _("200 DPI")); break;
+        case RES_400DPI: gp_widget_set_value (widget, _("400 DPI")); break;
+        }
+
+	gp_widget_new (GP_WIDGET_SECTION, _("Color Photo mode"), &section);
+	gp_widget_append (*window, section);
+
+        gp_widget_new (GP_WIDGET_RADIO, _("Depth"), &widget);
+        gp_widget_append (section, widget);
+        gp_widget_add_choice (widget, _("HQ (24bpp)"));
+        switch(camera->pl->profile[0x86]) {
+        case 0x08: gp_widget_set_value (widget, _("HQ (24bpp)")); break;
+        }
+
+        gp_widget_new (GP_WIDGET_RADIO, _("Lo Resolution"), &widget);
+        gp_widget_append (section, widget);
+        gp_widget_add_choice (widget, _("100 DPI"));
+        gp_widget_add_choice (widget, _("200 DPI"));
+        switch(camera->pl->profile[0x87]) {
+        case RES_100DPI: gp_widget_set_value (widget, _("100 DPI")); break;
+        case RES_200DPI: gp_widget_set_value (widget, _("200 DPI")); break;
+        }
+
+        gp_widget_new (GP_WIDGET_RADIO, _("Hi Resolution"), &widget);
+        gp_widget_append (section, widget);
+        gp_widget_add_choice (widget, _("200 DPI"));
+        gp_widget_add_choice (widget, _("400 DPI"));
+        switch(camera->pl->profile[0x88]) {
+        case RES_200DPI: gp_widget_set_value (widget, _("200 DPI")); break;
+        case RES_400DPI: gp_widget_set_value (widget, _("400 DPI")); break;
+        }
+
+	return GP_OK;
+}
+
+
+int camera_config_set (Camera *camera, CameraWidget *window, GPContext *context);
+int
+camera_config_set (Camera *camera, CameraWidget *window, GPContext *context)
+{
+	CameraWidget *section, *widget;
+	char *value;
+
+	gp_widget_get_child_by_label (window, _("Mono mode"), &section);
+	gp_widget_get_child_by_label (section, _("Depth"), &widget);
+	if (gp_widget_changed (widget)) {
+		gp_widget_get_value (widget, &value);
+		gp_widget_set_changed (widget, 0);
+		if (!strcmp(value, _("Mono (b/w)")))
+			camera->pl->profile[0x80] = 0x00;
+		else if (!strcmp(value, _("Grey (4bpp)")))
+			camera->pl->profile[0x80] = 0x01;
+		else if (!strcmp(value, _("Grey (8bpp)")))
+			camera->pl->profile[0x80] = 0x02;
+	}
+
+	gp_widget_get_child_by_label (section, _("Lo Resolution"), &widget);
+	if (gp_widget_changed (widget)) {
+		gp_widget_get_value (widget, &value);
+		gp_widget_set_changed (widget, 0);
+		if (!strcmp(value, _("100 DPI")))
+			camera->pl->profile[0x81] = RES_100DPI;
+		else if (!strcmp(value, _("200 DPI")))
+			camera->pl->profile[0x81] = RES_200DPI;;
+	}
+
+	gp_widget_get_child_by_label (section, _("Hi Resolution"), &widget);
+	if (gp_widget_changed (widget)) {
+		gp_widget_get_value (widget, &value);
+		gp_widget_set_changed (widget, 0);
+		if (!strcmp(value, _("200 DPI")))
+			camera->pl->profile[0x82] = RES_200DPI;
+		else if (!strcmp(value, _("400 DPI")))
+			camera->pl->profile[0x82] = RES_400DPI;;
+	}
+
+	gp_widget_get_child_by_label (window, _("Color Document mode"), &section);
+	gp_widget_get_child_by_label (section, _("Depth"), &widget);
+	if (gp_widget_changed (widget)) {
+		gp_widget_get_value (widget, &value);
+		gp_widget_set_changed (widget, 0);
+		if (!strcmp(value, _("NQ (12bpp)")))
+			camera->pl->profile[0x83] = 0x04;
+	}
+
+	gp_widget_get_child_by_label (section, _("Lo Resolution"), &widget);
+	if (gp_widget_changed (widget)) {
+		gp_widget_get_value (widget, &value);
+		gp_widget_set_changed (widget, 0);
+		if (!strcmp(value, _("100 DPI")))
+			camera->pl->profile[0x84] = RES_100DPI;
+		else if (!strcmp(value, _("200 DPI")))
+			camera->pl->profile[0x84] = RES_200DPI;;
+	}
+
+	gp_widget_get_child_by_label (section, _("Hi Resolution"), &widget);
+	if (gp_widget_changed (widget)) {
+		gp_widget_get_value (widget, &value);
+		gp_widget_set_changed (widget, 0);
+		if (!strcmp(value, _("200 DPI")))
+			camera->pl->profile[0x85] = RES_200DPI;
+		else if (!strcmp(value, _("400 DPI")))
+			camera->pl->profile[0x85] = RES_400DPI;;
+	}
+
+	gp_widget_get_child_by_label (window, _("Color Photo mode"), &section);
+	gp_widget_get_child_by_label (section, _("Depth"), &widget);
+	if (gp_widget_changed (widget)) {
+		gp_widget_get_value (widget, &value);
+		gp_widget_set_changed (widget, 0);
+		if (!strcmp(value, _("HQ (24bpp)")))
+			camera->pl->profile[0x86] = 0x08;
+	}
+
+	gp_widget_get_child_by_label (section, _("Lo Resolution"), &widget);
+	if (gp_widget_changed (widget)) {
+		gp_widget_get_value (widget, &value);
+		gp_widget_set_changed (widget, 0);
+		if (!strcmp(value, _("100 DPI")))
+			camera->pl->profile[0x87] = RES_100DPI;
+		else if (!strcmp(value, _("200 DPI")))
+			camera->pl->profile[0x87] = RES_200DPI;;
+	}
+
+	gp_widget_get_child_by_label (section, _("Hi Resolution"), &widget);
+	if (gp_widget_changed (widget)) {
+		gp_widget_get_value (widget, &value);
+		gp_widget_set_changed (widget, 0);
+		if (!strcmp(value, _("200 DPI")))
+			camera->pl->profile[0x88] = RES_200DPI;
+		else if (!strcmp(value, _("400 DPI")))
+			camera->pl->profile[0x88] = RES_400DPI;;
+	}
+
+	if (!dp_set_profile(camera))
+		return GP_ERROR;
+
+	return GP_OK;
+}
+
+
+int
+camera_summary (Camera *camera, CameraText *summary, GPContext *context);
+int
+camera_summary (Camera *camera, CameraText *summary, GPContext *context)
+{
+	sprintf(summary->text, "Scanner model: DocuPen RC800\n"
+		"Images in memory: %d\n"
+		"Used bytes in memory: %d\n"
+		"Internal Flash ID: %04x\n"
+		"Memory size: %d\n"
+		"Calibration values: %d %d %d %d %d %d %d %d",
+		le32toh(camera->pl->info.pagestored),
+		le32toh(camera->pl->info.datacountbyte),
+		le16toh(camera->pl->info.flashmemid),
+		le32toh(camera->pl->info.flashmemmax),
+		camera->pl->info.calibvalue[0],
+		camera->pl->info.calibvalue[1],
+		camera->pl->info.calibvalue[2],
+		camera->pl->info.calibvalue[3],
+		camera->pl->info.calibvalue[4],
+		camera->pl->info.calibvalue[5],
+		camera->pl->info.calibvalue[6],
+		camera->pl->info.calibvalue[7]
+		);
+	return GP_OK;
+}
+
+
+int
+camera_manual (Camera *camera, CameraText *manual, GPContext *context);
+int
+camera_manual (Camera *camera, CameraText *manual, GPContext *context)
+{
+	strcpy(manual->text,
+	_(
+	"Docupen scanner can't download/erase individual images, only everything\n"
+	"at once. To work-around this, a cache file is created where a copy of the\n"
+	"scanner's memory is stored. The cache fill is trigerred by downloading any\n"
+	"image - so downloading the first image will take long time if the cache is\n"
+	"empty or not valid. The cache is invalidated automatically when the amount\n"
+	"of used memory reported by the scanner does not match cache size.\n"
+	"The cache file is located at ~/.cache/docupen-SERIAL_NO.bin\n"
+	"\n"
+	"The scanner has a very short auto-power-off timeout - only 8 seconds - and\n"
+	"it's effective even when connected by USB. You need to turn it on before\n"
+	"each gphoto2 operation. In some situations, you might need to prevent it\n"
+	"from turning off by repeatedly pressing any of the buttons."
+	));
+
+	return GP_OK;
+}
+
+
+int
+camera_about (Camera *camera, CameraText *about, GPContext *context);
+int
+camera_about (Camera *camera, CameraText *about, GPContext *context)
+{
+	strcpy (about->text, _("DocuPen RC800 scanner library\n"
+			       "Copyright 2020 Ondrej Zary <ondrej@zary.sk>\n"
+			       "based on Docupen tools by Florian Heinz <fh@cronon-ag.de>"
+			       ));
+
+	return GP_OK;
+}
+
+
+int
+get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
+	       CameraFileType type, CameraFile *file, void *data,
+	       GPContext *context);
+int
+get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
+	       CameraFileType type, CameraFile *file, void *data,
+	       GPContext *context)
+{
+	Camera *camera = data;
+	struct dp_imagehdr header;
+	int ret;
+	char *file_data;
+	gdImagePtr img;
+	void *gdout;
+	int gdsize;
+	int nr = gp_filesystem_number(fs, folder, filename, context);
+	if (nr < 0)
+		return nr;
+	nr++; /* libgphoto2 file numbering is 0-based, docupen 1-based */
+
+	if (!dp_init_cache(camera)) {
+		GP_LOG_E("error initializing cache");
+		return GP_ERROR;
+	}
+
+	/* find the file in cache */
+	fseek(camera->pl->cache, 0, SEEK_SET);
+	do {
+		ret = fread(&header, 1, sizeof(header), camera->pl->cache);
+		if (ret < sizeof(header)) {
+			GP_LOG_E("error reading image header");
+			return GP_ERROR;
+		}
+		if (le16toh(header.magic) != DP_MAGIC) {
+			GP_LOG_E("invalid magic number in image header: 0x%04x", le16toh(header.magic));
+			return GP_ERROR;
+		}
+		if (le16toh(header.nr) == nr) /* found */
+			break;
+		fseek(camera->pl->cache, le32toh(header.payloadlen), SEEK_CUR);
+	} while (1);
+
+	file_data = malloc(le32toh(header.payloadlen));
+	if (!file_data)
+		return GP_ERROR_NO_MEMORY;
+
+	ret = fread(file_data, 1, le32toh(header.payloadlen), camera->pl->cache);
+	if (ret < le32toh(header.payloadlen)) {
+		perror("fread");
+		GP_LOG_E("error reading image data");
+		free(file_data);
+		return GP_ERROR;
+	}
+	switch (type) {
+	case GP_FILE_TYPE_PREVIEW:
+	case GP_FILE_TYPE_NORMAL:
+		switch (le16toh(header.type)) {
+		case TYPE_MONO:
+			img = dp_get_image_mono(&header, file_data);
+			break;
+		case TYPE_GREY4:
+		case TYPE_GREY8:
+			img = dp_get_image_grey(&header, file_data, camera->pl->lut);
+			break;
+		case TYPE_COLOR12:
+		case TYPE_COLOR24:
+			img = dp_get_image_color(&header, file_data, camera->pl->lut);
+			break;
+		default:
+			GP_LOG_E("invalid image type 0x%x", le16toh(header.type));
+			return GP_ERROR;
+		}
+		if (!img) {
+			free(file_data);
+			return GP_ERROR_NO_MEMORY;
+		}
+		gdout = gdImagePngPtr(img, &gdsize);
+		gdImageDestroy(img);
+		free(file_data);
+		if (!gdout) {
+			GP_LOG_E("image conversion error");
+			return GP_ERROR;
+		}
+		file_data = malloc(gdsize);
+		memcpy(file_data, gdout, gdsize);
+		gdFree(gdout);
+		gp_file_set_mime_type (file, GP_MIME_PNG);
+		gp_file_set_data_and_size (file, file_data, gdsize);
+		break;
+	case GP_FILE_TYPE_RAW:
+		gp_file_set_mime_type(file, GP_MIME_RAW);
+		memcpy(raw_header + RAW_HEADER_SERIAL_OFFSET, camera->pl->info.serialno, sizeof(camera->pl->info.serialno));
+		gp_file_append(file, (void *)&raw_header, sizeof(raw_header));
+		gp_file_append(file, (void *)&header, sizeof(header));
+		gp_file_append(file, file_data, le32toh(header.payloadlen));
+		free(file_data);
+		gp_file_adjust_name_for_mime_type(file);
+		break;
+	default:
+		return GP_ERROR_NOT_SUPPORTED;
+	}
+
+	return GP_OK;
+}
+
+
+int
+delete_all_func (CameraFilesystem *fs, const char *folder, void *data,
+		 GPContext *context);
+int
+delete_all_func (CameraFilesystem *fs, const char *folder, void *data,
+		 GPContext *context)
+{
+	Camera *camera = data;
+	unsigned char status;
+
+	if (!dp_cmd(camera->port, cmd_del_all)) {
+		GP_LOG_E("delete all command failed");
+		return GP_ERROR_CAMERA_ERROR;
+	}
+
+	do
+		gp_port_read(camera->port, (void *)&status, 1);
+	while (status == DP_ACK);
+
+	if (status != 0) {
+		GP_LOG_E("erase failed");
+		return GP_ERROR_CAMERA_ERROR;
+	}
+
+	if (!inquiry_read(camera)) {
+		GP_LOG_E("error reading inquiry after erase");
+		return GP_ERROR_CAMERA_ERROR;
+	}
+
+	dp_delete_cache(camera);
+
+	return GP_OK;
+}
+
+
+int
+file_list_func (CameraFilesystem *fs, const char *folder, CameraList *list,
+		void *data, GPContext *context);
+int
+file_list_func (CameraFilesystem *fs, const char *folder, CameraList *list,
+		void *data, GPContext *context)
+{
+	Camera *camera = data;
+	return gp_list_populate(list, "docupen%03i.png", le32toh(camera->pl->info.pagestored));
+}
+
+
+int
+storage_info_func (CameraFilesystem *fs,
+		CameraStorageInformation **storageinformations,
+		int *nrofstorageinformations, void *data,
+		GPContext *context);
+int
+storage_info_func (CameraFilesystem *fs,
+		CameraStorageInformation **storageinformations,
+		int *nrofstorageinformations, void *data,
+		GPContext *context)
+{
+	Camera *camera = data;
+	CameraStorageInformation *sinfo;
+
+	sinfo = malloc(sizeof(CameraStorageInformation));
+	if (!sinfo)
+		return GP_ERROR_NO_MEMORY;
+
+	*storageinformations = sinfo;
+	*nrofstorageinformations = 1;
+
+	sinfo->fields  = GP_STORAGEINFO_BASE;
+	strcpy(sinfo->basedir, "/");
+	sinfo->fields |= GP_STORAGEINFO_ACCESS;
+	sinfo->access  = GP_STORAGEINFO_AC_READONLY_WITH_DELETE;
+	sinfo->fields |= GP_STORAGEINFO_STORAGETYPE;
+	sinfo->type    = GP_STORAGEINFO_ST_REMOVABLE_RAM;
+	sinfo->fields |= GP_STORAGEINFO_FILESYSTEMTYPE;
+	sinfo->fstype  = GP_STORAGEINFO_FST_GENERICFLAT;
+	sinfo->fields |= GP_STORAGEINFO_MAXCAPACITY;
+	sinfo->capacitykbytes = le32toh(camera->pl->info.flashmemmax) / 1024;
+	sinfo->fields |= GP_STORAGEINFO_FREESPACEKBYTES;
+	sinfo->freekbytes = (le32toh(camera->pl->info.flashmemmax) - le32toh(camera->pl->info.datacountbyte)) / 1024;
+
+	return GP_OK;
+}
+
+
+int
+camera_id (CameraText *id)
+{
+	strcpy(id->text, "docupen");
+
+	return GP_OK;
+}
+
+
+int
+camera_abilities (CameraAbilitiesList *list)
+{
+	CameraAbilities a;
+
+	memset(&a, 0, sizeof(a));
+	strcpy(a.model, "Planon DocuPen RC800");
+	a.status            = GP_DRIVER_STATUS_EXPERIMENTAL;
+	a.port              = GP_PORT_USB;
+	a.usb_vendor        = 0x18dd;
+	a.usb_product       = 0x1000;
+	a.speed[0]          = 0;
+	a.operations        = GP_OPERATION_CONFIG;
+	a.file_operations   = GP_FILE_OPERATION_RAW;
+	a.folder_operations = GP_FOLDER_OPERATION_DELETE_ALL;
+
+	gp_abilities_list_append(list, a);
+
+	return GP_OK;
+}
+
+CameraFilesystemFuncs fsfuncs = {
+	.file_list_func = file_list_func,
+	.get_file_func = get_file_func,
+	.delete_all_func = delete_all_func,
+	.storage_info_func = storage_info_func
+};
+
+int
+camera_init (Camera *camera, GPContext *context)
+{
+	GPPortSettings settings;
+	char buf[64];
+
+        camera->functions->exit                 = camera_exit;
+        camera->functions->get_config           = camera_config_get;
+        camera->functions->set_config           = camera_config_set;
+        camera->functions->summary              = camera_summary;
+        camera->functions->manual               = camera_manual;
+        camera->functions->about                = camera_about;
+
+	gp_filesystem_set_funcs(camera->fs, &fsfuncs, camera);
+
+	camera->pl = calloc(1, sizeof(CameraPrivateLibrary));
+	if (!camera->pl)
+		return GP_ERROR_NO_MEMORY;
+
+	if (!dp_cmd(camera->port, cmd_query)) {
+		GP_LOG_E("query failed");
+		camera_exit(camera, context);
+		return GP_ERROR_CAMERA_ERROR;
+	}
+	gp_port_read(camera->port, buf, sizeof(buf));	/* read and ingore */
+
+	if (!dp_cmd(camera->port, cmd_inquiry)) {
+		GP_LOG_E("inquiry failed");
+		camera_exit(camera, context);
+		return GP_ERROR_CAMERA_ERROR;
+	}
+	if (!inquiry_read(camera)) {
+		GP_LOG_E("error reading inquiry reply");
+		camera_exit(camera, context);
+		return GP_ERROR_CAMERA_ERROR;
+	}
+
+	return GP_OK;
+}

--- a/camlibs/docupen/docupen.h
+++ b/camlibs/docupen/docupen.h
@@ -1,0 +1,91 @@
+#include <string.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <gd.h>
+
+#define MAX_CALIBVALUES	8
+#define SERIALNO_LEN	16
+
+struct dp_info {
+	uint8_t  s;
+	uint16_t version;
+	uint8_t  len;
+	uint32_t memwrite;
+	uint32_t pagestored;
+	uint16_t res;
+	uint32_t datacountbyte;
+	uint8_t  flashmemcfg;
+	uint16_t flashmemid;
+	uint32_t flashmemmax;
+	uint32_t errorcode;
+	uint32_t memwritestart;
+	uint8_t  packetsize[3];
+	uint8_t  notch[MAX_CALIBVALUES];
+	uint32_t ucorrectedcountbyte;
+	uint8_t  calibvalue[MAX_CALIBVALUES];
+	uint16_t checksum;
+	uint16_t m_badcols[10];
+	uint8_t  serialno[SERIALNO_LEN];
+	uint8_t  assignedserialno;
+	uint8_t  modelname[8];
+	uint32_t modelwidth;
+	uint8_t  encryptionsupport;
+	uint8_t  maxdpi;
+	uint8_t  dummy;
+	uint8_t  unused[250];
+} __attribute__ ((packed));
+
+#define DP_MAGIC	0x2049
+
+/* Vertical resolutions. Horizontal resolution is always 200dpi */
+#define RES_100DPI	0x19
+#define RES_200DPI	0x32
+#define RES_400DPI	0x64
+
+#define TYPE_FIRST	0x0000
+#define TYPE_MONO	0x4700
+#define TYPE_GREY4	0x0001
+#define TYPE_GREY8	0x0002
+#define TYPE_COLOR12	0x0004
+#define TYPE_COLOR24	0x0008
+
+#define PROFILE_LEN	0x400
+
+struct dp_imagehdr {
+	uint16_t magic;
+	uint16_t type;
+	uint8_t  unknown;	/* header size = always 0x32 */
+	uint8_t  dpi;
+	uint16_t sizex;
+	uint16_t sizey;
+	uint32_t payloadlen;
+	uint32_t payloadlen2; /* ???  is payloadlen-0x20 */
+	uint32_t payloadaddr;
+	uint32_t nextchunk_raw;
+	uint32_t nextchunk;  /* nextchunk-0x200, for USB-Mode */
+	uint16_t nr;
+	uint8_t  data[0];
+} __attribute__ ((packed));
+
+struct _CameraPrivateLibrary {
+	struct dp_info info;
+	uint32_t datalen;
+	char *cache_file;
+	FILE *cache;
+	struct lut *lut;
+	char *profile;
+};
+
+struct lut {
+    unsigned char data[256];
+};
+
+bool dp_cmd(GPPort *port, const char *cmd);
+bool dp_init_cache(Camera *camera);
+bool dp_delete_cache(Camera *camera);
+bool dp_init_calibration(Camera *camera, bool force);
+gdImagePtr dp_get_image_mono(struct dp_imagehdr *dp, void *data);
+gdImagePtr dp_get_image_grey(struct dp_imagehdr *dp, void *data, struct lut *lut);
+gdImagePtr dp_get_image_color(struct dp_imagehdr *dp, void *data, struct lut *lut);

--- a/camlibs/docupen/huffman.c
+++ b/camlibs/docupen/huffman.c
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2020 Ondrej Zary <ondrej@zary.sk>
+ * based on Docupen tools (C) 2008 Florian Heinz <fh@cronon-ag.de>
+ * based on code found in package sfftobmp (Thanks Peter!)
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "huffman.h"
+
+struct huffman {
+	unsigned short code;
+	int len;
+	unsigned char bits;
+};
+
+#define NOT_FOUND -1
+#define RL_EOL    -2
+struct huffman black[], white[], blackterm[], whiteterm[];
+
+static void skip(struct decoder *d, int nrbits) {
+	d->bitoff += nrbits % 8;
+	d->byteoff += nrbits / 8 + (d->bitoff / 8);
+	d->bitoff %= 8;
+}
+
+static unsigned short get(struct decoder *d, int nrbits) {
+	unsigned short ret = 0;
+	int bitoff, byteoff, i = 16;
+
+	bitoff = d->bitoff;
+	byteoff = d->byteoff;
+
+	while (nrbits--) {
+		ret >>= 1;
+		i--;
+		ret |= !!((d->data[byteoff] & (1 << (7 - bitoff++)))) << 15;
+		if (bitoff >= 8) {
+			 byteoff++;
+			 bitoff = 0;
+		}
+		if (byteoff >= d->length)
+			return -1;
+	}
+
+	return ret >> i;
+}
+
+static int find(struct decoder *d, struct huffman *tab)
+{
+	unsigned short bits;
+
+	while (tab->code) {
+		bits = get(d, tab->bits);
+		if (bits == tab->code) {
+			skip(d, tab->bits);
+			return tab->len;
+		}
+		tab++;
+	}
+
+	return NOT_FOUND;
+}
+
+void decoder_init(struct decoder *d, void *data, int length) {
+	memset(d, 0, sizeof(struct decoder));
+	d->data = data;
+	d->length = length;
+}
+
+int decoder_token(struct decoder *d, int *type, int *len) {
+	int l;
+	int found_nonterm = 0;
+
+	*type = DECODER_NOOP;
+
+	l = find(d, d->state & WHITE ? whiteterm : blackterm);
+	if (l == NOT_FOUND) {
+		if (d->state & TERM)
+			return -1;
+		l = find(d, d->state & WHITE ? white : black);
+		if (l == NOT_FOUND)
+			return -1;
+		found_nonterm = 1;
+	}
+
+	if (l == RL_EOL) {
+		*type = DECODER_EOL;
+		if (d->bitoff > 0) {
+			d->bitoff = 0;
+			d->byteoff++;
+		}
+		return 0;
+	}
+
+	if (l > 0) {
+		*type = d->state & WHITE ? DECODER_WHITE : DECODER_BLACK;
+		*len = l;
+	}
+	if (found_nonterm)
+		d->state = d->state & WHITE ? WHITE | TERM : BLACK | TERM;
+	else
+		d->state = d->state & WHITE ? BLACK : WHITE;
+
+	return 0;
+}
+
+struct huffman black[] = {
+	{ 0x0080, RL_EOL,  8 },
+	{ 0x0800, RL_EOL, 12 },
+	{ 0x001b,   64, 5 },
+	{ 0x0009,  128, 5 },
+	{ 0x003a,  192, 6 },
+	{ 0x0076,  256, 7 },
+	{ 0x006c,  320, 8 },
+	{ 0x00ec,  384, 8 },
+	{ 0x0026,  448, 8 },
+	{ 0x00a6,  512, 8 },
+	{ 0x0016,  576, 8 },
+	{ 0x00e6,  640, 8 },
+	{ 0x0066,  704, 9 },
+	{ 0x0166,  768, 9 },
+	{ 0x0096,  832, 9 },
+	{ 0x0196,  896, 9 },
+	{ 0x0056,  960, 9 },
+	{ 0x0156, 1024, 9 },
+	{ 0x00d6, 1088, 9 },
+	{ 0x01d6, 1152, 9 },
+	{ 0x0036, 1216, 9 },
+	{ 0x0136, 1280, 9 },
+	{ 0x00b6, 1344, 9 },
+	{ 0x01b6, 1408, 9 },
+	{ 0x0032, 1472, 9 },
+	{ 0x0132, 1536, 9 },
+	{ 0x00b2, 1600, 9 },
+	{ 0x0006, 1664, 6 },
+	{ 0x01b2, 1728, 9 },
+	{ 0x0080, 1792, 11 },
+	{ 0x0180, 1856, 11 },
+	{ 0x0580, 1920, 11 },
+	{ 0x0480, 1984, 12 },
+	{ 0x0c80, 2048, 12 },
+	{ 0x0280, 2112, 12 },
+	{ 0x0a80, 2176, 12 },
+	{ 0x0680, 2240, 12 },
+	{ 0x0e80, 2304, 12 },
+	{ 0x0380, 2368, 12 },
+	{ 0x0b80, 2432, 12 },
+	{ 0x0780, 2496, 12 },
+	{ 0x0f80, 2560, 12 },
+	{      0,    0, 0 }
+};
+
+struct huffman blackterm[] = {
+	{ 0x0080, RL_EOL,  8 },
+	{ 0x0800, RL_EOL, 12 },
+	{ 0x00ac,  0, 8 },
+	{ 0x0038,  1, 6 },
+	{ 0x000e,  2, 4 },
+	{ 0x0001,  3, 4 },
+	{ 0x000d,  4, 4 },
+	{ 0x0003,  5, 4 },
+	{ 0x0007,  6, 4 },
+	{ 0x000f,  7, 4 },
+	{ 0x0019,  8, 5 },
+	{ 0x0005,  9, 5 },
+	{ 0x001c, 10, 5 },
+	{ 0x0002, 11, 5 },
+	{ 0x0004, 12, 6 },
+	{ 0x0030, 13, 6 },
+	{ 0x000b, 14, 6 },
+	{ 0x002b, 15, 6 },
+	{ 0x0015, 16, 6 },
+	{ 0x0035, 17, 6 },
+	{ 0x0072, 18, 7 },
+	{ 0x0018, 19, 7 },
+	{ 0x0008, 20, 7 },
+	{ 0x0074, 21, 7 },
+	{ 0x0060, 22, 7 },
+	{ 0x0010, 23, 7 },
+	{ 0x000a, 24, 7 },
+	{ 0x006a, 25, 7 },
+	{ 0x0064, 26, 7 },
+	{ 0x0012, 27, 7 },
+	{ 0x000c, 28, 7 },
+	{ 0x0040, 29, 8 },
+	{ 0x00c0, 30, 8 },
+	{ 0x0058, 31, 8 },
+	{ 0x00d8, 32, 8 },
+	{ 0x0048, 33, 8 },
+	{ 0x00c8, 34, 8 },
+	{ 0x0028, 35, 8 },
+	{ 0x00a8, 36, 8 },
+	{ 0x0068, 37, 8 },
+	{ 0x00e8, 38, 8 },
+	{ 0x0014, 39, 8 },
+	{ 0x0094, 40, 8 },
+	{ 0x0054, 41, 8 },
+	{ 0x00d4, 42, 8 },
+	{ 0x0034, 43, 8 },
+	{ 0x00b4, 44, 8 },
+	{ 0x0020, 45, 8 },
+	{ 0x00a0, 46, 8 },
+	{ 0x0050, 47, 8 },
+	{ 0x00d0, 48, 8 },
+	{ 0x004a, 49, 8 },
+	{ 0x00ca, 50, 8 },
+	{ 0x002a, 51, 8 },
+	{ 0x00aa, 52, 8 },
+	{ 0x0024, 53, 8 },
+	{ 0x00a4, 54, 8 },
+	{ 0x001a, 55, 8 },
+	{ 0x009a, 56, 8 },
+	{ 0x005a, 57, 8 },
+	{ 0x00da, 58, 8 },
+	{ 0x0052, 59, 8 },
+	{ 0x00d2, 60, 8 },
+	{ 0x004c, 61, 8 },
+	{ 0x00cc, 62, 8 },
+	{ 0x002c, 63, 8 },
+	{      0, 0, 0 }
+};
+
+struct huffman white[] = {
+	{ 0x0080, RL_EOL,  8 },
+	{ 0x0800 ,RL_EOL, 12 },
+	{ 0x03c0,   64, 10 },
+	{ 0x0130,  128, 12 },
+	{ 0x0930,  192, 12 },
+	{ 0x0da0,  256, 12 },
+	{ 0x0cc0,  320, 12 },
+	{ 0x02c0,  384, 12 },
+	{ 0x0ac0,  448, 12 },
+	{ 0x06c0,  512, 13 },
+	{ 0x16c0,  576, 13 },
+	{ 0x0a40,  640, 13 },
+	{ 0x1a40,  704, 13 },
+	{ 0x0640,  768, 13 },
+	{ 0x1640,  832, 13 },
+	{ 0x09c0,  896, 13 },
+	{ 0x19c0,  960, 13 },
+	{ 0x05c0, 1024, 13 },
+	{ 0x15c0, 1088, 13 },
+	{ 0x0dc0, 1152, 13 },
+	{ 0x1dc0, 1216, 13 },
+	{ 0x0940, 1280, 13 },
+	{ 0x1940, 1344, 13 },
+	{ 0x0540, 1408, 13 },
+	{ 0x1540, 1472, 13 },
+	{ 0x0b40, 1536, 13 },
+	{ 0x1b40, 1600, 13 },
+	{ 0x04c0, 1664, 13 },
+	{ 0x14c0, 1728, 13 },
+	{ 0x0080, 1792, 11 },
+	{ 0x0180, 1856, 11 },
+	{ 0x0580, 1920, 11 },
+	{ 0x0480, 1984, 12 },
+	{ 0x0c80, 2048, 12 },
+	{ 0x0280, 2112, 12 },
+	{ 0x0a80, 2176, 12 },
+	{ 0x0680, 2240, 12 },
+	{ 0x0e80, 2304, 12 },
+	{ 0x0380, 2368, 12 },
+	{ 0x0b80, 2432, 12 },
+	{ 0x0780, 2496, 12 },
+	{ 0x0f80, 2560, 12 },
+	{      0,    0, 0 }
+};
+
+struct huffman whiteterm[] = {
+	{ 0x0080, RL_EOL,  8 },
+	{ 0x0800, RL_EOL, 12 },
+	{ 0x03b0,  0, 10 },
+	{ 0x0002,  1,  3 },
+	{ 0x0003,  2,  2 },
+	{ 0x0001,  3,  2 },
+	{ 0x0006,  4,  3 },
+	{ 0x000c,  5,  4 },
+	{ 0x0004,  6,  4 },
+	{ 0x0018,  7,  5 },
+	{ 0x0028,  8,  6 },
+	{ 0x0008,  9,  6 },
+	{ 0x0010, 10,  7 },
+	{ 0x0050, 11,  7 },
+	{ 0x0070, 12,  7 },
+	{ 0x0020, 13,  8 },
+	{ 0x00e0, 14,  8 },
+	{ 0x0030, 15,  9 },
+	{ 0x03a0, 16, 10 },
+	{ 0x0060, 17, 10 },
+	{ 0x0040, 18, 10 },
+	{ 0x0730, 19, 11 },
+	{ 0x00b0, 20, 11 },
+	{ 0x01b0, 21, 11 },
+	{ 0x0760, 22, 11 },
+	{ 0x00a0, 23, 11 },
+	{ 0x0740, 24, 11 },
+	{ 0x00c0, 25, 11 },
+	{ 0x0530, 26, 12 },
+	{ 0x0d30, 27, 12 },
+	{ 0x0330, 28, 12 },
+	{ 0x0b30, 29, 12 },
+	{ 0x0160, 30, 12 },
+	{ 0x0960, 31, 12 },
+	{ 0x0560, 32, 12 },
+	{ 0x0d60, 33, 12 },
+	{ 0x04b0, 34, 12 },
+	{ 0x0cb0, 35, 12 },
+	{ 0x02b0, 36, 12 },
+	{ 0x0ab0, 37, 12 },
+	{ 0x06b0, 38, 12 },
+	{ 0x0eb0, 39, 12 },
+	{ 0x0360, 40, 12 },
+	{ 0x0b60, 41, 12 },
+	{ 0x05b0, 42, 12 },
+	{ 0x0db0, 43, 12 },
+	{ 0x02a0, 44, 12 },
+	{ 0x0aa0, 45, 12 },
+	{ 0x06a0, 46, 12 },
+	{ 0x0ea0, 47, 12 },
+	{ 0x0260, 48, 12 },
+	{ 0x0a60, 49, 12 },
+	{ 0x04a0, 50, 12 },
+	{ 0x0ca0, 51, 12 },
+	{ 0x0240, 52, 12 },
+	{ 0x0ec0, 53, 12 },
+	{ 0x01c0, 54, 12 },
+	{ 0x0e40, 55, 12 },
+	{ 0x0140, 56, 12 },
+	{ 0x01a0, 57, 12 },
+	{ 0x09a0, 58, 12 },
+	{ 0x0d40, 59, 12 },
+	{ 0x0340, 60, 12 },
+	{ 0x05a0, 61, 12 },
+	{ 0x0660, 62, 12 },
+	{ 0x0e60, 63, 12 },
+	{      0, 0, 0 }
+};

--- a/camlibs/docupen/huffman.h
+++ b/camlibs/docupen/huffman.h
@@ -1,0 +1,23 @@
+struct decoder {
+	unsigned char *data;
+	int length;
+	int bitoff;
+	int byteoff;
+	int state;
+};
+
+void decoder_init(struct decoder *d, void *data, int length);
+int  decoder_token(struct decoder *d, int *type, int *len);
+
+enum {
+	BLACK = 0,
+	WHITE = 1,
+	TERM = (1 << 7)
+};
+
+enum {
+	DECODER_NOOP = 0,
+	DECODER_BLACK,
+	DECODER_WHITE,
+	DECODER_EOL
+};

--- a/camlibs/docupen/image.c
+++ b/camlibs/docupen/image.c
@@ -1,0 +1,259 @@
+/* image.c
+ *
+ * Copyright 2020 Ondrej Zary <ondrej@zary.sk>
+ * based on Docupen tools by Florian Heinz <fh@cronon-ag.de>
+ */
+#include <gphoto2/gphoto2-library.h>
+#include <gphoto2-endian.h>
+#include "docupen.h"
+#include "huffman.h"
+
+gdImagePtr dp_get_image_mono(struct dp_imagehdr *dp, void *data)
+{
+	gdImagePtr img, fixed;
+	int black, white;
+	int type, len;
+	int x = 0, y = 0;
+	struct decoder decoder;
+	int palette[256];
+	unsigned int tmp = 0;
+	int nr_marks = 0, mark = 0, offset = 0, last_mark = 0;
+	int dist = dp->dpi == RES_400DPI ? 26 : 13;
+	int out_width = dp->dpi == RES_400DPI ? 3072 : 1536;
+
+	img = gdImageCreate(le16toh(dp->sizex), le16toh(dp->sizey));
+	if (!img)
+		return NULL;
+
+	for (int i = 0; i <= 255; i++)
+		palette[i] = gdImageColorAllocate(img, i, i, i);
+	black = palette[0];
+	white = palette[255];
+
+	decoder_init(&decoder, data, le32toh(dp->payloadlen));
+	while (decoder_token(&decoder, &type, &len) >= 0) {
+		switch (type) {
+		case DECODER_EOL:
+			if (y > 0 && gdImagePalettePixel(img, 0, y) > 0xf0) {
+				nr_marks++;
+				last_mark = y;
+			}
+			y++;
+			x = 0;
+			tmp = 0;
+			break;
+		case DECODER_BLACK:
+		case DECODER_WHITE:
+			while (len && (x++ < le16toh(dp->sizex))) {
+				/* decode first 32 bits(pixels) as four 8bpp pixels */
+				if (x > le16toh(dp->sizex) - 32)
+					if (type == DECODER_WHITE)
+						tmp |= (1 << (le16toh(dp->sizex) - x));
+				if (x == le16toh(dp->sizex)) {
+					gdImageSetPixel(img, 0, y, tmp & 0xff);
+					gdImageSetPixel(img, 1, y, (tmp >> 8) & 0xff);
+					gdImageSetPixel(img, 2, y, (tmp >> 16) & 0xff);
+					gdImageSetPixel(img, 3, y, (tmp >> 24) & 0xff);
+				}
+				if (x <= le16toh(dp->sizex) - 32)
+					gdImageSetPixel(img, le16toh(dp->sizex) - x, y, (type == DECODER_WHITE) ? white : black);
+				len--;
+			}
+			break;
+		}
+		if (y >= le16toh(dp->sizey))
+			break;
+	}
+	/* don't lose the image bottom below the last mark */
+	if (last_mark < le16toh(dp->sizey) - 1) {
+		nr_marks++;
+		gdImageSetPixel(img, 0, le16toh(dp->sizey) - 1, 0xff);
+	}
+
+	fixed = gdImageCreate(out_width, nr_marks * dist);
+	if (!fixed) {
+		gdImageDestroy(img);
+		return NULL;
+	}
+	black = gdImageColorAllocate(fixed, 0, 0, 0);
+	white = gdImageColorAllocate(fixed, 255, 255, 255);
+
+	for (y = 0; y < img->sy; y++) {
+		if (y > 0 && gdImagePalettePixel(img, 0, y) > 0xf0) {
+			gdImageCopyResampled(fixed, img, 0, offset, 32, mark, out_width, dist, 1536, y - mark);
+			mark = y;
+			offset += dist;
+		}
+	}
+
+	gdImageDestroy(img);
+
+	return fixed;
+}
+
+struct line_grey4 {
+	unsigned char val[800];
+};
+
+struct line_grey8 {
+	unsigned char val[1600];
+};
+
+gdImagePtr dp_get_image_grey(struct dp_imagehdr *dp, void *data, struct lut *lut)
+{
+	gdImagePtr img, fixed;
+	int palette[256], palette2[256];
+	int i, j, odd, val;
+	struct line_grey4 *line4 = data;
+	struct line_grey8 *line8 = data;
+	int nr_marks = 0, mark = 0, offset = 0, last_mark = 0;
+	int pos_x;
+	int dist = dp->dpi == RES_400DPI ? 26 : 13;
+	int out_width = dp->dpi == RES_400DPI ? 3180 : 1590;
+
+	img = gdImageCreate(le16toh(dp->sizex), le16toh(dp->sizey));
+	if (!img)
+		return NULL;
+	for (i = 0; i <= 255; i++)
+		palette[i] = gdImageColorAllocate(img, i, i, i);
+
+	for (i = 0; i < le16toh(dp->sizey); i++) {
+		odd = 0;
+		for (j = 0; j < le16toh(dp->sizex); j++) {
+			if (le16toh(dp->type) == TYPE_GREY4) {
+				if (odd)
+					val = line4->val[j >> 1] & 0xf0;
+				else
+					val = (line4->val[j >> 1] & 0x0f) << 4;
+				odd = !odd;
+			} else
+				val = line8->val[j];
+			pos_x = le16toh(dp->sizex) - j - 1;
+			if (pos_x != 1599)
+				val = lut[pos_x * 3 + 2].data[val]; /* use red LUT */
+			gdImageSetPixel(img, pos_x, i, palette[val]);
+		}
+		if (i > 0 && gdImagePalettePixel(img, 1599, i) < 0xf0) {
+			nr_marks++;
+			last_mark = i;
+		}
+		line4++;
+		line8++;
+	}
+	/* don't lose the image bottom below the last mark */
+	if (last_mark < le16toh(dp->sizey) - 1) {
+		nr_marks++;
+		gdImageSetPixel(img, 1599, le16toh(dp->sizey) - 1, 0x80);
+	}
+
+	fixed = gdImageCreate(out_width, nr_marks * dist);
+	if (!fixed) {
+		gdImageDestroy(img);
+		return NULL;
+	}
+	for (i = 0; i <= 255; i++)
+		palette2[i] = gdImageColorAllocate(fixed, i, i, i);
+
+	for (i = 0; i < img->sy; i++) {
+		if (i > 0 && gdImagePalettePixel(img, 1599, i) < 0xf0) {
+			gdImageCopyResampled(fixed, img, 0, offset, 0, mark, out_width, dist, 1590, i - mark);
+			mark = i;
+			offset += dist;
+		}
+	}
+
+	gdImageDestroy(img);
+
+	return fixed;
+}
+
+struct line12 {
+	unsigned char r[800];
+	unsigned char g[800];
+	unsigned char b[800];
+};
+
+struct line24 {
+	unsigned char r[1600];
+	unsigned char g[1600];
+	unsigned char b[1600];
+};
+
+gdImagePtr dp_get_image_color(struct dp_imagehdr *dp, void *data, struct lut *lut)
+{
+	gdImagePtr img, fixed;
+	int i, j, odd;
+	unsigned char r, g, b;
+	struct line12 *line12 = data;
+	struct line24 *line24 = data;
+	int nr_marks = 0, mark = 0, offset = 0, last_mark = 0;
+	int pos_x;
+	int dist = dp->dpi == RES_400DPI ? 26 : 13;
+	int out_width = dp->dpi == RES_400DPI ? 3180 : 1590;
+
+	if ((le16toh(dp->sizex) <= 0) || (le16toh(dp->sizey) <= 0) ||
+		 ((le16toh(dp->sizex) * le16toh(dp->sizey) * 3) / (le16toh(dp->type) == TYPE_COLOR12 ? 2 : 1) > le32toh(dp->payloadlen)))
+		return NULL;
+
+	img = gdImageCreateTrueColor(le16toh(dp->sizex), le16toh(dp->sizey));
+	if (!img)
+		return NULL;
+
+	for (i = 0; i < le16toh(dp->sizey); i++) {
+		odd = 0;
+		for (j = 0; j < le16toh(dp->sizex); j++) {
+			if (le16toh(dp->type) == TYPE_COLOR12) {
+				if (odd) {
+					r = line12->r[j >> 1] & 0xf0;
+					g = line12->g[j >> 1] & 0xf0;
+					b = line12->b[j >> 1] & 0xf0;
+				} else {
+					r = (line12->r[j >> 1] & 0x0f) << 4;
+					g = (line12->g[j >> 1] & 0x0f) << 4;
+					b = (line12->b[j >> 1] & 0x0f) << 4;
+				}
+				odd = !odd;
+			} else {
+				r = line24->r[j];
+				g = line24->g[j];
+				b = line24->b[j];
+			}
+			pos_x = le16toh(dp->sizex) - j - 1;
+			if (pos_x != 1599) {
+				r = lut[pos_x * 3 + 2].data[r];
+				g = lut[pos_x * 3 + 1].data[g];
+				b = lut[pos_x * 3 + 0].data[b];
+			}
+			gdImageSetPixel(img, pos_x, i, (r << 16) | (g << 8) | b);
+		}
+		if (gdTrueColorGetRed(gdImageTrueColorPixel(img, 1599, i)) < 0xf0) {
+			nr_marks++;
+			last_mark = i;
+		}
+		line12++;
+		line24++;
+	}
+	/* don't lose the image bottom below the last mark */
+	if (last_mark < le16toh(dp->sizey) - 1) {
+		nr_marks++;
+		gdImageSetPixel(img, 1599, le16toh(dp->sizey) - 1, 0x80 << 16);
+	}
+
+	fixed = gdImageCreateTrueColor(out_width, nr_marks * dist);
+	if (!fixed) {
+		gdImageDestroy(img);
+		return NULL;
+	}
+
+	for (i = 0; i < img->sy; i++) {
+		if (gdTrueColorGetRed(gdImageTrueColorPixel(img, 1599, i)) < 0xf0) {
+			gdImageCopyResampled(fixed, img, 0, offset, 0, mark, out_width, dist, 1590, i - mark);
+			mark = i;
+			offset += dist;
+		}
+	}
+
+	gdImageDestroy(img);
+
+	return fixed;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -540,6 +540,7 @@ GP_CAMLIB([digigr8])dnl
 GP_CAMLIB([digita],[outdated])dnl
 GP_CAMLIB([dimera3500],[outdated])dnl
 GP_CAMLIB([directory])dnl
+GP_CAMLIB([docupen])dnl
 GP_CAMLIB([enigma13],[outdated])dnl
 GP_CAMLIB([fuji],[outdated])dnl
 GP_CAMLIB([gsmart300],[outdated])dnl


### PR DESCRIPTION
Add camlib for Docupen RC800 wand scanner. Based on Docupen tools by Florian Heinz (https://sourceforge.net/projects/docupen/) and much improved (image correction according to calibration data from scanner, greyscale support).