### PR TITLE
Also set params->controlmode in _put_Nikon_ControlMode

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -6926,6 +6926,7 @@ _put_Nikon_ControlMode(CONFIG_PUT_ARGS) {
 		return GP_ERROR;
 
 	C_PTP (ptp_nikon_changecameramode (&camera->pl->params, xval));
+	params->controlmode = xval;
 	return GP_OK;
 }
 


### PR DESCRIPTION
This keeps the internal state in sync so that if the control mode
is set to 0 via set-config, subsequent triggers/captures set it to 1.
Some Nikon cameras lock the shutter if in sleep mode. Setting
the control mode to 1 wakes up the camera, allowing the trigger to
proceed.

**Tested:**

Tested on a Nikon Z 7II. I do not know the behavior for other Nikons.

**Additional details:**

On a Nikon camera, when performing a trigger or capture, the control mode is set to 1. This locks the screen and buttons on the camera. To restore the UI, you can run "set-config controlmode=0". However, there is an internal variable that libgphoto2 keeps for the control mode, and that is not updated. On subsequent captures, the control mode is not set to 1 again because libgphoto2 thinks it is already set. I would guess this is usually not a problem, but on mirrorless Nikons (and possibly only when connected via Wi-Fi), if the control mode is 0, the camera is allowed to go into sleep mode, which locks the shutter.

A workaround is to run "set-config controlmode=1" to force it back to 1, which wakes up the camera and unlocks the shutter.

The fix is to set the internal control mode variable to whatever user value it is set to during set-config.

**Steps to reproduce:**

This command connects to the camera via Wi-Fi, triggers capture (setting control mode to 1), sets control mode to 0 (unlocking the camera UI), waits 60 seconds (for the camera to go to sleep), and triggers capture again: `gphoto2 --port ptpip:XXX.XXX.XXX.XXX --trigger-capture --set-config controlmode=0 --wait-event=60s --trigger-capture`

Without the fix, the second capture does not happen because the camera is still in sleep mode.

With the fix, the second capture happens.

**Potential issues:**

It is possible that existing programs/scripts rely on the current behavior, where manually setting controlmode=0 after the first capture will not cause libgphoto2 to lock the UI for subsequent captures. After this fix, they will need to manually set controlmode=0 after each capture to get the old behavior.

I tried a different solution too, which involves creating a new API to set the control mode and update the internal state. This doesn't touch the existing behavior. However, it is a larger change, which I embarrassingly made before I found out about the existence of the controlmode config. I can submit a PR for that if requested.