### PR TITLE
Revamp Sony ISO MFNR logic

### DIFF
--- a/camlibs/ptp2/cameras/sony-a6300.txt
+++ b/camlibs/ptp2/cameras/sony-a6300.txt
@@ -131,20 +131,20 @@ Choice: 68 12800 Multi Frame Noise Reduction
 Choice: 69 16000 Multi Frame Noise Reduction
 Choice: 70 25600 Multi Frame Noise Reduction
 Choice: 71 51200 Multi Frame Noise Reduction
-Choice: 72 36864 Multi Frame Noise Reduction
-Choice: 73 8192 Multi Frame Noise Reduction
-Choice: 74 16384 Multi Frame Noise Reduction
-Choice: 75 65535 Multi Frame Noise Reduction
-Choice: 76 100 Multi Frame Noise Reduction
-Choice: 77 200 Multi Frame Noise Reduction
-Choice: 78 400 Multi Frame Noise Reduction
-Choice: 79 800 Multi Frame Noise Reduction
-Choice: 80 1600 Multi Frame Noise Reduction
-Choice: 81 3200 Multi Frame Noise Reduction
-Choice: 82 6400 Multi Frame Noise Reduction
-Choice: 83 12800 Multi Frame Noise Reduction
-Choice: 84 25600 Multi Frame Noise Reduction
-Choice: 85 51200 Multi Frame Noise Reduction
+Choice: 72 102400 Multi Frame Noise Reduction
+Choice: 73 204800 Multi Frame Noise Reduction
+Choice: 74 409600 Multi Frame Noise Reduction
+Choice: 75 Auto ISO Multi Frame Noise Reduction+
+Choice: 76 100 Multi Frame Noise Reduction+
+Choice: 77 200 Multi Frame Noise Reduction+
+Choice: 78 400 Multi Frame Noise Reduction+
+Choice: 79 800 Multi Frame Noise Reduction+
+Choice: 80 1600 Multi Frame Noise Reduction+
+Choice: 81 3200 Multi Frame Noise Reduction+
+Choice: 82 6400 Multi Frame Noise Reduction+
+Choice: 83 12800 Multi Frame Noise Reduction+
+Choice: 84 25600 Multi Frame Noise Reduction+
+Choice: 85 51200 Multi Frame Noise Reduction+
 /main/imgsettings/colortemperature
 Label: Color Temperature
 Type: TEXT

--- a/camlibs/ptp2/cameras/sony-a6400.txt
+++ b/camlibs/ptp2/cameras/sony-a6400.txt
@@ -167,23 +167,23 @@ Choice: 68 12800 Multi Frame Noise Reduction
 Choice: 69 16000 Multi Frame Noise Reduction
 Choice: 70 25600 Multi Frame Noise Reduction
 Choice: 71 51200 Multi Frame Noise Reduction
-Choice: 72 36864 Multi Frame Noise Reduction
-Choice: 73 8192 Multi Frame Noise Reduction
-Choice: 74 16384 Multi Frame Noise Reduction
-Choice: 75 65535 Multi Frame Noise Reduction
-Choice: 76 100 Multi Frame Noise Reduction
-Choice: 77 200 Multi Frame Noise Reduction
-Choice: 78 400 Multi Frame Noise Reduction
-Choice: 79 800 Multi Frame Noise Reduction
-Choice: 80 1600 Multi Frame Noise Reduction
-Choice: 81 3200 Multi Frame Noise Reduction
-Choice: 82 6400 Multi Frame Noise Reduction
-Choice: 83 12800 Multi Frame Noise Reduction
-Choice: 84 25600 Multi Frame Noise Reduction
-Choice: 85 51200 Multi Frame Noise Reduction
-Choice: 86 36864 Multi Frame Noise Reduction
-Choice: 87 8192 Multi Frame Noise Reduction
-Choice: 88 16384 Multi Frame Noise Reduction
+Choice: 72 102400 Multi Frame Noise Reduction
+Choice: 73 204800 Multi Frame Noise Reduction
+Choice: 74 409600 Multi Frame Noise Reduction
+Choice: 75 Auto ISO Multi Frame Noise Reduction+
+Choice: 76 100 Multi Frame Noise Reduction+
+Choice: 77 200 Multi Frame Noise Reduction+
+Choice: 78 400 Multi Frame Noise Reduction+
+Choice: 79 800 Multi Frame Noise Reduction+
+Choice: 80 1600 Multi Frame Noise Reduction+
+Choice: 81 3200 Multi Frame Noise Reduction+
+Choice: 82 6400 Multi Frame Noise Reduction+
+Choice: 83 12800 Multi Frame Noise Reduction+
+Choice: 84 25600 Multi Frame Noise Reduction+
+Choice: 85 51200 Multi Frame Noise Reduction+
+Choice: 86 102400 Multi Frame Noise Reduction+
+Choice: 87 204800 Multi Frame Noise Reduction+
+Choice: 88 409600 Multi Frame Noise Reduction+
 END
 /main/imgsettings/colortemperature
 Label: Color Temperature

