### PR TITLE
Add ability to override iolibs/camlibs dirs at runtime

### DIFF
--- a/gphoto2/gphoto2-abilities-list.h
+++ b/gphoto2/gphoto2-abilities-list.h
@@ -184,6 +184,8 @@ int gp_abilities_list_lookup_model (CameraAbilitiesList *list,
 int gp_abilities_list_get_abilities (CameraAbilitiesList *list, int index,
 				     CameraAbilities *abilities);
 
+void gp_abilities_list_set_camlibs_override (const char *dir);
+
 const char *gp_message_codeset (const char *);
 
 

--- a/libgphoto2/gphoto2-abilities-list.c
+++ b/libgphoto2/gphoto2-abilities-list.c
@@ -87,6 +87,8 @@ gp_message_codeset (const char *codeset)
 	return bind_textdomain_codeset (GETTEXT_PACKAGE, codeset);
 }
 
+char *gp_abilities_list_camlibs_override = NULL;
+
 /**
  * \brief Allocate the memory for a new abilities list.
  *
@@ -302,7 +304,7 @@ int
 gp_abilities_list_load (CameraAbilitiesList *list, GPContext *context)
 {
 	const char *camlib_env = getenv(CAMLIBDIR_ENV);
-	const char *camlibs = (camlib_env != NULL)?camlib_env:CAMLIBS;
+	const char *camlibs = (camlib_env != NULL)?camlib_env:((gp_abilities_list_camlibs_override != NULL)?gp_abilities_list_camlibs_override:CAMLIBS);
 	C_PARAMS (list);
 
 	CHECK_RESULT (gp_abilities_list_load_dir (list, camlibs, context));
@@ -644,6 +646,18 @@ gp_abilities_list_get_abilities (CameraAbilitiesList *list, int index,
 	return (GP_OK);
 }
 
+void
+gp_abilities_list_set_camlibs_override (const char *dir)
+{
+	if (gp_abilities_list_camlibs_override != NULL) {
+		free (gp_abilities_list_camlibs_override);
+		gp_abilities_list_camlibs_override = NULL;
+	}
+
+	if (dir != NULL) {
+		gp_abilities_list_camlibs_override = strdup(dir);
+	}
+}
 
 #ifdef _GPHOTO2_INTERNAL_CODE
 

--- a/libgphoto2/libgphoto2.sym
+++ b/libgphoto2/libgphoto2.sym
@@ -8,6 +8,7 @@ gp_abilities_list_load_dir
 gp_abilities_list_lookup_model
 gp_abilities_list_new
 gp_abilities_list_reset
+gp_abilities_list_set_camlibs_override
 gp_ahd_decode
 gp_ahd_interpolate
 gp_bayer_decode

--- a/libgphoto2_port/gphoto2/gphoto2-port-info-list.h
+++ b/libgphoto2_port/gphoto2/gphoto2-port-info-list.h
@@ -92,6 +92,8 @@ int gp_port_info_list_lookup_name (GPPortInfoList *list, const char *name);
 
 int gp_port_info_list_get_info (GPPortInfoList *list, int n, GPPortInfo *info);
 
+void gp_port_info_list_set_iolibs_override (const char *dir);
+
 const char *gp_port_message_codeset (const char*);
 
 /**

--- a/libgphoto2_port/libgphoto2_port/gphoto2-port-info-list.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port-info-list.c
@@ -97,6 +97,8 @@ gp_port_message_codeset (const char *codeset) {
 	return bind_textdomain_codeset (GETTEXT_PACKAGE, codeset);
 }
 
+char *gp_port_info_list_iolibs_override = NULL;
+
 /**
  * \brief Create a new GPPortInfoList
  *
@@ -274,7 +276,7 @@ int
 gp_port_info_list_load (GPPortInfoList *list)
 {
 	const char *iolibs_env = getenv(IOLIBDIR_ENV);
-	const char *iolibs = (iolibs_env != NULL)?iolibs_env:IOLIBS;
+	const char *iolibs = (iolibs_env != NULL)?iolibs_env:((gp_port_info_list_iolibs_override != NULL)?gp_port_info_list_iolibs_override:IOLIBS);
 	int result;
 
 	C_PARAMS (list);
@@ -478,6 +480,18 @@ gp_port_info_list_get_info (GPPortInfoList *list, int n, GPPortInfo *info)
 	return GP_OK;
 }
 
+void
+gp_port_info_list_set_iolibs_override (const char *dir)
+{
+	if (gp_port_info_list_iolibs_override != NULL) {
+		free (gp_port_info_list_iolibs_override);
+		gp_port_info_list_iolibs_override = NULL;
+        }
+
+	if (dir != NULL) {
+		gp_port_info_list_iolibs_override = strdup(dir);
+	}
+}
 
 /**
  * \brief Get name of a specific port entry

--- a/libgphoto2_port/libgphoto2_port/libgphoto2_port.ver
+++ b/libgphoto2_port/libgphoto2_port/libgphoto2_port.ver
@@ -27,6 +27,7 @@ LIBGPHOTO2_5_0 {
 	gp_port_info_list_lookup_name;
 	gp_port_info_list_lookup_path;
 	gp_port_info_list_new;
+	gp_port_info_list_set_iolibs_override;
 	gp_port_library_version;
 	gp_port_message_codeset;
 	gp_port_new;


### PR DESCRIPTION
In an application I am developing I have the need to set the path for camlibs and iolibs at runtime as I don't know where the libraries will be when I build the library. This allows for creating a portable version of libgphoto2 which is not dependent on the install location (on macOS you need to use install_name_tool and otool to fix the dyld-id and locations of dependent libraries as well).

With this patch the override path has precedence over the location embedded by configure but will still be overwritten by the environment variables if present so the user/system administrator can still use their own versions of the libraries if they want.

I've tested this patch on Windows, Linux and macOS (x86, gcc and clang).