### PR TITLE
Not only Linux has statfs()

### DIFF
--- a/camlibs/directory/directory.c
+++ b/camlibs/directory/directory.c
@@ -746,7 +746,7 @@ storage_info_func (CameraFilesystem *fs,
 	Camera 				*camera = data;
 	CameraStorageInformation	*sfs;
 
-#if defined(linux) && defined(HAVE_STATFS)
+#if defined(HAVE_STATFS)
 	struct	statfs		stfs;
 	char *xpath;
 	int ret;


### PR DESCRIPTION
This makes gphoto2 test031 pass on GNU/Hurd.

And maybe on kFreeBSD as well, one time. On the other hand, I've got no idea why the Linux constraint was put here originally, does this break the Windows builds for example? I can't readily test that.