--- a/camlibs/ptp2/cameras/sony-a7r.txt
+++ b/camlibs/ptp2/cameras/sony-a7r.txt
@@ -1325,20 +1325,20 @@ Choice: 68 12800 Multi Frame Noise Reduction
 Choice: 69 16000 Multi Frame Noise Reduction
 Choice: 70 25600 Multi Frame Noise Reduction
 Choice: 71 51200 Multi Frame Noise Reduction
-Choice: 72 36864 Multi Frame Noise Reduction
-Choice: 73 8192 Multi Frame Noise Reduction
-Choice: 74 16384 Multi Frame Noise Reduction
-Choice: 75 65535 Multi Frame Noise Reduction
-Choice: 76 100 Multi Frame Noise Reduction
-Choice: 77 200 Multi Frame Noise Reduction
-Choice: 78 400 Multi Frame Noise Reduction
-Choice: 79 800 Multi Frame Noise Reduction
-Choice: 80 1600 Multi Frame Noise Reduction
-Choice: 81 3200 Multi Frame Noise Reduction
-Choice: 82 6400 Multi Frame Noise Reduction
-Choice: 83 12800 Multi Frame Noise Reduction
-Choice: 84 25600 Multi Frame Noise Reduction
-Choice: 85 51200 Multi Frame Noise Reduction
+Choice: 72 102400 Multi Frame Noise Reduction
+Choice: 73 204800 Multi Frame Noise Reduction
+Choice: 74 409600 Multi Frame Noise Reduction
+Choice: 75 Auto ISO Multi Frame Noise Reduction+
+Choice: 76 100 Multi Frame Noise Reduction+
+Choice: 77 200 Multi Frame Noise Reduction+
+Choice: 78 400 Multi Frame Noise Reduction+
+Choice: 79 800 Multi Frame Noise Reduction+
+Choice: 80 1600 Multi Frame Noise Reduction+
+Choice: 81 3200 Multi Frame Noise Reduction+
+Choice: 82 6400 Multi Frame Noise Reduction+
+Choice: 83 12800 Multi Frame Noise Reduction+
+Choice: 84 25600 Multi Frame Noise Reduction+
+Choice: 85 51200 Multi Frame Noise Reduction+
 /main/imgsettings/colortemperature
 Label: Color Temperature
 Type: TEXT

--- a/camlibs/ptp2/cameras/sony-dsc-rx0.txt
+++ b/camlibs/ptp2/cameras/sony-dsc-rx0.txt
@@ -222,23 +222,23 @@ Choice: 68 12800 Multi Frame Noise Reduction
 Choice: 69 16000 Multi Frame Noise Reduction
 Choice: 70 25600 Multi Frame Noise Reduction
 Choice: 71 51200 Multi Frame Noise Reduction
