### PR TITLE
camlibs/ptp2/ptp-pack.c: Fix aperture on EOS RP

### DIFF
--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -2607,11 +2607,7 @@ ptp_unpack_CANON_changes (PTPParams *params, unsigned char* data, unsigned int d
 				proptype = PTP_DPC_CANON_EOS_Aperture;
 				dpd = _lookup_or_allocate_canon_prop(params, proptype);
 				if (olcver >= 0x12) {
-					if (olcver == 0x13) {
-						dpd->CurrentValue.u16 = curdata[curoff+7]; /* R5 */
-					} else {
-						dpd->CurrentValue.u16 = curdata[curoff+5]; /* CHECK */
-					}
+					dpd->CurrentValue.u16 = curdata[curoff+7]; /* RP, R5, etc */
 				} else {
 					dpd->CurrentValue.u16 = curdata[curoff+4]; /* just use last byte */
 				}


### PR DESCRIPTION
My wife's EOS RP (FW 1.4.0) always reports the lens' lowest aperture unless we apply the same special handling which is enabled for `olcver == 0x13` (apparently, EOS R5). Tested with RF 35/1.8, and also on 5Div + Sigma 35 Art (to check a possible regression).

This reverts commit 5bf98e7f09e82d0e27f41a8df4ccb10e5feb6944 (and fixes a comment so that it more accurately reflects what's going on). I'm a bit nervous about this because that commit looks like it was explicitly designed to do the exact opposite of this one, but perhaps it was just to be extra cautious?

Cc: @arkellr @msmeissn 