### PR TITLE
Fix byte swap calls

### DIFF
--- a/camlibs/enigma13/enigma13.c
+++ b/camlibs/enigma13/enigma13.c
@@ -162,7 +162,7 @@ static int enigma13_get_filecount (Camera *camera, int *filecount)
         CHECK (gp_port_usb_msg_read (camera->port,
                              0x54, 0x0000, 0x0000,
                              (char*)&response, 0x02));
-        LE16TOH (response);
+        le16toh (response);
         *filecount = response;
         return GP_OK;
 }
@@ -188,7 +188,7 @@ static int enigma13_get_toc(Camera *camera, int *filecount, char** toc)
         CHECK (gp_port_usb_msg_read (camera->port,
                              0x54, 0x0000, 0x0000,
                              (char*)&response, 0x02));
-        LE16TOH (response);
+        le16toh (response);
         *filecount = response;
 
         /* Calc toc size */

--- a/camlibs/spca50x/spca50x-flash.c
+++ b/camlibs/spca50x/spca50x-flash.c
@@ -149,13 +149,13 @@ spca50x_flash_get_TOC(CameraPrivateLibrary *pl, int *filecount)
 						(char*)&n_toc_entries, 0x02));
 			/* Each file gets two toc entries, one for the image,
 			   one for the thumbnail */
-			LE16TOH (n_toc_entries);
+			le16toh (n_toc_entries);
 			*filecount = n_toc_entries/2;
 		} else {
 			CHECK (gp_port_usb_msg_read (pl->gpdev,
 						0x54, 0x0000, 0x0000,
 						(char*)&n_toc_entries, 0x02));
-			LE16TOH (n_toc_entries);
+			le16toh (n_toc_entries);
 			*filecount = n_toc_entries;
 		}
 		/* If empty, return now */
@@ -225,13 +225,13 @@ spca50x_flash_get_filecount (CameraPrivateLibrary *pl, int *filecount)
 						(char*)&response, 0x02));
 			/* Each file gets two toc entries, one for the
 			   image, one for the thumbnail */
-			LE16TOH (response);
+			le16toh (response);
 			*filecount = response/2;
 		} else {
 			CHECK (gp_port_usb_msg_read (pl->gpdev,
 						0x54, 0x0000, 0x0000,
 						(char*)&response, 0x02));
-			LE16TOH (response);
+			le16toh (response);
 			*filecount = response;
 		}
 	}

--- a/camlibs/spca50x/spca50x-sdram.c
+++ b/camlibs/spca50x/spca50x-sdram.c
@@ -123,7 +123,7 @@ spca50x_sdram_get_file_count_and_fat_count (CameraPrivateLibrary * lib,
 		CHECK (gp_port_usb_msg_read
 				(lib->gpdev, 0, 0, 0xe15,
 				 (char *) & lib->num_files_on_sdram, 1));
-		LE32TOH (lib->num_files_on_sdram);
+		le32toh (lib->num_files_on_sdram);
 
 		/*  get fatscount */
 		CHECK (gp_port_usb_msg_write

--- a/camlibs/st2205/st2205.c
+++ b/camlibs/st2205/st2205.c
@@ -502,7 +502,7 @@ st2205_read_raw_file(Camera *camera, int idx, unsigned char **raw)
 			"trying to read a deleted file");
 		return GP_ERROR_BAD_PARAMETERS;
 	}
-	LE32TOH(entry.address);
+	le32toh(entry.address);
 
 	GP_DEBUG ("file: %d start at: %08x\n", idx, entry.address);
 
@@ -515,10 +515,10 @@ st2205_read_raw_file(Camera *camera, int idx, unsigned char **raw)
 			return GP_ERROR_CORRUPTED_DATA;
 		}
 
-		BE16TOH(header.width);
-		BE16TOH(header.height);
-		BE16TOH(header.length);
-		BE16TOH(header.blocks);
+		be16toh(header.width);
+		be16toh(header.height);
+		be16toh(header.length);
+		be16toh(header.blocks);
 
 		if ((header.width != camera->pl->width) ||
 		    (header.height != camera->pl->height)) {
@@ -619,7 +619,7 @@ st2205_real_write_file(Camera *camera,
 							      &header,
 							      sizeof(header)))
 
-					BE16TOH(header.length);
+					be16toh(header.length);
 					end = start + sizeof(header) +
 					      header.length;
 				} else
@@ -1105,7 +1105,7 @@ st2205_get_free_mem_size(Camera *camera)
 							      &header,
 							      sizeof(header)))
 
-					BE16TOH(header.length);
+					be16toh(header.length);
 					end = start + sizeof(header) +
 					      header.length;
 				} else {


### PR DESCRIPTION
gphoto2-endian.h provides shims for the standard byte swap macros, so
using the standard name is preferred.