### PR TITLE
Misc Fuji fixes and improvements

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -507,7 +507,7 @@ camera_prepare_capture (Camera *camera, GPContext *context)
 			PTPPropertyValue propval;
 
 			/* without the firmware update ... not an error... */
-			if (!have_prop (camera, PTP_VENDOR_FUJI, 0xd207))
+			if (!have_prop (camera, PTP_VENDOR_FUJI, PTP_DPC_FUJI_PriorityMode))
 				return GP_OK;
 
 			/* timelapse does:
@@ -518,7 +518,7 @@ camera_prepare_capture (Camera *camera, GPContext *context)
 			propval.u16 = 0x0001;
 			LOG_ON_PTP_E (ptp_setdevicepropvalue (params, 0xd38c, &propval, PTP_DTC_UINT16));
 			propval.u16 = 0x0002;
-			LOG_ON_PTP_E (ptp_setdevicepropvalue (params, 0xd207, &propval, PTP_DTC_UINT16));
+			LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
 			return GP_OK;
 		}
 		break;
@@ -629,7 +629,7 @@ camera_unprepare_capture (Camera *camera, GPContext *context)
 			}
 
 			propval.u16 = 0x0001;
-			C_PTP (ptp_setdevicepropvalue (params, 0xd207, &propval, PTP_DTC_UINT16));
+			C_PTP (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
 			return GP_OK;
 		}
 		break;

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -1554,6 +1554,12 @@ static struct deviceproptableu16 fuji_filmsimulation[] = {
 };
 GENERIC16TABLE(Fuji_FilmSimulation,fuji_filmsimulation)
 
+static struct deviceproptableu16 fuji_prioritymode[] = {
+	{ N_("Camera"),	1,	PTP_VENDOR_FUJI },
+	{ N_("USB"),	2,	PTP_VENDOR_FUJI },
+};
+GENERIC16TABLE(Fuji_PriorityMode,fuji_prioritymode)
+
 static int
 _get_ExpCompensation(CONFIG_GET_ARGS) {
 	int j;
@@ -10020,6 +10026,7 @@ static struct submenu camera_settings_menu[] = {
 	{ N_("External Recording Control"),     "externalrecordingcontrol", PTP_DPC_NIKON_ExternalRecordingControl,     PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_OffOn_UINT8,    _put_Nikon_OffOn_UINT8 },
 	{ N_("Camera Action"),          "cameraaction", 	0xd208, 			    PTP_VENDOR_FUJI,	PTP_DTC_UINT16,	_get_Fuji_Action,		_put_Fuji_Action },
 	{ N_("Priority Mode"),		"prioritymode",		PTP_DPC_SONY_PriorityMode,  	    PTP_VENDOR_SONY,	PTP_DTC_INT8, 	_get_Sony_PriorityMode,     	_put_Sony_PriorityMode },
+	{ N_("Priority Mode"),          "prioritymode",         PTP_DPC_FUJI_PriorityMode,          PTP_VENDOR_FUJI,    PTP_DTC_UINT16, _get_Fuji_PriorityMode,         _put_Fuji_PriorityMode },
 
 /* virtual */
 	{ N_("Thumb Size"),		"thumbsize",    0,  PTP_VENDOR_NIKON,   0,  _get_Nikon_Thumbsize,   _put_Nikon_Thumbsize },

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -6361,7 +6361,7 @@ camera_trigger_capture (Camera *camera, GPContext *context)
 		/* poll camera until it is ready */
 		propval.u16 = 0x0000;
 		while (propval.u16 == 0x0000) {
-			C_PTP_REP (ptp_getdevicepropvalue (params, 0xd212, &propval, PTP_DTC_UINT64));
+			C_PTP_REP (ptp_getdevicepropvalue (params, PTP_DPC_FUJI_CurrentState, &propval, PTP_DTC_UINT16));
 		}
 	}
 

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -6944,6 +6944,8 @@ sonyout:
 				goto handleregular;
 			C_PTP (ptp_getobjecthandles (params, PTP_HANDLER_SPECIAL, 0x000000, 0x000000, &handles));
 			for (i=handles.n;i--;) {
+				if (params->inliveview == 1 && handles.Handler[i] == 0x80000001) /* Ignore preview image object handle while liveview is active */
+					continue;
 				if (PTP_RC_OK == ptp_object_find (params, handles.Handler[i], &oi)) /* already have it */
 					continue;
 				event.Code = PTP_EC_ObjectAdded;


### PR DESCRIPTION
While investigating #653 I fixed some bugs and added a new config option for Fuji cameras.

In this case this is:
- A fix for a wrong property data type in `camera_trigger_capture`
- A new config option to change camera priority mode (USB remote or local camera control)
- Replaced usage of magic numbers with the corresponding DPC #define
- A fix for active live-view (via repeatedly calling `camera_capture_preview`) conflicting with tethered shooting by downloading new images when detected by `camera_wait_for_event`

This is only tested with a Fuji X-T4 as that is what I have access to but I don't think anything should break with other Fuji cameras.