### PR TITLE
PTP/IP: Better error reporting and timeout handling

### DIFF
--- a/camlibs/ptp2/fujiptpip.c
+++ b/camlibs/ptp2/fujiptpip.c
@@ -962,18 +962,21 @@ ptp_fujiptpip_connect (PTPParams* params, const char *address) {
 		perror ("connect cmd");
 		PTPSOCK_CLOSE (params->cmdfd);
 		PTPSOCK_CLOSE (params->evtfd);
+		PTPSOCK_CLOSE (params->jpgfd);
 		return GP_ERROR_IO;
 	}
 	ret = ptp_fujiptpip_init_command_request (params);
 	if (ret != PTP_RC_OK) {
 		PTPSOCK_CLOSE (params->cmdfd);
 		PTPSOCK_CLOSE (params->evtfd);
+		PTPSOCK_CLOSE (params->jpgfd);
 		return translate_ptp_result (ret);
 	}
 	ret = ptp_fujiptpip_init_command_ack (params);
 	if (ret != PTP_RC_OK) {
 		PTPSOCK_CLOSE (params->cmdfd);
 		PTPSOCK_CLOSE (params->evtfd);
+		PTPSOCK_CLOSE (params->jpgfd);
 		return translate_ptp_result (ret);
 	}
 	GP_LOG_D ("fujiptpip connected!");

