### PR TITLE
Normalize Sony shutter speeds

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -5059,6 +5059,14 @@ _get_Sony_ShutterSpeed(CONFIG_GET_ARGS) {
 			x = dpd->FORM.Enum.SupportedValue[i].u32 >> 16;
 			y = dpd->FORM.Enum.SupportedValue[i].u32 & 0xffff;
 
+			// Sony reports high shutter speeds as 300/10, 250/10, etc.
+			// Normalize them to integers for better output and to match
+			// `sony_shuttertable` format.
+			if (y == 10 && x % 10 == 0) {
+				x /= 10;
+				y = 1;
+			}
+
 			if (y == 1)
 				sprintf (buf, "%d",x);
 			else
@@ -5086,6 +5094,13 @@ _get_Sony_ShutterSpeed(CONFIG_GET_ARGS) {
 	} else {
 		x = dpd->CurrentValue.u32>>16;
 		y = dpd->CurrentValue.u32&0xffff;
+
+		// Normalize current value from 300/10, 250/10 etc. to integers too.
+		if (y == 10 && x % 10 == 0) {
+			x /= 10;
+			y = 1;
+		}
+
 		if (y == 1)
 			sprintf (buf, "%d",x);
 		else


### PR DESCRIPTION
Apparently Sony reports shutter speeds that are integer seconds as "300/10", "250/10", "200/10" etc. This happens both on Sony a6600 I currently have as well as I can see this when searching for 0xd229 among camlibs/sony-*.txt - that is, even models with enums use this format.

Interestigly, setting shutter speeds accept either form, so what happened is you could set shutter speed to e.g. "5" and camera would change it, but then camera would report back "50/10" which is no longer valid value for the shutter speed widget.

This PR normalizes all such shutter speeds to their integer form, so that "5" would be reported back as well in such scenario.