### PR TITLE
Mark properties without setters as readonly

### DIFF
--- a/camlibs/canon/library.c
+++ b/camlibs/canon/library.c
@@ -1911,6 +1911,7 @@ camera_get_config (Camera *camera, CameraWidget **window, GPContext *context)
 	gp_widget_new (GP_WIDGET_TEXT, _("Camera Model"), &t);
 	gp_widget_set_name (t, "model");
 	gp_widget_set_value (t, camera->pl->ident);
+	gp_widget_set_readonly (t, 1);
 	gp_widget_append (section, t);
 
 	gp_widget_new (GP_WIDGET_TEXT, _("Date and Time"), &t);
@@ -1923,6 +1924,7 @@ camera_get_config (Camera *camera, CameraWidget **window, GPContext *context)
 	} else {
 		gp_widget_set_value (t, _("Error"));
 	}
+	gp_widget_set_readonly (t, 1);
 	gp_widget_append (section, t);
 
 	gp_widget_new (GP_WIDGET_TEXT, _("Firmware Version"), &t);
@@ -1930,6 +1932,7 @@ camera_get_config (Camera *camera, CameraWidget **window, GPContext *context)
 	sprintf (firm, "%i.%i.%i.%i", camera->pl->firmwrev[3], camera->pl->firmwrev[2],
 		 camera->pl->firmwrev[1], camera->pl->firmwrev[0]);
 	gp_widget_set_value (t, firm);
+	gp_widget_set_readonly (t, 1);
 	gp_widget_append (section, t);
 
 	canon_get_batt_status (camera, &pwr_status, &pwr_source, context);
@@ -1948,6 +1951,7 @@ camera_get_config (Camera *camera, CameraWidget **window, GPContext *context)
 	gp_widget_new (GP_WIDGET_TEXT, _("Power"), &t);
 	gp_widget_set_name (t, "power");
 	gp_widget_set_value (t, power_str);
+	gp_widget_set_readonly (t, 1);
 	gp_widget_append (section, t);
 
 

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -10734,6 +10734,9 @@ _get_config (Camera *camera, const char *confname, CameraWidget **outwidget, Cam
 
 						GP_LOG_D ("Getting function prop '%s' / 0x%04x", cursub->label, cursub->type );
 						ret = cursub->getfunc (camera, &widget, cursub, NULL);
+						if (ret == GP_OK && cursub->putfunc == _put_None) {
+							gp_widget_set_readonly(widget, 1);
+						}
 						if (mode == MODE_SINGLE_GET) {
 							*outwidget = widget;
 							free (setprops);
@@ -10769,6 +10772,9 @@ _get_config (Camera *camera, const char *confname, CameraWidget **outwidget, Cam
 					GP_LOG_D ("Failed to parse value of property '%s' / 0x%04x: error code %d", cursub->label, cursub->propid, ret);
 					continue;
 				}
+				if (cursub->putfunc == _put_None) {
+					gp_widget_set_readonly(widget, 1);
+				}
 				if (mode == MODE_SINGLE_GET) {
 					*outwidget = widget;
 					free (setprops);
@@ -10794,6 +10800,9 @@ _get_config (Camera *camera, const char *confname, CameraWidget **outwidget, Cam
 				if (ret != GP_OK) {
 					GP_LOG_D ("Failed to parse value of property '%s' / 0x%04x: error code %d", cursub->label, cursub->propid, ret);
 					continue;
+				}
+				if (cursub->putfunc == _put_None) {
+					gp_widget_set_readonly(widget, 1);
 				}
 				if (mode == MODE_SINGLE_GET) {
 					*outwidget = widget;


### PR DESCRIPTION
Without this, widgets for things like "Serial Number", "Manufacturer", "Battery level" etc. would be created as writable, even though they are not.

It it possible to special case them in GUI frontends when rendering (e.g. by making everything under "status" section readonly anyway), but it seems better to return correct readonly status for such properties from libgphoto2 itself.