### PR TITLE
Fixed an error check on _set_config

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -11096,7 +11096,7 @@ _set_config (Camera *camera, const char *confname, CameraWidget *window, GPConte
 						ptp_free_devicepropvalue (cursub->type, &propval);
 					}
 					ptp_free_devicepropdesc(&dpd);
-					if (ret != GP_OK) continue; /* see if we have another match */
+					if (ret == GP_OK) continue; /* see if we have another match */
 				} else {
 					ret = cursub->putfunc (camera, widget, NULL, NULL);
 				}


### PR DESCRIPTION
When updating multiple settings at the same time, this continue was allowing an early failure to be ignored (if the next setting returned GP_OK).

Not sure if this is the best route to fix.