### PR TITLE
Provide correct search size to memchr

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -3623,7 +3623,7 @@ enable_liveview:
 		}
 
 		/* look for the JPEG SOI marker (0xFFD8) in data */
-		jpgStartPtr = (unsigned char*)memchr(jpgStartPtr, 0xff, size);
+		jpgStartPtr = (unsigned char*)memchr(jpgStartPtr, 0xff, ximage + size - jpgStartPtr);
 		while(jpgStartPtr && ((jpgStartPtr+1) < (ximage + size))) {
 			if(*(jpgStartPtr + 1) == 0xd8) { /* SOI found */
 				break;


### PR DESCRIPTION
https://github.com/gphoto/libgphoto2/commit/6c26cdc5b0b8f177bb0d74ea93c8f0d45afb3a09 adjusted `jpgStartPtr` to start after an offset if such is found in the initial blob.

The following `memchr` call was changed to use the adjusted `jpgStartPtr` pointer, but the size parameter was never changed, in theory allowing `memchr` to search in the garbage area past the allocation.

On practice this shouldn't matter because during the previous adjustment it's checked that the following bytes are indeed 0xFF 0xD8 so memchr loop should stop right away, but 1) in theory vectorized memchr might try to read more if it thinks there's enough data to parallelise operations, 2) this can be error-prone in the future and 3) I actually ran into an issue here in combination with a buggy `memchr` implementation in one compiler (which is, admittedly, unrelated issue and I reported it separately).