-Choice: 72 36864 Multi Frame Noise Reduction
-Choice: 73 8192 Multi Frame Noise Reduction
-Choice: 74 16384 Multi Frame Noise Reduction
-Choice: 75 65535 Multi Frame Noise Reduction
-Choice: 76 100 Multi Frame Noise Reduction
-Choice: 77 200 Multi Frame Noise Reduction
-Choice: 78 400 Multi Frame Noise Reduction
-Choice: 79 800 Multi Frame Noise Reduction
-Choice: 80 1600 Multi Frame Noise Reduction
-Choice: 81 3200 Multi Frame Noise Reduction
-Choice: 82 6400 Multi Frame Noise Reduction
-Choice: 83 12800 Multi Frame Noise Reduction
-Choice: 84 25600 Multi Frame Noise Reduction
-Choice: 85 51200 Multi Frame Noise Reduction
-Choice: 86 36864 Multi Frame Noise Reduction
-Choice: 87 8192 Multi Frame Noise Reduction
-Choice: 88 16384 Multi Frame Noise Reduction
+Choice: 72 102400 Multi Frame Noise Reduction
+Choice: 73 204800 Multi Frame Noise Reduction
+Choice: 74 409600 Multi Frame Noise Reduction
+Choice: 75 Auto ISO Multi Frame Noise Reduction+
+Choice: 76 100 Multi Frame Noise Reduction+
+Choice: 77 200 Multi Frame Noise Reduction+
+Choice: 78 400 Multi Frame Noise Reduction+
+Choice: 79 800 Multi Frame Noise Reduction+
+Choice: 80 1600 Multi Frame Noise Reduction+
+Choice: 81 3200 Multi Frame Noise Reduction+
+Choice: 82 6400 Multi Frame Noise Reduction+
+Choice: 83 12800 Multi Frame Noise Reduction+
+Choice: 84 25600 Multi Frame Noise Reduction+
+Choice: 85 51200 Multi Frame Noise Reduction+
+Choice: 86 102400 Multi Frame Noise Reduction+
+Choice: 87 204800 Multi Frame Noise Reduction+
+Choice: 88 409600 Multi Frame Noise Reduction+
 END
 /main/imgsettings/colortemperature
 Label: Color Temperature

--- a/camlibs/ptp2/cameras/sony-dsc-rx100m5.txt
+++ b/camlibs/ptp2/cameras/sony-dsc-rx100m5.txt
@@ -172,20 +172,20 @@ Choice: 68 12800 Multi Frame Noise Reduction
 Choice: 69 16000 Multi Frame Noise Reduction
 Choice: 70 25600 Multi Frame Noise Reduction
 Choice: 71 51200 Multi Frame Noise Reduction
-Choice: 72 36864 Multi Frame Noise Reduction
-Choice: 73 8192 Multi Frame Noise Reduction
-Choice: 74 16384 Multi Frame Noise Reduction
-Choice: 75 65535 Multi Frame Noise Reduction
-Choice: 76 100 Multi Frame Noise Reduction
-Choice: 77 200 Multi Frame Noise Reduction
-Choice: 78 400 Multi Frame Noise Reduction
-Choice: 79 800 Multi Frame Noise Reduction
-Choice: 80 1600 Multi Frame Noise Reduction
-Choice: 81 3200 Multi Frame Noise Reduction
-Choice: 82 6400 Multi Frame Noise Reduction
-Choice: 83 12800 Multi Frame Noise Reduction
-Choice: 84 25600 Multi Frame Noise Reduction
-Choice: 85 51200 Multi Frame Noise Reduction
+Choice: 72 102400 Multi Frame Noise Reduction
+Choice: 73 204800 Multi Frame Noise Reduction
+Choice: 74 409600 Multi Frame Noise Reduction
+Choice: 75 Auto ISO Multi Frame Noise Reduction+
+Choice: 76 100 Multi Frame Noise Reduction+
+Choice: 77 200 Multi Frame Noise Reduction+
+Choice: 78 400 Multi Frame Noise Reduction+
+Choice: 79 800 Multi Frame Noise Reduction+
+Choice: 80 1600 Multi Frame Noise Reduction+
+Choice: 81 3200 Multi Frame Noise Reduction+
+Choice: 82 6400 Multi Frame Noise Reduction+
+Choice: 83 12800 Multi Frame Noise Reduction+
+Choice: 84 25600 Multi Frame Noise Reduction+
+Choice: 85 51200 Multi Frame Noise Reduction+
 /main/imgsettings/colortemperature
 Label: Color Temperature
 Type: TEXT

