### PR TITLE
Fix various issues to reduce compiler warnings

### DIFF
--- a/camlibs/agfa-cl20/agfa_cl20.c
+++ b/camlibs/agfa-cl20/agfa_cl20.c
@@ -153,7 +153,7 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 {
 	Camera *camera = privdata;
 	int n = -1;
-	int size = -1;
+	unsigned int size = -1;
 	unsigned char hb, lb;
 	unsigned long j;
 	unsigned int app1len = -1;

--- a/camlibs/ax203/ax203.c
+++ b/camlibs/ax203/ax203.c
@@ -45,69 +45,69 @@ static const struct eeprom_info {
 	int has_4k_sectors;
 	int pp_64k;
 } ax203_eeprom_info[] = {
-	{ "AMIC A25L040", 0x37133037,  524288, 1 },
-	{ "AMIC A25L080", 0x37143037, 1048576, 1 },
-	{ "AMIC A25L40P", 0x1320377f,  524288, 0 },
-	{ "AMIC A25L80P", 0x1420377f, 1048576, 0 },
-	{ "AMIC A25L16P", 0x1520377f, 2097152, 0 },
+	{ "AMIC A25L040", 0x37133037,  524288, 1, 0 },
+	{ "AMIC A25L080", 0x37143037, 1048576, 1, 0 },
+	{ "AMIC A25L40P", 0x1320377f,  524288, 0, 0 },
+	{ "AMIC A25L80P", 0x1420377f, 1048576, 0, 0 },
+	{ "AMIC A25L16P", 0x1520377f, 2097152, 0, 0 },
 
 	/* Note the ATmel AT26DF041 id:0x0000441f is fsck-ed up. It doesn't
 	   support ERASE_64K, (only 4K) and SPI_EEPROM_PP is 0x11 rather then
 	   0x02 (0x02 only programs a single byte). */
 	/* I cannot find a datasheet for the ATmel AT26DF081 id:0x0000451f */
-	{ "ATmel AT26DF161",  0x0000461f, 2097152, 1 },
-	{ "ATmel AT26DF081A", 0x0001451f, 1048576, 1 },
-	{ "ATmel AT26DF161A", 0x0001461f, 2097152, 1 },
-	{ "ATmel AT25DF081",  0x0002451f, 1048576, 1 },
-	{ "ATmel AT25DF161",  0x0002461f, 2097152, 1 },
+	{ "ATmel AT26DF161",  0x0000461f, 2097152, 1, 0 },
+	{ "ATmel AT26DF081A", 0x0001451f, 1048576, 1, 0 },
+	{ "ATmel AT26DF161A", 0x0001461f, 2097152, 1, 0 },
+	{ "ATmel AT25DF081",  0x0002451f, 1048576, 1, 0 },
+	{ "ATmel AT25DF161",  0x0002461f, 2097152, 1, 0 },
 
-	{ "EON EN25B16", 0x1c15201c, 2097152, 0 },
-	{ "EON EN25B32", 0x1c16201c, 4194304, 0 },
-	{ "EON EN25F80", 0x1c14311c, 1048576, 1 },
-	{ "EON EN25F16", 0x1c15311c, 2097152, 1 },
+	{ "EON EN25B16", 0x1c15201c, 2097152, 0, 0 },
+	{ "EON EN25B32", 0x1c16201c, 4194304, 0, 0 },
+	{ "EON EN25F80", 0x1c14311c, 1048576, 1, 0 },
+	{ "EON EN25F16", 0x1c15311c, 2097152, 1, 0 },
 
-	{ "ESI ES25P80", 0x0014204a, 1048576, 0 },
-	{ "ESI ES25P16", 0x0015204a, 2097152, 0 },
+	{ "ESI ES25P80", 0x0014204a, 1048576, 0, 0 },
+	{ "ESI ES25P16", 0x0015204a, 2097152, 0, 0 },
 
-	{ "ESMT F25L008 (top)",    0x8c14208c, 1048576, 1 },
-	{ "ESMT F25L008 (bottom)", 0x8c14218c, 1048576, 1 },
+	{ "ESMT F25L008 (top)",    0x8c14208c, 1048576, 1, 0 },
+	{ "ESMT F25L008 (bottom)", 0x8c14218c, 1048576, 1, 0 },
 
-	{ "GigaDevice GD25Q40", 0xc81340c8,  524288, 1 },
-	{ "GigaDevice GD25Q80", 0xc81440c8, 1048576, 1 },
-	{ "GigaDevice GD25Q16", 0xc81540c8, 2097152, 1 },
+	{ "GigaDevice GD25Q40", 0xc81340c8,  524288, 1, 0 },
+	{ "GigaDevice GD25Q80", 0xc81440c8, 1048576, 1, 0 },
+	{ "GigaDevice GD25Q16", 0xc81540c8, 2097152, 1, 0 },
 
-	{ "MXIC MX25L4005A", 0xc21320c2,  524288, 1 },
-	{ "MXIC MX25L8005A", 0xc21420c2, 1048576, 1 },
-	{ "MXIC MX25L1605A", 0xc21520c2, 2097152, 1 },
+	{ "MXIC MX25L4005A", 0xc21320c2,  524288, 1, 0 },
+	{ "MXIC MX25L8005A", 0xc21420c2, 1048576, 1, 0 },
+	{ "MXIC MX25L1605A", 0xc21520c2, 2097152, 1, 0 },
 
-	{ "Nantronics N25S80", 0xd51430d5, 1048576, 1 },
+	{ "Nantronics N25S80", 0xd51430d5, 1048576, 1, 0 },
 
-	{ "PMC Pm25LV010", 0x007e9d7f, 524288, 0 },
+	{ "PMC Pm25LV010", 0x007e9d7f, 524288, 0, 0 },
 
-	{ "Spansion S25FL004A", 0x00120201,  524288, 0 },
-	{ "Spansion S25FL008A", 0x00130201, 1048576, 0 },
-	{ "Spansion S25FL016A", 0x00140201, 2097152, 0 },
+	{ "Spansion S25FL004A", 0x00120201,  524288, 0, 0 },
+	{ "Spansion S25FL008A", 0x00130201, 1048576, 0, 0 },
+	{ "Spansion S25FL016A", 0x00140201, 2097152, 0, 0 },
 
 	{ "SST25VF080", 0xbf8e25bf, 1048576, 0, 1 },
 	{ "SST25VF016", 0xbf4125bf, 2097152, 0, 1 },
 
-	{ "ST M25P08", 0x7f142020, 1048576, 0 },
-	{ "ST M25P16", 0x7f152020, 2097152, 0 },
-	{ "ST M25P32", 0x7f162020, 4194304, 0 },
-	{ "ST M25P64", 0x7f172020, 8388608, 0 },
+	{ "ST M25P08", 0x7f142020, 1048576, 0, 0 },
+	{ "ST M25P16", 0x7f152020, 2097152, 0, 0 },
+	{ "ST M25P32", 0x7f162020, 4194304, 0, 0 },
+	{ "ST M25P64", 0x7f172020, 8388608, 0, 0 },
 
-	{ "Winbond W25P80", 0x001420ef, 1048576, 0 },
-	{ "Winbond W25P16", 0x001520ef, 2097152, 0 },
+	{ "Winbond W25P80", 0x001420ef, 1048576, 0, 0 },
+	{ "Winbond W25P16", 0x001520ef, 2097152, 0, 0 },
 
-	{ "Winbond W25X40", 0x001330ef,  524288, 1 },
-	{ "Winbond W25X80", 0x001430ef, 1048576, 1 },
-	{ "Winbond W25X16", 0x001530ef, 2097152, 1 },
-	{ "Winbond W25X32", 0x001630ef, 4194304, 1 },
-	{ "Winbond W25X64", 0x001730ef, 8388608, 1 },
+	{ "Winbond W25X40", 0x001330ef,  524288, 1, 0 },
+	{ "Winbond W25X80", 0x001430ef, 1048576, 1, 0 },
+	{ "Winbond W25X16", 0x001530ef, 2097152, 1, 0 },
+	{ "Winbond W25X32", 0x001630ef, 4194304, 1, 0 },
+	{ "Winbond W25X64", 0x001730ef, 8388608, 1, 0 },
 
-	{ "Winbond W25Q80", 0x001440ef, 1048576, 1 },
-	{ "Winbond W25Q16", 0x001540ef, 2097152, 1 },
-	{ "Winbond W25Q32", 0x001640ef, 4194304, 1 },
+	{ "Winbond W25Q80", 0x001440ef, 1048576, 1, 0 },
+	{ "Winbond W25Q16", 0x001540ef, 2097152, 1, 0 },
+	{ "Winbond W25Q32", 0x001640ef, 4194304, 1, 0 },
 
 	{ }
 };
@@ -1138,8 +1138,8 @@ ax203_decode_image(Camera *camera, char *src, int src_size, int **dest)
 			return GP_ERROR_CORRUPTED_DATA;
 		}
 		tinyjpeg_get_components (camera->pl->jdec, components);
