### PR TITLE
ptp2: Fix C_PTP_MSG args in _put_Canon_EOS_ViewFinder

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -6966,8 +6966,8 @@ _put_Canon_EOS_ViewFinder(CONFIG_PUT_ARGS) {
 	else
 		xval.u16 = 0;
 	C_PTP_MSG (ptp_canon_eos_setdevicepropvalue (params, PTP_DPC_CANON_EOS_EVFOutputDevice, &xval, PTP_DTC_UINT16),
-		   "ptp2_eos_viewfinder enable", "setval of evf outputmode to %d failed", xval.u32);
-	return GP_OK;
+		   "ptp2_eos_viewfinder enable: failed to set evf outputmode to %d", xval.u16);
+        return GP_OK;
 }
 
 static int


### PR DESCRIPTION
This got broken in 62063e9 almost 6 years ago. There were two issues with
this:
1) At some point the parameter value type got changed from u32 to u16
which would cause bogus parameter data to get printed here.
2) While switching from gp_log(...) to C_PTP_MSG the domain was left there
as a separate parameter which caused a SIGSEV in `vsnprintf` in
gphoto2-port-log.c:116. C_PTP_MSG doesn't take an explicit domain which
resulted in the original domain argument being used as the format string
and the original format string as a parameter for the format string.
This resulted in a "classical" format string argument mismatch which made
`vsnprintf` very unhappy.