--- a/camlibs/ptp2/cameras/sony-rx10-3.txt
+++ b/camlibs/ptp2/cameras/sony-rx10-3.txt
@@ -177,20 +177,20 @@ Choice: 68 12800 Multi Frame Noise Reduction
 Choice: 69 16000 Multi Frame Noise Reduction
 Choice: 70 25600 Multi Frame Noise Reduction
 Choice: 71 51200 Multi Frame Noise Reduction
-Choice: 72 36864 Multi Frame Noise Reduction
-Choice: 73 8192 Multi Frame Noise Reduction
-Choice: 74 16384 Multi Frame Noise Reduction
-Choice: 75 65535 Multi Frame Noise Reduction
-Choice: 76 100 Multi Frame Noise Reduction
-Choice: 77 200 Multi Frame Noise Reduction
-Choice: 78 400 Multi Frame Noise Reduction
-Choice: 79 800 Multi Frame Noise Reduction
-Choice: 80 1600 Multi Frame Noise Reduction
-Choice: 81 3200 Multi Frame Noise Reduction
-Choice: 82 6400 Multi Frame Noise Reduction
-Choice: 83 12800 Multi Frame Noise Reduction
-Choice: 84 25600 Multi Frame Noise Reduction
-Choice: 85 51200 Multi Frame Noise Reduction
+Choice: 72 102400 Multi Frame Noise Reduction
+Choice: 73 204800 Multi Frame Noise Reduction
+Choice: 74 409600 Multi Frame Noise Reduction
+Choice: 75 Auto ISO Multi Frame Noise Reduction+
+Choice: 76 100 Multi Frame Noise Reduction+
+Choice: 77 200 Multi Frame Noise Reduction+
+Choice: 78 400 Multi Frame Noise Reduction+
+Choice: 79 800 Multi Frame Noise Reduction+
+Choice: 80 1600 Multi Frame Noise Reduction+
+Choice: 81 3200 Multi Frame Noise Reduction+
+Choice: 82 6400 Multi Frame Noise Reduction+
+Choice: 83 12800 Multi Frame Noise Reduction+
+Choice: 84 25600 Multi Frame Noise Reduction+
+Choice: 85 51200 Multi Frame Noise Reduction+
 /main/imgsettings/colortemperature
 Label: Color Temperature
 Type: TEXT

--- a/camlibs/ptp2/cameras/sony-rx100m4.txt
+++ b/camlibs/ptp2/cameras/sony-rx100m4.txt
@@ -144,20 +144,20 @@ Choice: 68 12800 Multi Frame Noise Reduction
 Choice: 69 16000 Multi Frame Noise Reduction
 Choice: 70 25600 Multi Frame Noise Reduction
 Choice: 71 51200 Multi Frame Noise Reduction
