### PR TITLE
Recognize Nikon Z 7II and fix VendorExtensionID over PTP/IP

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -369,7 +369,9 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 	if (	(	(di->VendorExtensionID == PTP_VENDOR_MICROSOFT) ||
 			(di->VendorExtensionID == PTP_VENDOR_MTP)
 		) &&
-		(camera->port->type == GP_PORT_USB) &&
+		(	(camera->port->type == GP_PORT_USB) ||
+			(camera->port->type == GP_PORT_PTPIP)
+		) &&
 		(a.usb_vendor == 0x4b0)
 	) {
 		/*camera->pl->bugs |= PTP_MTP;*/

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -1705,6 +1705,9 @@ static struct {
 	/* Thomas Schaad */
 	{"Nikon:Z5",                      0x04b0, 0x0448, PTP_CAP|PTP_CAP_PREVIEW},
 
+	/* Fahrion <fahrion.2600@gmail.com> */
+	{"Nikon:Z7_2",                	  0x04b0, 0x044b, PTP_CAP|PTP_CAP_PREVIEW},
+
 	/* Thomas Schaad <tom@avisec.ch> */
 	{"Nikon:Z6_2",                	  0x04b0, 0x044c, PTP_CAP|PTP_CAP_PREVIEW},
 


### PR DESCRIPTION
This PR adds the vendor and product code for the Nikon Z 7II. It also fixes the VendorExtensionID for the Z 7II (and probably other Nikon cameras) when connecting to the camera over PTP/IP, such as via the built-in Wi-Fi.

**Tested:**
* auto-detect shows "Nikon Z7_2"
* summary command displays the correct Vendor Extension ID "0xa" for Nikon and shows additional configs
* Capture and image download both work over USB and Wi-Fi