### PR TITLE
mime type update for CR3

### DIFF
--- a/camlibs/directory/directory.c
+++ b/camlibs/directory/directory.c
@@ -109,6 +109,7 @@ static const struct {
 	{"crw",  GP_MIME_CRW},
 	{"rw2",  GP_MIME_RW2},
 	{"cr2",  GP_MIME_RAW},
+	{"cr3",  GP_MIME_RAW},
 	{"nef",  GP_MIME_RAW},
 	{"mrw",  GP_MIME_RAW},
 	{"dng",  GP_MIME_RAW},

--- a/libgphoto2/gphoto2-file.c
+++ b/libgphoto2/gphoto2-file.c
@@ -1097,6 +1097,7 @@ gp_file_adjust_name_for_mime_type (CameraFile *file)
 		GP_MIME_AVI,  "avi",
 		GP_MIME_CRW,  "crw",
 		GP_MIME_CR2,  "cr2",
+		GP_MIME_CR3,  "cr3",
 		GP_MIME_NEF,  "nef",
 		GP_MIME_TXT,  "txt",
 		NULL};


### PR DESCRIPTION
this patch updates mime types to recognize CR3 format, this is important e.g. for listing directories