-		for (y = 0; y < camera->pl->height; y++) {
-			for (x = 0; x < camera->pl->width; x++) {
+		for (y = 0; y < (unsigned int)camera->pl->height; y++) {
+			for (x = 0; x < (unsigned int)camera->pl->width; x++) {
 				dest[y][x] = gdTrueColor (components[0][0],
 							  components[0][1],
 							  components[0][2]);
@@ -1155,8 +1155,8 @@ ax203_decode_image(Camera *camera, char *src, int src_size, int **dest)
 		jpeg_mem_src (&dinfo, (unsigned char *)src, src_size);
 		jpeg_read_header (&dinfo, TRUE);
 		jpeg_start_decompress (&dinfo);
-		if (dinfo.output_width  != camera->pl->width ||
-		    dinfo.output_height != camera->pl->height ||
+		if (dinfo.output_width  != (unsigned int)camera->pl->width ||
+		    dinfo.output_height != (unsigned int)camera->pl->height ||
 		    dinfo.output_components != 3 ||
 		    dinfo.out_color_space != JCS_RGB) {
 			gp_log (GP_LOG_ERROR, "ax203",
@@ -1198,7 +1198,7 @@ ax203_encode_image(Camera *camera, int **src, char *dest, int dest_size)
 #ifdef HAVE_LIBGD
 	int size = ax203_filesize (camera);
 #ifdef HAVE_LIBJPEG
-	int x, y;
+	unsigned int x, y;
 	struct jpeg_compress_struct cinfo;
 	struct jpeg_error_mgr jcerr;
 	JOCTET *jpeg_dest = NULL;
@@ -1251,7 +1251,7 @@ ax203_encode_image(Camera *camera, int **src, char *dest, int dest_size)
 		jpeg_finish_compress (&cinfo);
 		jpeg_destroy_compress (&cinfo);
 
-		if (jpeg_size > dest_size) {
+		if (jpeg_size > (unsigned int)dest_size) {
 			free (jpeg_dest);
 			gp_log (GP_LOG_ERROR, "ax203",
 				"JPEG is bigger then buffer");

--- a/camlibs/ax203/ax203_compress_jpeg.c
+++ b/camlibs/ax203/ax203_compress_jpeg.c
@@ -321,12 +321,12 @@ ax206_compress_jpeg(Camera *camera, int **in, uint8_t *outbuf, int out_size,
 			jpeg_finish_compress (&cinfo);
 
 			stop = 0;
-			for (i = 2; i < buf_size && !stop; i += size) {
+			for (i = 2; (unsigned long)i < buf_size && !stop; i += size) {
 				stop = buf[i] == 0xff && buf[i + 1] == 0xda;
 				i += 2;
 				size = (buf[i] << 8) | buf[i + 1];
 			}
-			if (i >= buf_size) {
+			if ((unsigned long)i >= buf_size) {
 				gp_log (GP_LOG_ERROR, "ax203",
 					"missing in ff da marker?");
 				return GP_ERROR_CORRUPTED_DATA;

--- a/camlibs/canon/canon.c
+++ b/camlibs/canon/canon.c
@@ -399,7 +399,7 @@ replace_filename_extension(const char *filename, const char __unused__ *newext)
                 return NULL;
         }
         if ((unsigned int)(p - buf) < sizeof (buf) - 4) {
-                strncpy (p, ".THM", 4);
+                memcpy (p, ".THM", 4);
                 GP_DEBUG ("replace_filename_extension: New name for '%s' is '%s'",
                           filename, buf);
                 return buf;
@@ -451,7 +451,7 @@ filename_to_audio(const char *filename, const char __unused__ *newext)
                 return NULL;
         }
         if ((unsigned int)(p - buf) < sizeof (buf) - 4) {
-                strncpy (p, ".WAV", 4);
+                memcpy (p, ".WAV", 4);
                 GP_DEBUG ("filename_to_audio: New name for '%s' is '%s'",
                           filename, buf);
                 return buf;

--- a/camlibs/canon/library.c
+++ b/camlibs/canon/library.c
@@ -1484,21 +1484,21 @@ put_file_func (CameraFilesystem __unused__ *fs, const char __unused__ *folder, c
 		}
 	}
 
-	sprintf (dcf_root_dir, "%s\\DCIM", camera->pl->cached_drive);
+	snprintf (dcf_root_dir, sizeof (dcf_root_dir), "%s\\DCIM", camera->pl->cached_drive);
 
 	if (strlen (dir) == 0) {
-		sprintf (dir, "\\100CANON");
-		sprintf (destname, "AUT_0001.JPG");
+		snprintf (dir, sizeof (dir), "\\100CANON");
+		snprintf (destname, sizeof (destname), "AUT_0001.JPG");
 	} else {
 		if (strlen (destname) == 0) {
-			sprintf (destname, "AUT_%c%c01.JPG", dir[2], dir[3]);
+			snprintf (destname, sizeof (destname), "AUT_%c%c01.JPG", dir[2], dir[3]);
 		} else {
-			sprintf (buf, "%c%c", destname[6], destname[7]);
+			snprintf (buf, sizeof (buf), "%c%c", destname[6], destname[7]);
 			j = 1;
 			j = atoi (buf);
 			if (j == 99) {
 				j = 1;
-				sprintf (buf, "%c%c%c", dir[1], dir[2], dir[3]);
+				snprintf (buf, sizeof (buf), "%c%c%c", dir[1], dir[2], dir[3]);
 				dirnum = atoi (buf);
 				if (dirnum == 999) {
 					gp_context_error (context,
@@ -1507,15 +1507,15 @@ put_file_func (CameraFilesystem __unused__ *fs, const char __unused__ *folder, c
 					return GP_ERROR;
 				} else {
 					dirnum++;
-					sprintf (dir, "\\%03iCANON", dirnum);
+					snprintf (dir, sizeof (dir), "\\%03iCANON", dirnum);
 				}
 			} else
 				j++;
 
-			sprintf (destname, "AUT_%c%c%02i.JPG", dir[2], dir[3], j);
+			snprintf (destname, sizeof (destname), "AUT_%c%c%02i.JPG", dir[2], dir[3], j);
 		}
 
-		sprintf (destpath, "%s%s", dcf_root_dir, dir);
+		snprintf (destpath, sizeof (destpath), "%s%s", dcf_root_dir, dir);
 
 		GP_DEBUG ("destpath: %s destname: %s", destpath, destname);
 	}

--- a/camlibs/digigr8/digi_postprocess.c
+++ b/camlibs/digigr8/digi_postprocess.c
@@ -336,7 +336,7 @@ static int
 histogram (unsigned char *data, unsigned int size, int *htable_r,
 					    int *htable_g, int *htable_b)
 {
-	int x;
+	unsigned int x;
 	/* Initializations */
 	for (x = 0; x < 0x100; x++) {
 		htable_r[x] = 0;
@@ -356,7 +356,8 @@ histogram (unsigned char *data, unsigned int size, int *htable_r,
 int
 white_balance (unsigned char *data, unsigned int size, float saturation)
 {
-	int x, r, g, b, max, d;
+	unsigned int x, max;
+	int r, g, b, d;
 	double r_factor, g_factor, b_factor, max_factor;
 	int htable_r[0x100], htable_g[0x100], htable_b[0x100];
 	unsigned char gtable[0x100];

--- a/camlibs/digigr8/library.c
+++ b/camlibs/digigr8/library.c
@@ -198,7 +198,7 @@ get_file_func(CameraFilesystem *fs, const char *folder, const char *filename,
 	int status = GP_OK;
 	Camera *camera = user_data;
 	unsigned int b;
-	int w, h;
+	unsigned int w, h;
 	int k, next;
 	unsigned char comp_ratio;
 	unsigned char lighting;

--- a/camlibs/dimera/dimera3500.c
+++ b/camlibs/dimera/dimera3500.c
@@ -186,7 +186,7 @@ static int
 conversion_chuck (const unsigned int width, const unsigned int height,
 	const unsigned char *src,unsigned char *dst
 ) {
-	int x, y;
+	unsigned int x, y;
 	int p1, p2, p3, p4;
 	int red, green, blue;
 

--- a/camlibs/dimera/mesalib.c
+++ b/camlibs/dimera/mesalib.c
@@ -114,7 +114,7 @@ mesa_flush( GPPort *port, int timeout )
 }
 
 /* Read exactly this number of bytes from the port within the given timeouts */
-int
+unsigned int
 mesa_read( GPPort *port, uint8_t *b, int s, int timeout2, int timeout1 )
 {
 	int		n = 0;

--- a/camlibs/dimera/mesalib.h
+++ b/camlibs/dimera/mesalib.h
@@ -113,7 +113,7 @@ struct mesa_image_info {
 
 void
 mesa_flush( GPPort *port, int timeout );
-int
+unsigned int
 mesa_read( GPPort *port, uint8_t *b, int s, int timeout2, int timeout1 );
 int
 mesa_send_command( GPPort *port, uint8_t *cmd, int n, int ackTimeout );

--- a/camlibs/docupen/cache.c
+++ b/camlibs/docupen/cache.c
@@ -43,7 +43,7 @@ static bool fill_cache(Camera *camera)
 			break;
 		fwrite(buf, 1, ret, camera->pl->cache);
 		done += ret;
-		if (ret < pktsize)
+		if ((size_t)ret < pktsize)
 			break;
 	}
 	free(buf);

--- a/camlibs/docupen/docupen.c
+++ b/camlibs/docupen/docupen.c
@@ -41,7 +41,7 @@
 #  define N_(String) (String)
 #endif
 
-
+#if 0
 static const struct {
 	char *model;
 	int usb_vendor;
@@ -50,6 +50,7 @@ static const struct {
 	{ "Planon DocuPen RC800", 0x18dd, 0x1000 },
 	{ NULL, 0, 0 }
 };
+#endif
 
 #define DP_ACK 0xD1
 #define DP_CMD_LEN 8
@@ -437,7 +438,7 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 {
 	Camera *camera = data;
 	struct dp_imagehdr header;
-	int ret;
+	size_t ret;
 	char *file_data;
 	gdImagePtr img;
 	void *gdout;
@@ -658,7 +659,6 @@ CameraFilesystemFuncs fsfuncs = {
 int
 camera_init (Camera *camera, GPContext *context)
 {
-	GPPortSettings settings;
 	char buf[64];
 
         camera->functions->exit                 = camera_exit;

--- a/camlibs/fuji/fuji.c
+++ b/camlibs/fuji/fuji.c
@@ -178,7 +178,7 @@ fuji_recv (Camera *camera, unsigned char *buf, unsigned int *buf_len,
 	   unsigned char *last, GPContext *context)
 {
 	unsigned char b[1024], check = 0;
-	int i;
+	unsigned int i;
 
 	/*
 	 * Read the header. The checksum covers all bytes between

--- a/camlibs/fuji/library.c
+++ b/camlibs/fuji/library.c
@@ -165,7 +165,7 @@ file_list_func (CameraFilesystem *fs, const char *folder, CameraList *list,
 		void *data, GPContext *context)
 {
 	Camera *camera = data;
-	int i;
+	unsigned int i;
 	unsigned int n;
 	const char *name;
 

--- a/camlibs/gsmart300/gsmart300.c
+++ b/camlibs/gsmart300/gsmart300.c
@@ -336,7 +336,7 @@ gsmart300_reset (CameraPrivateLibrary * lib)
 	GP_DEBUG ("* gsmart300_reset");
 	CHECK (gp_port_usb_msg_write (lib->gpdev, 0x02, 0x0000, 0x0003,
 				      NULL, 0));
-	sleep (1.5);
+	sleep (1);
 	return GP_OK;
 }
 
@@ -348,7 +348,7 @@ static int gsmart300_download_data (CameraPrivateLibrary * lib, int data_type,
 				 uint16_t index, unsigned int size, uint8_t * buf)
 {
 	uint16_t fat_index = 0x1fff - index;
-	int i;
+	unsigned int i;
 
 	if (data_type == __GS300_FAT)
 		CHECK (gp_port_usb_msg_write (lib->gpdev, 0x03,
@@ -376,7 +376,7 @@ static int
 gsmart300_get_FATs (CameraPrivateLibrary * lib)
 {
 	uint8_t type;
-	unsigned int index = 0;
+	int index = 0;
 	unsigned int file_index = 0;
 	uint8_t *p = NULL;
 	char buf[14];

--- a/camlibs/iclick/library.c
+++ b/camlibs/iclick/library.c
@@ -60,7 +60,7 @@ static struct {
    	unsigned short idProduct;
 } models[] = {
         {"iClick 5X",    GP_DRIVER_STATUS_EXPERIMENTAL, 0x2770, 0x9153},
-	{NULL,0,0}
+	{NULL,0,0,0}
 };
 
 int
@@ -252,10 +252,9 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 		free (frame_data);
 		return GP_ERROR_NOT_SUPPORTED;
 	case GP_FILE_TYPE_NORMAL:
-		if (icl_get_width_height (camera->pl, entry, &w, &h) >= GP_OK)
-			break; /* Known format, process image */
-		/* Unsupported format, fallthrough to raw */
 	case GP_FILE_TYPE_RAW:
+		if (type == GP_FILE_TYPE_NORMAL && icl_get_width_height (camera->pl, entry, &w, &h) >= GP_OK)
+			break; /* Known format, process image */
 		gp_file_set_mime_type (file, GP_MIME_RAW);
 		gp_file_adjust_name_for_mime_type (file);
 	        gp_file_set_data_and_size (file, (char *)frame_data, datasize);

--- a/camlibs/jl2005a/jl2005a.c
+++ b/camlibs/jl2005a/jl2005a.c
@@ -121,7 +121,7 @@ jl2005a_read_picture_data (Camera *camera, GPPort *port,
 					unsigned char *data, unsigned int size)
 {
 	unsigned char *to_read;
-	int maxdl = 0xfa00;
+	unsigned int maxdl = 0xfa00;
 	int ret;
 
 	to_read=data;
@@ -156,7 +156,7 @@ jl2005a_read_picture_data (Camera *camera, GPPort *port,
 	}
 	ret = gp_port_read(port, (char *)to_read, size);
 	if (ret < GP_OK) return ret;
-	if (ret < size) return GP_ERROR;
+	if ((unsigned int)ret < size) return GP_ERROR;
 	/* Switch the inep back to 0x84. */
 	set_usb_in_endpoint	(camera, 0x84);
 	return GP_OK;

--- a/camlibs/jl2005a/library.c
+++ b/camlibs/jl2005a/library.c
@@ -165,8 +165,9 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 	Camera *camera = user_data;
 	int status = GP_OK;
 	unsigned int w, h = 0;
-	int i,j,k;
-	int b = 0;
+	unsigned int i, j;
+	int k;
+	unsigned int b = 0;
 	int compressed = 0;
 	unsigned char header[5] = "\xff\xff\xff\xff\x55";
 	unsigned int size;

--- a/camlibs/jl2005c/img_enhance.c
+++ b/camlibs/jl2005c/img_enhance.c
@@ -63,7 +63,7 @@ int
 histogram (unsigned char *data, unsigned int size, int *htable_r,
 						int *htable_g, int *htable_b)
 {
-	int x;
+	unsigned int x;
 	/* Initializations */
 	for (x = 0; x < 0x100; x++) {
 		htable_r[x] = 0;
@@ -84,7 +84,8 @@ histogram (unsigned char *data, unsigned int size, int *htable_r,
 int
 white_balance (unsigned char *data, unsigned int size, float saturation)
 {
-	int x, r, g, b, max, d;
+	unsigned int x, max;
+	int r, g, b, d;
 	double r_factor, g_factor, b_factor, max_factor;
 	int htable_r[0x100], htable_g[0x100], htable_b[0x100];
 	unsigned char gtable[0x100];

--- a/camlibs/kodak/dc120/dc120.c
+++ b/camlibs/kodak/dc120/dc120.c
@@ -86,7 +86,7 @@ static int find_folder( Camera *camera, const char *folder,
 {
     CameraList *albums = NULL;
     const char* album_name;
-    int folder_len;
+    size_t folder_len;
     int i;
     char *dc120_folder_card   = _("CompactFlash Card");
 

--- a/camlibs/kodak/dc120/library.c
+++ b/camlibs/kodak/dc120/library.c
@@ -518,7 +518,7 @@ static int dc120_get_file (Camera *camera, CameraFile *file, int file_number, ch
 	gp_file_get_data_and_size (size_file, &file_data, &file_size);
 
 	offset = 2 + (file_number-1) * 20;
-	if( file_size < offset+19 )
+	if( file_size < (unsigned int)(offset+19) )
 	  {
 	    gp_file_free(size_file);
 	    free (p);

--- a/camlibs/kodak/dc210/dc210.c
+++ b/camlibs/kodak/dc210/dc210.c
@@ -260,7 +260,7 @@ camera_get_config (Camera *camera, CameraWidget **window, GPContext *context)
 
         gp_widget_new (GP_WIDGET_MENU, _("Exposure compensation"), &widget);
         gp_widget_append (section, widget);
-	for (i = 0; i < sizeof(exp_comp)/sizeof(*exp_comp); i++){
+	for (i = 0; (unsigned int)i < sizeof(exp_comp)/sizeof(*exp_comp); i++){
 		gp_widget_add_choice (widget, exp_comp[i]);
 		if (status.exp_compensation + 4 == i)
 			gp_widget_set_value (widget, exp_comp[i]);
@@ -305,7 +305,7 @@ camera_get_config (Camera *camera, CameraWidget **window, GPContext *context)
 	gp_port_get_settings (camera->port, &settings);
         gp_widget_new (GP_WIDGET_MENU, _("Port speed"), &widget);
         gp_widget_append (section, widget);
-	for (i = 0; i < sizeof(abilities.speed); i++){
+	for (i = 0; (unsigned int)i < sizeof(abilities.speed); i++){
 		if (abilities.speed[i] == 0) break;
 		snprintf(stringbuffer, 12, "%d", abilities.speed[i]);
 		gp_widget_add_choice (widget, stringbuffer);
@@ -425,7 +425,7 @@ camera_set_config (Camera *camera, CameraWidget *window, GPContext *context)
 	if (gp_widget_changed (w)) {
 	        gp_widget_set_changed (w, 0);
 		gp_widget_get_value (w, &wvalue);
-		for (i = 0; i < sizeof(exp_comp)/sizeof(*exp_comp); i++){
+		for (i = 0; (unsigned int)i < sizeof(exp_comp)/sizeof(*exp_comp); i++){
 			if (strncmp(wvalue, exp_comp[i], 4) == 0){
 				dc210_set_exp_compensation(camera, i - 4);
 				break;

--- a/camlibs/kodak/dc240/library.c
+++ b/camlibs/kodak/dc240/library.c
@@ -114,7 +114,7 @@ static unsigned char *
 dc240_packet_new_path (const char *folder, const char *filename) {
     unsigned char *p;
     char buf[1024];
-    int x;
+    size_t x;
     unsigned char cs = 0;
 
     p = malloc(sizeof(char)*60);
@@ -733,7 +733,8 @@ int dc240_get_directory_list (Camera *camera, CameraList *list, const char *fold
                              unsigned char attrib, GPContext *context) {
 
     CameraFile *file;
-    int x, y=0, z, size=256;
+    unsigned int x, y=0, z;
+    int size=256;
     char buf[64];
     unsigned char *p1 = dc240_packet_new(0x99);
     unsigned char *p2 = dc240_packet_new_path(folder, NULL);
@@ -741,7 +742,7 @@ int dc240_get_directory_list (Camera *camera, CameraList *list, const char *fold
     unsigned long int fsize;
     int ret;
     int num_of_entries = 0; /* number of entries in the listing */
-    int total_size = 0; /* total useful size of the listing */
+    unsigned int total_size = 0; /* total useful size of the listing */
 
     gp_file_new(&file);
     ret = dc240_packet_exchange(camera, file, p1, p2, &size, 256, context);
@@ -809,10 +810,11 @@ int dc240_file_action (Camera *camera, int action, CameraFile *file,
 
     switch (action) {
     case DC240_ACTION_PREVIEW:
-        cmd_packet[4] = 0x02;
-        thumb = 1;
-        /* no break on purpose */
     case DC240_ACTION_IMAGE:
+        if (action == DC240_ACTION_PREVIEW) {
+            cmd_packet[4] = 0x02;
+            thumb = 1;
+        }
         if ((size = dc240_get_file_size(camera, folder, filename, thumb, context)) < GP_OK) {
             retval = GP_ERROR;
             break;

--- a/camlibs/kodak/dc3200/dc3200.c
+++ b/camlibs/kodak/dc3200/dc3200.c
@@ -179,7 +179,8 @@ static int folder_list_func (CameraFilesystem *fs, const char *folder,
 	long unsigned 	data_len = 0;
 	unsigned char	*ptr_data_buff;
 	char		filename[13], *ptr;
-	int		res, i;
+	int		res;
+	unsigned int	i;
 
 	if(camera->pl->context)
 	{
@@ -260,7 +261,8 @@ static int file_list_func (CameraFilesystem *fs, const char *folder,
 	long unsigned	data_len = 0;
 	unsigned char	*ptr_data_buff;
 	char		filename[13];
-	int		res, i;
+	int		res;
+	unsigned int	i;
 
 	if(camera->pl->context)
 	{

--- a/camlibs/kodak/ez200/ez200.c
+++ b/camlibs/kodak/ez200/ez200.c
@@ -163,7 +163,7 @@ static const struct {
    	unsigned short idProduct;
 } models[] = {
         {"Kodak EZ200", GP_DRIVER_STATUS_PRODUCTION, 0x040a, 0x0300},
-	{NULL,0,0}
+	{NULL,0,0,0}
 };
 
 int

--- a/camlibs/largan/lmini/lmini.c
+++ b/camlibs/largan/lmini/lmini.c
@@ -237,7 +237,7 @@ int largan_get_pict (Camera * camera, largan_pict_type type,
 		if (ret < GP_OK) {
 			return ret;
 		}
-		if (ret < pict->data_size) {
+		if ((unsigned int)ret < pict->data_size) {
 			GP_DEBUG ("largan_get_pict(): picture data short read\n");
 			return GP_ERROR;
 		}

--- a/camlibs/mars/mars.c
+++ b/camlibs/mars/mars.c
@@ -387,7 +387,7 @@ mars_routine (Info *info, GPPort *port, char param, int n)
 int
 histogram (unsigned char *data, unsigned int size, int *htable_r, int *htable_g, int *htable_b)
 {
-	int x;
+	unsigned int x;
 	/* Initializations */
 	for (x = 0; x < 0x100; x++) {
 		htable_r[x] = 0;
@@ -408,7 +408,8 @@ int
 mars_white_balance (unsigned char *data, unsigned int size, float saturation,
 						float image_gamma)
 {
-	int x, r, g, b, max, d;
+	unsigned int x, max;
+	int r, g, b, d;
 	double r_factor, g_factor, b_factor, max_factor;
 	int htable_r[0x100], htable_g[0x100], htable_b[0x100];
 	unsigned char gtable[0x100];

--- a/camlibs/minolta/dimagev/packet.c
+++ b/camlibs/minolta/dimagev/packet.c
@@ -48,7 +48,8 @@
 	 A packet must be at least eight bytes, with at least one byte of payload.
 */
 dimagev_packet *dimagev_make_packet(const unsigned char *const buffer, unsigned int length, unsigned int seq) {
-	unsigned int i=0, checksum=0;
+	int i=0;
+	unsigned int checksum=0;
 	dimagev_packet *p;
 
 	if ( ( p = calloc(1, sizeof(dimagev_packet) ) ) == NULL ) {

--- a/camlibs/minolta/dimagev/util.c
+++ b/camlibs/minolta/dimagev/util.c
@@ -72,8 +72,9 @@ unsigned char *dimagev_ycbcr_to_ppm(unsigned char *ycbcr) {
 	unsigned char *rgb_data, *ycrcb_current, *rgb_current;
 	int count=0;
 	unsigned int magic_r, magic_g, magic_b;
+	const unsigned int size = 14413;
 
-	if ( ( rgb_data = malloc( 14413 ) ) == NULL ) {
+	if ( ( rgb_data = malloc( size ) ) == NULL ) {
 		GP_DEBUG( "dimagev_ycbcr_to_ppm::unable to allocate buffer for Y:Cb:Cr conversion");
 		return NULL;
 	}
@@ -82,7 +83,7 @@ unsigned char *dimagev_ycbcr_to_ppm(unsigned char *ycbcr) {
 	rgb_current = &(rgb_data[13]);
 
 	/* This is the header for a PPM "rawbits" bitmap of size 80x60. */
-	strncpy((char *)rgb_data, "P6\n80 60\n255\n", 13);
+	strncpy((char *)rgb_data, "P6\n80 60\n255\n", size);
 
 	for ( count = 0 ; count < 9600 ; count+=4, ycrcb_current+=4, rgb_current+=6 ) {
 		magic_b = ( ( ycrcb_current[2] > (unsigned char) 128 ? 128 : ycrcb_current[2] ) - 128 ) * ( 2 - ( 2 * CR_COEFF ) ) + ycrcb_current[0];

--- a/camlibs/pccam300/library.c
+++ b/camlibs/pccam300/library.c
@@ -104,7 +104,8 @@ file_list_func (CameraFilesystem *fs, const char *folder,
 		CameraList *list, void *data, GPContext *context)
 {
 	Camera *camera = data;
-	unsigned int i, id, size, type;
+	int i;
+	unsigned int id, size, type;
 	int filecount;
 	CameraFile *file;
 	CameraFileInfo info;

--- a/camlibs/ricoh/g3.c
+++ b/camlibs/ricoh/g3.c
@@ -358,7 +358,8 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 {
 	Camera *camera = data;
 	char *buf = NULL, *reply = NULL, *cmd =NULL, *msg = NULL;
-	unsigned int len, bytes, seek;
+	unsigned int len, bytes;
+	int seek;
 	int ret, channel;
 
 	ret = g3_cwd_command (camera->port, folder);
@@ -758,7 +759,7 @@ folder_list_func (CameraFilesystem *fs, const char *folder, CameraList *list,
 	free(cmd);cmd = NULL;
 	if (ret < GP_OK) goto out;
 	if (buf[0] == '1') { /* 1xx means another reply follows */
-		int n = 0;
+		unsigned int n = 0;
 
 		ret = g3_channel_read(camera->port, &channel, &buf, &len); /* data. */
 		if (ret < GP_OK) goto out;
@@ -805,7 +806,8 @@ file_list_func (CameraFilesystem *fs, const char *folder, CameraList *list,
 	free(cmd); cmd = NULL;
 	if (ret < GP_OK) goto out;
 	if (buf[0] == '1') { /* 1xx means another reply follows */
-		int n = 0, channel;
+		unsigned int n = 0;
+		int channel;
 		unsigned int len, rlen;
 		ret = g3_channel_read(camera->port, &channel, &buf, &len); /* data. */
 		if (ret < GP_OK) goto out;

--- a/camlibs/ricoh/library.c
+++ b/camlibs/ricoh/library.c
@@ -565,7 +565,7 @@ camera_init (Camera *camera, GPContext *context)
 	}
 
 	/* Contact made. Do we need to change the speed? */
-	if (settings.serial.speed != speed) {
+	if ((unsigned int)settings.serial.speed != speed) {
 		for (i = 0; speeds[i].speed; i++)
 			if (speeds[i].speed == speed)
 				break;

--- a/camlibs/sierra/library.c
+++ b/camlibs/sierra/library.c
@@ -200,8 +200,8 @@ int sierra_list_files (Camera *camera, const char *folder, CameraList *list, GPC
 int sierra_list_folders (Camera *camera, const char *folder, CameraList *list,
 			 GPContext *context)
 {
-	int j, count;
-	unsigned int i, bsize;
+	int i, j, count;
+	unsigned int bsize;
 	char buf[1024];
 
 	/* List the folders only if the camera supports them */
@@ -680,7 +680,7 @@ sierra_read_packet (Camera *camera, unsigned char *packet, GPContext *context)
 			for (c = 0, i = 4; i < br - 2; i++)
 				c += packet[i];
 			c &= 0xffff;
-			if (c == (packet[br - 2] + (packet[br - 1] * 256)))
+			if (c == ((unsigned int)packet[br - 2] + ((unsigned int)packet[br - 1] * 256)))
 				break;
 
 			/*
@@ -983,7 +983,7 @@ sierra_set_speed (Camera *camera, SierraSpeed speed, GPContext *context)
 	 * they are currently operating at that speed.
 	 */
 	CHECK (gp_port_get_settings (camera->port, &settings));
-	if (settings.serial.speed == bit_rate)
+	if ((unsigned int)settings.serial.speed == bit_rate)
 		return GP_OK;
 
 	/*

--- a/camlibs/sierra/olympus-desc.c
+++ b/camlibs/sierra/olympus-desc.c
@@ -350,6 +350,7 @@ static const RegisterDescriptorType olysp500uz_reg_03[] = {
  * does not work well, since only about 30 of some 16 million values are
  * valid.
  */
+#if 0
 static const ValueNameType olyrange_reg_03_val_names[] = {
 	{
 		{ .range = { 0, 16000000, 100 } }, NULL
@@ -362,6 +363,7 @@ static const RegisterDescriptorType olyrange_reg_03[] = {
 		VAL_NAME_INIT (olyrange_reg_03_val_names)
 	}
 };
+#endif
 
 /*
  * Olympus 3040 Register 5: aperture settings. Works only in A or M mode
@@ -453,6 +455,7 @@ static const RegisterDescriptorType oly750uz_reg_05[] = {
 /*
  * Olympus SP-500uz Register 5: aperture settings.
  */
+#if 0
 static const ValueNameType olysp500uz_reg_05_val_names[] = {
 	{ { 0 }, N_("Auto") },
 	{ { 28 }, "F2.8" },
@@ -473,6 +476,8 @@ static const RegisterDescriptorType olysp500uz_reg_05[] = {
 		VAL_NAME_INIT (olysp500uz_reg_05_val_names)
 	}
 };
+#endif
+
 /*
  * Register 6: color mode
  */
@@ -820,6 +825,7 @@ static const RegisterDescriptorType oly750uz_reg_71[] = {
 /*
  * Oly SP-500 uz Register 71: optical zoom value.
  */
+#if 0
 static const ValueNameType olysp500uz_reg_71_val_names[] = {
 	{
 		{ .range = { 6.3, 63.0, .3 } }, NULL
@@ -832,6 +838,7 @@ static const RegisterDescriptorType olysp500uz_reg_71[] = {
 		VAL_NAME_INIT (olysp500uz_reg_71_val_names)
 	}
 };
+#endif
 
 /*
  * Oly 3040 Register 71: optical zoom value.

--- a/camlibs/sierra/sierra-desc.c
+++ b/camlibs/sierra/sierra-desc.c
@@ -112,7 +112,9 @@ static int
 camera_cam_desc_get_widget (Camera *camera, CameraRegisterType *reg_p,
 			    CameraWidget *section, GPContext *context)
 {
-	int ind, vind, ret, value;
+	int ret;
+	unsigned int value;
+	unsigned int ind, vind;
 	int mask;
 	char buff[1024];
 	CameraWidget *child;
@@ -139,7 +141,7 @@ camera_cam_desc_get_widget (Camera *camera, CameraRegisterType *reg_p,
 		 * the fly and make a union with reg_value and a void*.
 		 */
 		ret = sierra_get_string_register (camera, reg_p->reg_number,
-					  -1, NULL, (unsigned char *)buff, (unsigned int *)&value, context);
+					  -1, NULL, (unsigned char *)buff, &value, context);
 		if ((ret == GP_OK) && value != reg_p->reg_len) {
 			GP_DEBUG ("Bad length result %d", value);
 			return (GP_ERROR);
@@ -198,7 +200,7 @@ camera_get_config_cam_desc (Camera *camera, CameraWidget **window,
 			    GPContext *context)
 {
 	CameraWidget *section;
-	int indw, indr;
+	unsigned int indw, indr;
 	const CameraDescType *cam_desc = NULL;
 
 	GP_DEBUG ("*** camera_get_config_cam_desc");
@@ -360,7 +362,8 @@ static int
 camera_cam_desc_set_widget (Camera *camera, CameraRegisterType *reg_p,
 			    CameraWidget *window, GPContext *context)
 {
-	int ind, vind, ret;
+	int ret;
+	unsigned int ind, vind;
 	union value_in {
 		char *charp;
 		int val;
@@ -423,7 +426,7 @@ int
 camera_set_config_cam_desc (Camera *camera, CameraWidget *window,
 			    GPContext *context)
 {
-	int wind, rind;
+	unsigned int wind, rind;
 	const CameraDescType *cam_desc = NULL;
 
 	GP_DEBUG ("*** camera_set_config_cam_desc");

--- a/camlibs/sierra/sierra-usbwrap.c
+++ b/camlibs/sierra/sierra-usbwrap.c
@@ -459,7 +459,7 @@ usb_wrap_DATA (GPPort *dev, unsigned int type, char *sierra_response, int *sierr
    msg_len = msg_len * 256 + (unsigned int)(size.c2);
    msg_len = msg_len * 256 + (unsigned int)(size.c1);
 
-   if (*sierra_len < msg_len - sizeof(*msg))
+   if ((unsigned int)*sierra_len < msg_len - sizeof(*msg))
    {
       GP_DEBUG( "usb_wrap_read_packet buffer too small! (%i < %i) *** FAILED", *sierra_len, msg_len);
       return GP_ERROR;

--- a/camlibs/sierra/sierra.c
+++ b/camlibs/sierra/sierra.c
@@ -60,8 +60,8 @@ static int get_jpeg_data(const char *data, int data_size, char **jpeg_data, int 
 /* Useful markers */
 static const char JPEG_SOI_MARKER[]  = { (char)0xFF, (char)0xD8, '\0' };
 static const char JPEG_SOF_MARKER[]  = { (char)0xFF, (char)0xD9, '\0' };
-static const char JPEG_APP1_MARKER[] = { (char)0xFF, (char)0xE1, '\0' };
-static const char TIFF_SOI_MARKER[]  = { (char)0x49, (char)0x49, (char)0x2A, (char)0x00, (char)0x08, '\0' };
+/*static const char JPEG_APP1_MARKER[] = { (char)0xFF, (char)0xE1, '\0' };*/
+/*static const char TIFF_SOI_MARKER[]  = { (char)0x49, (char)0x49, (char)0x2A, (char)0x00, (char)0x08, '\0' };*/
 
 static struct {
 	const char *manuf;
@@ -782,7 +782,7 @@ put_file_func (CameraFilesystem * fs, const char *folder, const char *filename,
 
 	/* Check the available memory */
 	CHECK (sierra_get_memory_left(camera, &available_memory, context));
-	if (available_memory < data_size) {
+	if (available_memory < 0 || (unsigned int)available_memory < data_size) {
 		gp_context_error (context,
 				    _("Not enough memory available on the memory card"));
 		return GP_ERROR_NO_MEMORY;
@@ -2259,7 +2259,7 @@ camera_init (Camera *camera, GPContext *context)
 			/* Find the speed into abilities.speeds array.
 			 * Highest speeds are last ... so look backwards ...
 			 */
-			for (i=0;i<sizeof(a.speed)/sizeof(a.speed[0]) && a.speed[i];i++)
+			for (i=0;(unsigned int)i<sizeof(a.speed)/sizeof(a.speed[0]) && a.speed[i];i++)
 				/*empty*/;
 			i--;
 			for (; i >= 0 ; i--) {

--- a/camlibs/sipix/blink2.c
+++ b/camlibs/sipix/blink2.c
@@ -95,7 +95,8 @@ file_list_func (CameraFilesystem *fs, const char *folder, CameraList *list,
 		void *data, GPContext *context)
 {
 	Camera		*camera = data;
-	int		i, ret;
+	unsigned int	i;
+	int		ret;
 	unsigned int	bytes, numpics;
 	unsigned char	*xbuf, buf[8];
 
@@ -115,7 +116,7 @@ file_list_func (CameraFilesystem *fs, const char *folder, CameraList *list,
 		free(xbuf);
 		return ret;
 	}
-	if (ret < bytes) return GP_ERROR_IO_READ;
+	if ((unsigned int)ret < bytes) return GP_ERROR_IO_READ;
 	for ( i=0; i < numpics; i++) {
 		char name[20];
 		if (xbuf[8*(i+1)])
@@ -134,8 +135,9 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 	       GPContext *context)
 {
 	Camera *camera = data;
-        int image_no, result;
-	int	i, ret;
+	int image_no, result;
+	unsigned int i;
+	int ret;
 	unsigned int numpics, bytes;
 	unsigned char	*xbuf, buf[8];
 
@@ -168,7 +170,7 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 		free(xbuf);
 		return ret;
 	}
-	if (ret < bytes) return GP_ERROR_IO_READ;
+	if ((unsigned int)ret < bytes) return GP_ERROR_IO_READ;
 	for ( i=0; i < numpics; i++) {
 		int end, start;
 
@@ -194,7 +196,7 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 		free(addrs);
                 return image_no;
 	}
-	if (image_no >= numpics) {
+	if (image_no < 0 || (unsigned int)image_no >= numpics) {
 		free(addrs);
 		gp_log(GP_LOG_DEBUG, "blink2","image %d requested, but only %d pics on camera?", image_no, numpics);
                 return GP_ERROR;
@@ -284,7 +286,7 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 			gp_file_append (file, foo, strlen(foo));
 		}
 		for (i = 0; i < dinfo.output_height ; i++ ) {
-			int j;
+			unsigned int j;
 			JSAMPROW row[1];
 			JSAMPARRAY arr = row;
 
@@ -343,7 +345,7 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 		len = len*8;
 		do {
 			curread = 4096;
-			if (curread > len) curread = len;
+			if ((unsigned int)curread > len) curread = len;
 			curread = gp_port_read( camera->port, buf2, curread);
 			if (curread < GP_OK) {
 				result = GP_OK;

--- a/camlibs/sipix/web2.c
+++ b/camlibs/sipix/web2.c
@@ -181,7 +181,7 @@ web2_getpicture(GPPort *port, GPContext *context, CameraFile *file)
 
     while (curread < size) {
 	int toread = size-curread;
-	if (toread > sizeof(xbuf))
+	if ((unsigned int)toread > sizeof(xbuf))
 	    toread = sizeof(xbuf);
 	ret = gp_port_read(port, xbuf, toread);
 	if (ret < GP_OK)

--- a/camlibs/smal/ultrapocket.c
+++ b/camlibs/smal/ultrapocket.c
@@ -173,7 +173,7 @@ getpicture_logitech_pd(Camera *camera, GPContext *context, unsigned char **rd, c
     unsigned char *rawdata;
     int            ptc,pc,id;
 
-    strncpy(command+3, filename, 11); /* the id of the image to transfer */
+    strncpy((char*)(command+3), filename, 11); /* the id of the image to transfer */
 
     CHECK_RESULT(ultrapocket_command(port, 1, command, 0x10));
 

--- a/camlibs/sonix/sonix.c
+++ b/camlibs/sonix/sonix.c
@@ -477,7 +477,7 @@ static int
 histogram (unsigned char *data, unsigned int size, int *htable_r,
 						int *htable_g, int *htable_b)
 {
-	int x;
+	unsigned int x;
 	/* Initializations */
 	for (x = 0; x < 256; x++) {
 		htable_r[x] = 0;
@@ -498,7 +498,8 @@ histogram (unsigned char *data, unsigned int size, int *htable_r,
 int
 white_balance (unsigned char *data, unsigned int size, float saturation)
 {
-	int x, r, g, b, max, d;
+	unsigned int x, max;
+	int r, g, b, d;
 	double r_factor, g_factor, b_factor, max_factor, MAX_FACTOR=1.6;
 	int htable_r[256], htable_g[256], htable_b[256];
 	unsigned char gtable[256];

--- a/camlibs/spca50x/spca50x-sdram.c
+++ b/camlibs/spca50x/spca50x-sdram.c
@@ -447,7 +447,7 @@ spca50x_get_avi (CameraPrivateLibrary * lib, uint8_t ** buf,
 			/* jpeg starts here */
 			if ((data - mybuf) + frame_size > size) {
 				free (mybuf);
-				GP_DEBUG("BAD: accessing more than we read (%d vs total %d)", (data-mybuf)+frame_size , size);
+				GP_DEBUG("BAD: accessing more than we read (%u vs total %d)", (unsigned int)((data-mybuf)+frame_size), size);
 				return GP_ERROR_CORRUPTED_DATA;
 			}
 			create_jpeg_from_data (avi, data, qIndex, frame_width,
@@ -696,7 +696,7 @@ spca50x_get_image_thumbnail (CameraPrivateLibrary * lib, uint8_t ** buf,
 int
 spca50x_sdram_get_info (CameraPrivateLibrary * lib)
 {
-	unsigned int index;
+	int index;
 	uint8_t dramtype = 0;
 	uint8_t *p;
 	uint32_t start_page, end_page;
@@ -859,7 +859,7 @@ spca50x_get_FATs (CameraPrivateLibrary * lib, int dramtype)
 	unsigned int index = 0;
 	unsigned int file_index = 0;
 	uint8_t *p = NULL;
-	uint8_t buf[30];
+	char buf[30];
 
 	/* Reset image and movie counter */
 	lib->num_images = lib->num_movies = 0;
@@ -879,7 +879,7 @@ spca50x_get_FATs (CameraPrivateLibrary * lib, int dramtype)
 
 	p = lib->fats;
 	if (lib->bridge == BRIDGE_SPCA504) {
-		while (index < lib->num_fats) {
+		while (index < (unsigned int)lib->num_fats) {
 			CHECK (spca50x_sdram_get_fat_page (lib, index,
 						dramtype, p));
 			if (p[0] == 0xFF)
@@ -904,8 +904,8 @@ spca50x_get_FATs (CameraPrivateLibrary * lib, int dramtype)
 	p = lib->fats;
 	index = 0;
 
-	while (index < lib->num_fats) {
-		if (file_index >= lib->num_files_on_sdram) {
+	while (index < (unsigned int)lib->num_fats) {
+		if (file_index >= (unsigned int)lib->num_files_on_sdram) {
 			free (lib->fats); lib->fats = NULL;
 			free (lib->sdram_files); lib->sdram_files = NULL;
 			return GP_ERROR;
@@ -940,7 +940,7 @@ spca50x_get_FATs (CameraPrivateLibrary * lib, int dramtype)
 			lib->sdram_files[file_index].fat = p;
 			lib->sdram_files[file_index].fat_start = index;
 			lib->sdram_files[file_index].fat_end = index;
-			lib->sdram_files[file_index].name = strdup ((char*)buf);
+			lib->sdram_files[file_index].name = strdup (buf);
 			if (lib->bridge == BRIDGE_SPCA504) {
 				lib->sdram_files[file_index].width =
 					(p[8] & 0xFF) * 16;

--- a/camlibs/stv0680/bayer.c
+++ b/camlibs/stv0680/bayer.c
@@ -174,7 +174,7 @@ void light_enhance(int vw, int vh, int coarse, int fine,
 	}
     }
 
-    for (i=0;i<(vw*vh*3);i+=3)
+    for (i=0;i<(unsigned long int)(vw*vh*3);i+=3)
     {
 	int r,g,b;
 	r = *(output+i);

--- a/camlibs/toshiba/pdrm11/pdrm11.c
+++ b/camlibs/toshiba/pdrm11/pdrm11.c
@@ -85,7 +85,7 @@ int pdrm11_init(GPPort *port)
 
 int pdrm11_get_filenames(GPPort *port, CameraList *list)
 {
-	int i, j;
+	unsigned int i, j;
 	uint32_t numPics;
 	char name[20];
 	char buf[30];
@@ -156,7 +156,7 @@ int pdrm11_get_file(CameraFilesystem *fs, const char *filename, CameraFileType t
 	uint8_t buf[30];
 	uint8_t *image;
 	uint8_t temp;
-	int i;
+	unsigned int i;
 	int ret;
 	int file_type;
 
@@ -207,10 +207,10 @@ int pdrm11_get_file(CameraFilesystem *fs, const char *filename, CameraFileType t
 	}
 
 	ret = gp_port_read(port, (char *)image, size);
-	if(ret != size) {
+	if(ret < GP_OK || (unsigned int)ret != size) {
 		GP_DEBUG("failed to read from port.  Giving it one more try...");
 		ret = gp_port_read(port, (char *)image, size);
-		if(ret != size) {
+		if(ret < GP_OK || (unsigned int)ret != size) {
 			GP_DEBUG("gp_port_read returned %d 0x%x.  size: %d 0x%x", ret, ret, size, size);
 			free (image);
 			return(GP_ERROR_IO_READ);

--- a/libgphoto2_port/libgphoto2_port/gphoto2-port-info-list.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port-info-list.c
@@ -176,7 +176,7 @@ gp_port_info_list_free (GPPortInfoList *list)
 int
 gp_port_info_list_append (GPPortInfoList *list, GPPortInfo info)
 {
-	int generic, i;
+	unsigned int generic, i;
 
 	C_PARAMS (list);
 
@@ -465,13 +465,13 @@ gp_port_info_list_get_info (GPPortInfoList *list, int n, GPPortInfo *info)
 
 	GP_LOG_D ("Getting info of entry %i (%i available)...", n, list->count);
 
-	C_PARAMS (n >= 0 && n < list->count);
+	C_PARAMS (n >= 0 && (unsigned int)n < list->count);
 
 	/* Ignore generic entries */
 	for (i = 0; i <= n; i++)
 		if (!strlen (list->info[i]->name)) {
 			n++;
-			C_PARAMS (n < list->count);
+			C_PARAMS ((unsigned int)n < list->count);
 		}
 
 	*info = list->info[n];

--- a/libgphoto2_port/libgphoto2_port/gphoto2-port-log.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port-log.c
@@ -137,10 +137,10 @@ gpi_vsnprintf (const char* format, va_list args)
 int
 gp_log_remove_func (int id)
 {
-	int i;
+	unsigned int i;
 
 	for (i=0;i<log_funcs_count;i++) {
-		if (log_funcs[i].id == id) {
+		if (log_funcs[i].id == (unsigned int)id) {
 			memmove (log_funcs + i, log_funcs + i + 1, sizeof(LogFunc) * (log_funcs_count - i - 1));
 			log_funcs_count--;
 			return GP_OK;


### PR DESCRIPTION
This pull request consists of 44 commits to different camlibs, iolibs, core code and examples to reduce number of warnings given by compilers.

The motivation is to be able to compile the whole codebase with `-Wall -Wextra` without being overwhelmed by compiler output. While most of the edits submitted here had no real impact, there were number of bugs already found. Each commit has a summary of changes.

Code was tested on GCC 8.4.0, 9.3.0 and 10.1.0 with `-Wall -Wextra -Wno-unused-parameter -Wno-format-overflow -Wno-format-truncation -Wno-stringop-truncation` and on Clang 10.0.0 with `-Wall -Wextra -Wno-unused-parameter`. Currently only `x86_64` architecture was used.

I don't know how much of these changes are acceptable, but let me know if something should be changed or submitted as separate PR.