-Choice: 72 36864 Multi Frame Noise Reduction
-Choice: 73 8192 Multi Frame Noise Reduction
-Choice: 74 16384 Multi Frame Noise Reduction
-Choice: 75 65535 Multi Frame Noise Reduction
-Choice: 76 100 Multi Frame Noise Reduction
-Choice: 77 200 Multi Frame Noise Reduction
-Choice: 78 400 Multi Frame Noise Reduction
-Choice: 79 800 Multi Frame Noise Reduction
-Choice: 80 1600 Multi Frame Noise Reduction
-Choice: 81 3200 Multi Frame Noise Reduction
-Choice: 82 6400 Multi Frame Noise Reduction
-Choice: 83 12800 Multi Frame Noise Reduction
-Choice: 84 25600 Multi Frame Noise Reduction
-Choice: 85 51200 Multi Frame Noise Reduction
+Choice: 72 102400 Multi Frame Noise Reduction
+Choice: 73 204800 Multi Frame Noise Reduction
+Choice: 74 409600 Multi Frame Noise Reduction
+Choice: 75 Auto ISO Multi Frame Noise Reduction+
+Choice: 76 100 Multi Frame Noise Reduction+
+Choice: 77 200 Multi Frame Noise Reduction+
+Choice: 78 400 Multi Frame Noise Reduction+
+Choice: 79 800 Multi Frame Noise Reduction+
+Choice: 80 1600 Multi Frame Noise Reduction+
+Choice: 81 3200 Multi Frame Noise Reduction+
+Choice: 82 6400 Multi Frame Noise Reduction+
+Choice: 83 12800 Multi Frame Noise Reduction+
+Choice: 84 25600 Multi Frame Noise Reduction+
+Choice: 85 51200 Multi Frame Noise Reduction+
 END
 /main/imgsettings/colortemperature
 Label: Color Temperature

--- a/camlibs/ptp2/cameras/sony-rx100m5.txt
+++ b/camlibs/ptp2/cameras/sony-rx100m5.txt
@@ -199,20 +199,20 @@ Choice: 68 12800 Multi Frame Noise Reduction
 Choice: 69 16000 Multi Frame Noise Reduction
 Choice: 70 25600 Multi Frame Noise Reduction
 Choice: 71 51200 Multi Frame Noise Reduction
-Choice: 72 36864 Multi Frame Noise Reduction
-Choice: 73 8192 Multi Frame Noise Reduction
-Choice: 74 16384 Multi Frame Noise Reduction
-Choice: 75 65535 Multi Frame Noise Reduction
-Choice: 76 100 Multi Frame Noise Reduction
-Choice: 77 200 Multi Frame Noise Reduction
-Choice: 78 400 Multi Frame Noise Reduction
-Choice: 79 800 Multi Frame Noise Reduction
-Choice: 80 1600 Multi Frame Noise Reduction
-Choice: 81 3200 Multi Frame Noise Reduction
-Choice: 82 6400 Multi Frame Noise Reduction
-Choice: 83 12800 Multi Frame Noise Reduction
-Choice: 84 25600 Multi Frame Noise Reduction
-Choice: 85 51200 Multi Frame Noise Reduction
+Choice: 72 102400 Multi Frame Noise Reduction
+Choice: 73 204800 Multi Frame Noise Reduction
+Choice: 74 409600 Multi Frame Noise Reduction
+Choice: 75 Auto ISO Multi Frame Noise Reduction+
+Choice: 76 100 Multi Frame Noise Reduction+
+Choice: 77 200 Multi Frame Noise Reduction+
+Choice: 78 400 Multi Frame Noise Reduction+
+Choice: 79 800 Multi Frame Noise Reduction+
+Choice: 80 1600 Multi Frame Noise Reduction+
+Choice: 81 3200 Multi Frame Noise Reduction+
+Choice: 82 6400 Multi Frame Noise Reduction+
+Choice: 83 12800 Multi Frame Noise Reduction+
+Choice: 84 25600 Multi Frame Noise Reduction+
+Choice: 85 51200 Multi Frame Noise Reduction+
 END
 /main/imgsettings/colortemperature
 Label: Color Temperature

--- a/camlibs/ptp2/cameras/sony-rx100m5a.txt
+++ b/camlibs/ptp2/cameras/sony-rx100m5a.txt
@@ -208,23 +208,23 @@ Choice: 66 12800 Multi Frame Noise Reduction
 Choice: 67 16000 Multi Frame Noise Reduction
 Choice: 68 25600 Multi Frame Noise Reduction
 Choice: 69 51200 Multi Frame Noise Reduction
