### PR TITLE
sierra: Fix Epson PhotoPC 500

### DIFF
--- a/camlibs/sierra/library.c
+++ b/camlibs/sierra/library.c
@@ -464,8 +464,9 @@ sierra_write_packet (Camera *camera, char *packet, GPContext *context)
 		if (camera->pl->flags & SIERRA_NO_BLOCK_WRITE) {
 			for (x = 0; x < length; x++)
 				CHECK (gp_port_write(camera->port, &packet[x], 1));
-		} else
+		} else {
 			CHECK (gp_port_write (camera->port, packet, length));
+		}
 	}
 
 	return GP_OK;

--- a/camlibs/sierra/library.c
+++ b/camlibs/sierra/library.c
@@ -61,6 +61,7 @@ enum _SierraPacket {
 	ACK				= 0x06,
 	SIERRA_PACKET_INVALID		= 0x11,
 	SIERRA_PACKET_NAK		= 0x15,
+	SIERRA_PACKET_CANCEL		= 0x18,
 	SIERRA_PACKET_COMMAND		= 0x1b,
 	SIERRA_PACKET_WRONG_SPEED	= 0x8c,
 	SIERRA_PACKET_SESSION_ERROR	= 0xfc,
@@ -595,6 +596,7 @@ sierra_read_packet (Camera *camera, unsigned char *packet, GPContext *context)
 		case ACK:
 		case SIERRA_PACKET_INVALID:
 		case SIERRA_PACKET_NAK:
+		case SIERRA_PACKET_CANCEL:
 		case SIERRA_PACKET_SESSION_ERROR:
 		case SIERRA_PACKET_SESSION_END:
 		case SIERRA_PACKET_WRONG_SPEED:
@@ -794,6 +796,7 @@ sierra_transmit_ack (Camera *camera, char *packet, GPContext *context)
 			GP_DEBUG ("Transmission successful.");
 			return GP_OK;
 		case SIERRA_PACKET_INVALID:
+		case SIERRA_PACKET_CANCEL:
 			gp_context_error (context, _("Packet was rejected "
 				"by camera. Please contact "
 				"%s."), MAIL_GPHOTO_DEVEL);

--- a/camlibs/sierra/library.c
+++ b/camlibs/sierra/library.c
@@ -460,7 +460,11 @@ sierra_write_packet (Camera *camera, char *packet, GPContext *context)
 			(camera->pl->flags & SIERRA_WRAP_USB_MASK),
 			packet, length));
 	} else {
-		CHECK (gp_port_write (camera->port, packet, length));
+		if (camera->pl->flags & SIERRA_NO_BLOCK_WRITE) {
+			for (x = 0; x < length; x++)
+				CHECK (gp_port_write(camera->port, &packet[x], 1));
+		} else
+			CHECK (gp_port_write (camera->port, packet, length));
 	}
 
 	return GP_OK;

--- a/camlibs/sierra/sierra.h
+++ b/camlibs/sierra/sierra.h
@@ -39,6 +39,7 @@ typedef enum {
 	SIERRA_NO_USB_CLEAR	= 1<<6,
 	SIERRA_NO_REGISTER_40	= 1<<7,
 	SIERRA_MID_SPEED	= 1<<8,	/* serial line 9600 -> 57600 */
+	SIERRA_NO_BLOCK_WRITE	= 1<<9,
 } SierraFlags;
 
 struct _CameraPrivateLibrary {


### PR DESCRIPTION
Got an old Epson PtohoPC 500 camera only to find that it does not work with gphoto2.
Seems it has problems with speed over 38400bps, but it works fine in Windows at 115200bps.
Add the same workaround that Windows software uses - write data one byte at a time if the first command times out.
Also found that the camera responds with unknown 0x18 response to the "folder test" command.