### PR TITLE
camlibs/ptp2: Unpack Canon EOS changes for INT32 properties

### DIFF
--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -2422,6 +2422,11 @@ ptp_unpack_CANON_changes (PTPParams *params, unsigned char* data, unsigned int d
 					break;
 				}
 				switch (dpd->DataType) {
+				case PTP_DTC_INT32:
+					dpd->FactoryDefaultValue.i32	= dtoh32a(xdata);
+					dpd->CurrentValue.i32		= dtoh32a(xdata);
+					ptp_debug (params ,"event %d: currentvalue of %x is %x", i, proptype, dpd->CurrentValue.i32);
+					break;
 				case PTP_DTC_UINT32:
 					dpd->FactoryDefaultValue.u32	= dtoh32a(xdata);
 					dpd->CurrentValue.u32		= dtoh32a(xdata);


### PR DESCRIPTION
White implementing a control for the white balance shift I noticed the WhiteBalanceAdjust{A,B} properties where always reported as 0.
After investigating a bit I noticed that changes for `PTP_DTC_INT32` properties weren't being unpacked which resulted in missed updates when the value changes on the camera and libgphoto getting out of sync.