### PR TITLE
Fix memory leak in capture preview for Sony

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -3603,6 +3603,8 @@ enable_liveview:
 				continue;
 			}
 
+			ptp_free_objectinfo(&oi);
+
 			ret = ptp_getobject_with_size(params, preview_object, &ximage, &size);
 			if (ret == PTP_RC_OK)
 				break;


### PR DESCRIPTION
I've noticed consistent memory increase while streaming preview from a Sony camera. Building with `-fsanitize=leak` revealed that the leak is coming from `strdup <- ptp_unpack_string <- ptp_unpack_OI <- ptp_getobjectinfo`.

Apparently, `PTPObjectInfo` contains heap-allocated strings for `Filename` & `Keywords`, and so `ptp_free_objectinfo` always must be called on the `ptp_getobjectinfo` results.

That all sounds good, but what seriously worries me is that, after fixing this particular codepath for PTP_VENDOR_SONY, I've searched for other usages of `ptp_getobjectinfo`, and majority of them don't ever call `ptp_free_objectinfo` on the result.

That is, there's probably tons of other leaks out there for various cameras just out of this single call, and someone needs to go through all those usages and fix them one by one. While it might be a simple refactoring, it requires great care and I'm not ready to invest into it especially when there's no way of testing the result with other camera models.

Perhaps a more systematic fix is necessary - for example, `PTPObjectInfo` could be changed to contain fixed-length char arrays and sidestep this problem altogether.

More generally, it might be also worth running GPhoto's tests with address & leak sanitizers enabled to detect all such similar problems.