### PR TITLE
Add support for reading Canon EOS MovieMode switch and setting it on/off

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -7607,6 +7607,30 @@ _put_Generic_OPCode(CONFIG_PUT_ARGS)
 }
 
 static int
+_get_Canon_EOS_MovieModeSw(CONFIG_GET_ARGS) {
+	int val;
+
+	gp_widget_new (GP_WIDGET_TOGGLE, _(menu->label), widget);
+	gp_widget_set_name (*widget,menu->name);
+	val = 2; /* always changed */
+	gp_widget_set_value  (*widget, &val);
+	return (GP_OK);
+}
+
+static int
+_put_Canon_EOS_MovieModeSw(CONFIG_PUT_ARGS) {
+	int		val;
+	PTPParams	*params = &(camera->pl->params);
+	CR (gp_widget_get_value(widget, &val));
+
+	if(val)
+		C_PTP_MSG (ptp_generic_no_data(params, PTP_OC_CANON_EOS_MovieSelectSWOn, 0), "Failed to set MovieSetSelectSWOn");
+	else
+		C_PTP_MSG (ptp_generic_no_data(params, PTP_OC_CANON_EOS_MovieSelectSWOff, 0), "Failed to set MovieSetSelectSWOff");
+	return GP_OK;
+}
+
+static int
 _get_Sony_Movie(CONFIG_GET_ARGS) {
 	int val;
 
@@ -9233,6 +9257,7 @@ static struct submenu camera_actions_menu[] = {
 	{ N_("Movie Capture"),                  "movie",            0,  PTP_VENDOR_NIKON,   PTP_OC_NIKON_StartMovieRecInCard,   _get_Nikon_Movie,               _put_Nikon_Movie },
 	{ N_("Movie Capture"),                  "movie",            0,  PTP_VENDOR_SONY,    PTP_OC_SONY_SDIOConnect,            _get_Sony_Movie,                _put_Sony_Movie },
 	{ N_("Movie Capture"),                  "movie",            0,  PTP_VENDOR_SONY,    PTP_OC_SONY_QX_Connect,             _get_Sony_QX_Movie,             _put_Sony_QX_Movie },
+	{ N_("Movie Mode"),                     "eosmoviemode",     0,  PTP_VENDOR_CANON,   0,                                  _get_Canon_EOS_MovieModeSw,     _put_Canon_EOS_MovieModeSw },
 	{ N_("PTP Opcode"),                     "opcode",           0,  0,                  PTP_OC_GetDeviceInfo,               _get_Generic_OPCode,            _put_Generic_OPCode },
 	{ 0,0,0,0,0,0,0 },
 };
@@ -9281,6 +9306,7 @@ static struct submenu camera_status_menu[] = {
 	{ N_("AF Locked"),              "aflocked",         PTP_DPC_NIKON_AFLockStatus,             PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_OnOff_UINT8,         _put_None },
 	{ N_("AE Locked"),              "aelocked",         PTP_DPC_NIKON_AELockStatus,             PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_OnOff_UINT8,         _put_None },
 	{ N_("FV Locked"),              "fvlocked",         PTP_DPC_NIKON_FVLockStatus,             PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_OnOff_UINT8,         _put_None },
+	{ N_("Movie Switch"),	        "eosmovieswitch",   PTP_DPC_CANON_EOS_FixedMovie,           PTP_VENDOR_CANON,   PTP_DTC_UINT32, _get_INT,                       _put_None },
 	{ 0,0,0,0,0,0,0 },
 };
 

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -2253,6 +2253,7 @@ ptp_unpack_CANON_changes (PTPParams *params, unsigned char* data, unsigned int d
 					XX(EOS_EFComp)
 					XX(EOS_LensName)
 					XX(EOS_LensID)
+					XX(EOS_FixedMovie)
 #undef XX
 						dpd->GetSet = PTP_DPGS_Get;
 						break;
@@ -2282,6 +2283,7 @@ ptp_unpack_CANON_changes (PTPParams *params, unsigned char* data, unsigned int d
 				case PTP_DPC_CANON_EOS_BuiltinStroboMode:
 				case PTP_DPC_CANON_EOS_StroboETTL2Metering:
 				case PTP_DPC_CANON_EOS_ColorTemperature:
+				case PTP_DPC_CANON_EOS_FixedMovie:
 					dpd->DataType = PTP_DTC_UINT32;
 					break;
 				/* enumeration for AEM is never provided, but is available to set */

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -5539,6 +5539,7 @@ ptp_get_property_description(PTPParams* params, uint16_t dpc)
 		{PTP_DPC_CANON_TypeOfSupportedSlideShow,	N_("Type of Slideshow")},
 		{PTP_DPC_CANON_AverageFilesizes,N_("Average Filesizes")},
 		{PTP_DPC_CANON_ModelID,		N_("Model ID")},
+		{PTP_DPC_CANON_EOS_FixedMovie,	N_("EOS Fixed Movie Switch")},
 		{0,NULL}
 	};
 


### PR DESCRIPTION
This adds support for reading the state of the hardware "Movie Mode" switch setting on Canon EOS cameras as well as switching between still image and movie capture mode in software, without needing to move said switch.

Originally I wanted to implement reading the switch state and setting the mode as a single configuration item but couldn't figure out how to read the device property the regular way and not issue SetDevicePropertyEx commands to set it but only use a custom function.

Also I'm not sure if `_get_Canon_EOS_MovieModeSw` is a good implementation of a "write only"/"action trigger" configuration item (though other implementations nearby do exactly that).

I think this fixes #574 