--- a/camlibs/ptp2/fujiptpip.c
+++ b/camlibs/ptp2/fujiptpip.c
@@ -162,6 +162,8 @@ ptp_fujiptpip_sendreq (PTPParams* params, PTPContainer* req, int dataphase)
 	free (request);
 	if (ret == PTPSOCK_ERR) {
 		ptpip_perror ("sendreq/write to cmdfd");
+		if (ptpip_get_socket_error() == ETIMEDOUT)
+			return PTP_ERROR_TIMEOUT;
 		return PTP_ERROR_IO;
 	}
 	if (ret != len) {
@@ -186,6 +188,8 @@ ptp_fujiptpip_generic_read (PTPParams *params, int fd, PTPIPHeader *hdr, unsigne
 		ret = read (fd, xhdr + curread, len - curread);
 		if (ret == PTPSOCK_ERR) {
 			ptpip_perror ("read fujiptpip generic");
+			if (ptpip_get_socket_error() == ETIMEDOUT)
+				return PTP_ERROR_TIMEOUT;
 			return PTP_ERROR_IO;
 		}
 		GP_LOG_DATA ((char*)xhdr+curread, ret, "ptpip/generic_read header:");
@@ -211,6 +215,8 @@ ptp_fujiptpip_generic_read (PTPParams *params, int fd, PTPIPHeader *hdr, unsigne
 		if (ret == PTPSOCK_ERR) {
 			GP_LOG_E ("error %d in reading PTPIP data", ptpip_get_socket_error());
 			free (*data);*data = NULL;
+			if (ptpip_get_socket_error() == ETIMEDOUT)
+				return PTP_ERROR_TIMEOUT;
 			return PTP_ERROR_IO;
 		} else {
 			GP_LOG_DATA ((char*)((*data)+curread), ret, "ptpip/generic_read data:");
@@ -282,6 +288,8 @@ ptp_fujiptpip_senddata (PTPParams* params, PTPContainer* ptp,
 	ret = write (params->cmdfd, request, sizeof(request));
 	if (ret == PTPSOCK_ERR) {
 		ptpip_perror ("sendreq/write to cmdfd");
+		if (ptpip_get_socket_error() == ETIMEDOUT)
+			return PTP_ERROR_TIMEOUT;
 		return PTP_ERROR_IO;
 	}
 	if (ret != sizeof(request)) {
@@ -314,6 +322,8 @@ ptp_fujiptpip_senddata (PTPParams* params, PTPContainer* ptp,
 			if (ret == PTPSOCK_ERR) {
 				ptpip_perror ("write in senddata failed");
 				free (xdata);
+				if (ptpip_get_socket_error() == ETIMEDOUT)
+					return PTP_ERROR_TIMEOUT;
 				return PTP_ERROR_IO;
 			}
 			written += ret;
@@ -623,6 +633,8 @@ ptp_fujiptpip_init_command_request (PTPParams* params)
 	free (cmdrequest);
 	if (ret == PTPSOCK_ERR) {
 		ptpip_perror("write init cmd request");
+		if (ptpip_get_socket_error() == ETIMEDOUT)
+			return PTP_ERROR_TIMEOUT;
 		return PTP_ERROR_IO;
 	}
 	GP_LOG_E ("return %d / len %d", ret, len);

--- a/camlibs/ptp2/fujiptpip.c
+++ b/camlibs/ptp2/fujiptpip.c
@@ -637,7 +637,7 @@ ptp_fujiptpip_init_command_request (PTPParams* params)
 			return PTP_ERROR_TIMEOUT;
 		return PTP_ERROR_IO;
 	}
-	GP_LOG_E ("return %d / len %d", ret, len);
+	GP_LOG_D ("return %d / len %d", ret, len);
 	if (ret != len) {
 		GP_LOG_E ("return %d vs len %d", ret, len);
 		return PTP_RC_GeneralError;

--- a/camlibs/ptp2/ptpip-private.h
+++ b/camlibs/ptp2/ptpip-private.h
@@ -23,6 +23,8 @@
 
 /* Definitions for PTP/IP to work with WinSock and regular BSD-style sockets */
 #ifdef WIN32
+# include <winsock2.h>
+# include <ws2tcpip.h>
 # define PTPSOCK_SOCKTYPE SOCKET
 # define PTPSOCK_INVALID INVALID_SOCKET
 # define PTPSOCK_CLOSE closesocket
@@ -31,6 +33,7 @@
 # define PTPSOCK_WRITE(fd, buf, size) send((fd), ((char*)(buf)), (size), 0)
 # define PTPSOCK_PROTO IPPROTO_TCP
 #else
+# include <sys/socket.h>
 # define PTPSOCK_SOCKTYPE int
 # define PTPSOCK_INVALID -1
 # define PTPSOCK_CLOSE close
@@ -40,7 +43,17 @@
 # define PTPSOCK_PROTO 0
 #endif
 
+#include <sys/types.h> /* for ssize_t, size_t */
+
+#define PTPIP_DEFAULT_TIMEOUT_S 2
+#define PTPIP_DEFAULT_TIMEOUT_MS 500
+
+int ptpip_connect_with_timeout(int fd, const struct sockaddr *address, socklen_t address_len, int seconds, int milliseconds);
+ssize_t ptpip_read_with_timeout(int fd, void *buf, size_t nbytes, int seconds, int milliseconds);
+ssize_t ptpip_write_with_timeout(int fd, void *buf, size_t nbytes, int seconds, int milliseconds);
+int ptpip_set_nonblock(int fd);
 void ptpip_perror(const char *what);
 int ptpip_get_socket_error(void);
+void ptpip_set_socket_error(int err);
 
 #endif

--- a/camlibs/ptp2/ptpip-private.h
+++ b/camlibs/ptp2/ptpip-private.h
@@ -18,8 +18,10 @@
  * Boston, MA  02110-1301  USA
  */
 
-/* Definitions for PTP/IP to work with WinSock and regular BSD-style sockets */
+#ifndef PTPIP_PRIVATE_H
+#define PTPIP_PRIVATE_H
 
+/* Definitions for PTP/IP to work with WinSock and regular BSD-style sockets */
 #ifdef WIN32
 # define PTPSOCK_SOCKTYPE SOCKET
 # define PTPSOCK_INVALID INVALID_SOCKET
@@ -36,4 +38,9 @@
 # define PTPSOCK_READ(fd, buf, size) read((fd), (buf), (size))
 # define PTPSOCK_WRITE(fd, buf, size) write((fd), (buf), (size))
 # define PTPSOCK_PROTO 0
+#endif
+
+void ptpip_perror(const char *what);
+int ptpip_get_socket_error(void);
+
 #endif

--- a/camlibs/ptp2/ptpip.c
+++ b/camlibs/ptp2/ptpip.c
@@ -150,6 +150,8 @@ ptp_ptpip_sendreq (PTPParams* params, PTPContainer* req, int dataphase)
 	free (request);
 	if (ret == PTPSOCK_ERR) {
 		ptpip_perror ("sendreq/write to cmdfd");
+		if (ptpip_get_socket_error() == ETIMEDOUT)
+			return PTP_ERROR_TIMEOUT;
 		return PTP_ERROR_IO;
 	}
 	if (ret != len) {
@@ -169,6 +171,8 @@ ptp_ptpip_generic_read (PTPParams *params, int fd, PTPIPHeader *hdr, unsigned ch
 		ret = PTPSOCK_READ (fd, xhdr + curread, len - curread);
 		if (ret == PTPSOCK_ERR) {
 			ptpip_perror ("read PTPIPHeader");
+			if (ptpip_get_socket_error() == ETIMEDOUT)
+				return PTP_ERROR_TIMEOUT;
 			return PTP_ERROR_IO;
 		}
 		GP_LOG_DATA ((char*)xhdr+curread, ret, "ptpip/generic_read header:");
@@ -194,6 +198,8 @@ ptp_ptpip_generic_read (PTPParams *params, int fd, PTPIPHeader *hdr, unsigned ch
 		if (ret == PTPSOCK_ERR) {
 			GP_LOG_E ("error %d in reading PTPIP data", ptpip_get_socket_error());
 			free (*data);*data = NULL;
+			if (ptpip_get_socket_error() == ETIMEDOUT)
+				return PTP_ERROR_TIMEOUT;
 			return PTP_ERROR_IO;
 		} else {
 			GP_LOG_DATA ((char*)((*data)+curread), ret, "ptpip/generic_read data:");
@@ -261,6 +267,8 @@ ptp_ptpip_senddata (PTPParams* params, PTPContainer* ptp,
 	ret = PTPSOCK_WRITE (params->cmdfd, request, sizeof(request));
 	if (ret == PTPSOCK_ERR) {
 		ptpip_perror ("sendreq/write to cmdfd");
+		if (ptpip_get_socket_error() == ETIMEDOUT)
+			return PTP_ERROR_TIMEOUT;
 		return PTP_ERROR_IO;
 	}
 	if (ret != sizeof(request)) {
@@ -299,6 +307,8 @@ ptp_ptpip_senddata (PTPParams* params, PTPContainer* ptp,
 			if (ret == PTPSOCK_ERR) {
 				ptpip_perror ("write in senddata failed");
 				free (xdata);
+				if (ptpip_get_socket_error() == ETIMEDOUT)
+					return PTP_ERROR_TIMEOUT;
 				return PTP_ERROR_IO;
 			}
 			written += ret;
@@ -477,6 +487,8 @@ ptp_ptpip_init_command_request (PTPParams* params)
 	free (cmdrequest);
 	if (ret == PTPSOCK_ERR) {
 		ptpip_perror("write init cmd request");
+		if (ptpip_get_socket_error() == ETIMEDOUT)
+			return PTP_ERROR_TIMEOUT;
 		return PTP_ERROR_IO;
 	}
 	GP_LOG_E ("return %d / len %d", ret, len);
@@ -537,6 +549,8 @@ ptp_ptpip_init_event_request (PTPParams* params)
 	ret = PTPSOCK_WRITE (params->evtfd, evtrequest, ptpip_eventinit_size);
 	if (ret == PTPSOCK_ERR) {
 		ptpip_perror("write init evt request");
+		if (ptpip_get_socket_error() == ETIMEDOUT)
+			return PTP_ERROR_TIMEOUT;
 		return PTP_ERROR_IO;
 	}
 	if (ret != ptpip_eventinit_size) {
@@ -598,6 +612,8 @@ ptp_ptpip_event (PTPParams* params, PTPContainer* event, int wait)
 		if (1 != ret) {
 			if (-1 == ret) {
 				GP_LOG_D ("select returned error, errno is %d", ptpip_get_socket_error());
+				if (ptpip_get_socket_error() == ETIMEDOUT)
+					return PTP_ERROR_TIMEOUT;
 				return PTP_ERROR_IO;
 			}
 			return PTP_ERROR_TIMEOUT;

--- a/camlibs/ptp2/ptpip.c
+++ b/camlibs/ptp2/ptpip.c
@@ -492,7 +492,7 @@ ptp_ptpip_init_command_request (PTPParams* params)
 			return PTP_ERROR_TIMEOUT;
 		return PTP_ERROR_IO;
 	}
-	GP_LOG_E ("return %d / len %d", ret, len);
+	GP_LOG_D ("return %d / len %d", ret, len);
 	if (ret != len) {
 		GP_LOG_E ("return %d vs len %d", ret, len);
 		return PTP_RC_GeneralError;

--- a/libgphoto2/gphoto2-camera.c
+++ b/libgphoto2/gphoto2-camera.c
@@ -263,6 +263,7 @@ struct _CameraPrivateCore {
 int
 gp_camera_exit (Camera *camera, GPContext *context)
 {
+	int exit_result = GP_OK;
 	C_PARAMS (camera);
 
 	GP_LOG_D ("Exiting camera ('%s')...", camera->pc->a.model);
@@ -287,7 +288,7 @@ gp_camera_exit (Camera *camera, GPContext *context)
 #ifdef HAVE_MULTI
 		gp_port_open (camera->port);
 #endif
-		camera->functions->exit (camera, context);
+		exit_result = camera->functions->exit (camera, context);
 	}
 	gp_port_close (camera->port);
 	memset (camera->functions, 0, sizeof (CameraFunctions));
@@ -302,7 +303,7 @@ gp_camera_exit (Camera *camera, GPContext *context)
 
 	gp_filesystem_reset (camera->fs);
 
-	return (GP_OK);
+	return exit_result;
 }
 
 


### PR DESCRIPTION
The current PTP/IP implementation doesn't have very granular error reporting and returns PTP_RC_GeneralError where a more specific error cause is available. Another issue in situations with flakey and/or suboptimal WiFi coverage is that libgphoto can get stuck on blocking read(), write() or connect() calls when trying to talk to the camera for an undefined amount of time which causes the application using libgphoto to hang (or at least its gphoto thread).

This PR addresses both issues be introducing non blocking socket based communication with timeout as well as adding/adjusting the error codes returned.

This code was tested on Linux, Windows and macOS (mainly with Canon cameras).