### PR TITLE
Make it possible to build libgphoto2 on macOS

### DIFF
--- a/camlibs/ptp2/fujiptpip.c
+++ b/camlibs/ptp2/fujiptpip.c
@@ -42,6 +42,7 @@
  * - jpeg pipe , port 55742 (camera remote port starts listen when you run "InitiateOpenCapture")
  */
 #define _DEFAULT_SOURCE
+#define _DARWIN_C_SOURCE
 #include "config.h"
 
 #include <stdlib.h>

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -22,6 +22,7 @@
  */
 
 #define _DEFAULT_SOURCE
+#define _DARWIN_C_SOURCE
 #include "config.h"
 
 #include <stdlib.h>

--- a/camlibs/ptp2/ptpip.c
+++ b/camlibs/ptp2/ptpip.c
@@ -29,6 +29,7 @@
  * Nikon WU-1* adapters might use 0011223344556677 as GUID always...
  */
 #define _DEFAULT_SOURCE
+#define _DARWIN_C_SOURCE
 #include "config.h"
 
 #include <stdlib.h>

--- a/camlibs/sierra/library.c
+++ b/camlibs/sierra/library.c
@@ -17,6 +17,7 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
+#define _DARWIN_C_SOURCE
 #include "config.h"
 #include "library.h"
 

--- a/camlibs/st2205/st2205.c
+++ b/camlibs/st2205/st2205.c
@@ -19,6 +19,7 @@
  */
 #define _DEFAULT_SOURCE
 #define _POSIX_C_SOURCE 1
+#define _DARWIN_C_SOURCE
 #include "config.h"
 
 #include <stdio.h>

--- a/examples/config.c
+++ b/examples/config.c
@@ -1,3 +1,4 @@
+#define _DARWIN_C_SOURCE
 #include "samples.h"
 
 #include <string.h>

--- a/libgphoto2/gphoto2-abilities-list.c
+++ b/libgphoto2/gphoto2-abilities-list.c
@@ -21,6 +21,7 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
+#define _DARWIN_C_SOURCE
 
 #include "config.h"
 #include <gphoto2/gphoto2-abilities-list.h>

--- a/libgphoto2/gphoto2-file.c
+++ b/libgphoto2/gphoto2-file.c
@@ -26,6 +26,7 @@
  */
 #define _POSIX_SOURCE
 #define _DEFAULT_SOURCE
+#define _DARWIN_C_SOURCE
 
 #include "config.h"
 #include <gphoto2/gphoto2-file.h>

--- a/libgphoto2/gphoto2-widget.c
+++ b/libgphoto2/gphoto2-widget.c
@@ -20,6 +20,7 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
+#define _DARWIN_C_SOURCE
 #include "config.h"
 #include <gphoto2/gphoto2-widget.h>
 

--- a/libgphoto2_port/serial/unix.c
+++ b/libgphoto2_port/serial/unix.c
@@ -28,6 +28,7 @@
  */
 
 #define _DEFAULT_SOURCE
+#define _DARWIN_C_SOURCE
 /* Solaris needs this */
 #define __EXTENSIONS__
 


### PR DESCRIPTION
As noted in https://github.com/gphoto/gphoto2/issues/373 and #552, building on macOS raises errors about implicitly declaring library functions from string.h.

https://github.com/gphoto/libgphoto2/commit/ac4546e0dddf580c7e7558531818423dd3c81c3f partially fixed the issue by defining `_DARWIN_C_SOURCE` in gphoto2-port-info-list.c. In this change, I did the same to all the other files that caused similar errors until `make` stopped returning errors.