-Choice: 70 36864 Multi Frame Noise Reduction
-Choice: 71 8192 Multi Frame Noise Reduction
-Choice: 72 16384 Multi Frame Noise Reduction
-Choice: 73 65535 Multi Frame Noise Reduction
-Choice: 74 100 Multi Frame Noise Reduction
-Choice: 75 200 Multi Frame Noise Reduction
-Choice: 76 400 Multi Frame Noise Reduction
-Choice: 77 800 Multi Frame Noise Reduction
-Choice: 78 1600 Multi Frame Noise Reduction
-Choice: 79 3200 Multi Frame Noise Reduction
-Choice: 80 6400 Multi Frame Noise Reduction
-Choice: 81 12800 Multi Frame Noise Reduction
-Choice: 82 25600 Multi Frame Noise Reduction
-Choice: 83 51200 Multi Frame Noise Reduction
-Choice: 84 36864 Multi Frame Noise Reduction
-Choice: 85 8192 Multi Frame Noise Reduction
-Choice: 86 16384 Multi Frame Noise Reduction
+Choice: 70 102400 Multi Frame Noise Reduction
+Choice: 71 204800 Multi Frame Noise Reduction
+Choice: 72 409600 Multi Frame Noise Reduction
+Choice: 73 Auto ISO Multi Frame Noise Reduction+
+Choice: 74 100 Multi Frame Noise Reduction+
+Choice: 75 200 Multi Frame Noise Reduction+
+Choice: 76 400 Multi Frame Noise Reduction+
+Choice: 77 800 Multi Frame Noise Reduction+
+Choice: 78 1600 Multi Frame Noise Reduction+
+Choice: 79 3200 Multi Frame Noise Reduction+
+Choice: 80 6400 Multi Frame Noise Reduction+
+Choice: 81 12800 Multi Frame Noise Reduction+
+Choice: 82 25600 Multi Frame Noise Reduction+
+Choice: 83 51200 Multi Frame Noise Reduction+
+Choice: 84 102400 Multi Frame Noise Reduction+
+Choice: 85 204800 Multi Frame Noise Reduction+
+Choice: 86 409600 Multi Frame Noise Reduction+
 END
 /main/imgsettings/colortemperature
 Label: Color Temperature

--- a/camlibs/ptp2/cameras/sony-rx100m6.txt
+++ b/camlibs/ptp2/cameras/sony-rx100m6.txt
@@ -216,23 +216,23 @@ Choice: 66 12800 Multi Frame Noise Reduction
 Choice: 67 16000 Multi Frame Noise Reduction
 Choice: 68 25600 Multi Frame Noise Reduction
 Choice: 69 51200 Multi Frame Noise Reduction
-Choice: 70 36864 Multi Frame Noise Reduction
-Choice: 71 8192 Multi Frame Noise Reduction
-Choice: 72 16384 Multi Frame Noise Reduction
-Choice: 73 65535 Multi Frame Noise Reduction
-Choice: 74 100 Multi Frame Noise Reduction
-Choice: 75 200 Multi Frame Noise Reduction
-Choice: 76 400 Multi Frame Noise Reduction
-Choice: 77 800 Multi Frame Noise Reduction
-Choice: 78 1600 Multi Frame Noise Reduction
-Choice: 79 3200 Multi Frame Noise Reduction
-Choice: 80 6400 Multi Frame Noise Reduction
-Choice: 81 12800 Multi Frame Noise Reduction
-Choice: 82 25600 Multi Frame Noise Reduction
-Choice: 83 51200 Multi Frame Noise Reduction
-Choice: 84 36864 Multi Frame Noise Reduction
-Choice: 85 8192 Multi Frame Noise Reduction
-Choice: 86 16384 Multi Frame Noise Reduction
+Choice: 70 102400 Multi Frame Noise Reduction
+Choice: 71 204800 Multi Frame Noise Reduction
+Choice: 72 409600 Multi Frame Noise Reduction
+Choice: 73 Auto ISO Multi Frame Noise Reduction+
+Choice: 74 100 Multi Frame Noise Reduction+
+Choice: 75 200 Multi Frame Noise Reduction+
+Choice: 76 400 Multi Frame Noise Reduction+
+Choice: 77 800 Multi Frame Noise Reduction+
+Choice: 78 1600 Multi Frame Noise Reduction+
+Choice: 79 3200 Multi Frame Noise Reduction+
+Choice: 80 6400 Multi Frame Noise Reduction+
+Choice: 81 12800 Multi Frame Noise Reduction+
+Choice: 82 25600 Multi Frame Noise Reduction+
+Choice: 83 51200 Multi Frame Noise Reduction+
+Choice: 84 102400 Multi Frame Noise Reduction+
+Choice: 85 204800 Multi Frame Noise Reduction+
+Choice: 86 409600 Multi Frame Noise Reduction+
 END
 /main/imgsettings/colortemperature
 Label: Color Temperature

