### PR TITLE
WIP: Make PTP/IP implementation work on Windows

### DIFF
--- a/camlibs/ptp2/Makefile-files
+++ b/camlibs/ptp2/Makefile-files
@@ -14,7 +14,7 @@ ptp2_la_SOURCES = \
 	ptp2/ptp-private.h ptp2/ptpip.c ptp2/config.c \
 	ptp2/music-players.h ptp2/device-flags.h \
 	ptp2/olympus-wrap.c ptp2/olympus-wrap.h \
-	ptp2/chdk.c ptp2/fujiptpip.c
+	ptp2/chdk.c ptp2/fujiptpip.c ptp2/ptpip-private.h
 ptp2_la_LDFLAGS = $(camlib_ldflags)
 ptp2_la_DEPENDENCIES = $(camlib_dependencies)
 ptp2_la_LIBADD = $(camlib_libadd) $(LTLIBICONV) $(LIBXML2_LIBS) @LIBJPEG@ @LIBWS232@

--- a/camlibs/ptp2/ptpip-private.h
+++ b/camlibs/ptp2/ptpip-private.h
@@ -1,0 +1,39 @@
+/* ptpip-private.h
+ *
+ * Copyright (C) 2020 Daniel Schulte <trilader@schroedingers-bit.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+/* Definitions for PTP/IP to work with WinSock and regular BSD-style sockets */
+
+#ifdef WIN32
+# define PTPSOCK_SOCKTYPE SOCKET
+# define PTPSOCK_INVALID INVALID_SOCKET
+# define PTPSOCK_CLOSE closesocket
+# define PTPSOCK_ERR SOCKET_ERROR
+# define PTPSOCK_READ(fd, buf, size) recv((fd), ((char*)(buf)), (size), 0)
+# define PTPSOCK_WRITE(fd, buf, size) send((fd), ((char*)(buf)), (size), 0)
+# define PTPSOCK_PROTO IPPROTO_TCP
+#else
+# define PTPSOCK_SOCKTYPE int
+# define PTPSOCK_INVALID -1
+# define PTPSOCK_CLOSE close
+# define PTPSOCK_ERR -1
+# define PTPSOCK_READ(fd, buf, size) read((fd), (buf), (size))
+# define PTPSOCK_WRITE(fd, buf, size) write((fd), (buf), (size))
+# define PTPSOCK_PROTO 0
+#endif


### PR DESCRIPTION
This PR makes the PTP/IP implementation (regular and Fuji) work on Windows.

Most of the work was wrapping the platform specific quirks/differences between WinSock2 and regular BSD sockets in some macros which abstract away the differences. This also sends the correct hostname to the camera instead of the fixed `gpwindows` string.

- The Fuji implementation is untested as I don't have a Fuji camera.
- The regular implementation was tested with a Canon EOS 77D.

**What I still need help with:**
My autoconf/automake skills are basically nonexistent. The ptp2 camlib need to link to `ws2_32.lib` when building on Windows. For development I worked around that by running `./configure LDFLAGS="-lws_32" ...` but that's not something that should be expected for people to do explicitly.

**Point for discussion:**
WinSock2 needs to be initialized before use by calling `WSAStartup`. I'm not sure who (application using libgphoto vs. libgphoto2 itself) should do that. I think having the application do it makes more sense as the application might also needs to do other network stuff for which that could be needed anyway.