--- a/camlibs/ptp2/cameras/sony-rx1rm2.txt
+++ b/camlibs/ptp2/cameras/sony-rx1rm2.txt
@@ -199,20 +199,20 @@ Choice: 68 12800 Multi Frame Noise Reduction
 Choice: 69 16000 Multi Frame Noise Reduction
 Choice: 70 25600 Multi Frame Noise Reduction
 Choice: 71 51200 Multi Frame Noise Reduction
-Choice: 72 36864 Multi Frame Noise Reduction
-Choice: 73 8192 Multi Frame Noise Reduction
-Choice: 74 16384 Multi Frame Noise Reduction
-Choice: 75 65535 Multi Frame Noise Reduction
-Choice: 76 100 Multi Frame Noise Reduction
-Choice: 77 200 Multi Frame Noise Reduction
-Choice: 78 400 Multi Frame Noise Reduction
-Choice: 79 800 Multi Frame Noise Reduction
-Choice: 80 1600 Multi Frame Noise Reduction
-Choice: 81 3200 Multi Frame Noise Reduction
-Choice: 82 6400 Multi Frame Noise Reduction
-Choice: 83 12800 Multi Frame Noise Reduction
-Choice: 84 25600 Multi Frame Noise Reduction
-Choice: 85 51200 Multi Frame Noise Reduction
+Choice: 72 102400 Multi Frame Noise Reduction
+Choice: 73 204800 Multi Frame Noise Reduction
+Choice: 74 409600 Multi Frame Noise Reduction
+Choice: 75 Auto ISO Multi Frame Noise Reduction+
+Choice: 76 100 Multi Frame Noise Reduction+
+Choice: 77 200 Multi Frame Noise Reduction+
+Choice: 78 400 Multi Frame Noise Reduction+
+Choice: 79 800 Multi Frame Noise Reduction+
+Choice: 80 1600 Multi Frame Noise Reduction+
+Choice: 81 3200 Multi Frame Noise Reduction+
+Choice: 82 6400 Multi Frame Noise Reduction+
+Choice: 83 12800 Multi Frame Noise Reduction+
+Choice: 84 25600 Multi Frame Noise Reduction+
+Choice: 85 51200 Multi Frame Noise Reduction+
 END
 /main/imgsettings/colortemperature
 Label: Color Temperature


### PR DESCRIPTION
This PR contains various fixes for Multi-Frame Noise Reduction ISO mode in Sony cameras.

 - Add support for distinguishing Standard vs High modes for Multi Frame Noise Reduction.
 
   Previously those would be rendered as separate options with the same name, making it impossible to choose the correct one or switch from one to another.
 
   Now the high mode is indicated by the `+` suffix.
 - Fix higher ISO values for MFNR too.
 
   Previously a mask 0xffff was used, which was incorrect and didn't cover higher ISO values. As a result, they were rendered incorrectly.
   
   Instead, base ISO should be read with 0x00ff_ffff mask, and the highest byte then indicates the MFNR mode (0 for disabled, 1 for Standard, 2 for High). This also simplifies the logic for Auto ISO, since it's correctly covered by the updated mask.

I also went ahead and wrote a one-off script to update .txt files for Sony cameras to show the fixed values.