### PR TITLE
gh workflows: remove requirements for flex, bison

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: apt-get install
-      run: sudo apt-get update && sudo apt-get install -y autopoint gettext libusb-1.0-0-dev libcurl4-openssl-dev bison flex
+      run: sudo apt-get update && sudo apt-get install -y autopoint gettext libusb-1.0-0-dev libcurl4-openssl-dev
     - name: autoreconf
       run: autoreconf -i -f
     - name: configure

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
 
     # install all necessary things
-    - run: sudo apt-get update && sudo apt-get install -y autopoint gettext libusb-1.0-0-dev libcurl4-openssl-dev bison flex
+    - run: sudo apt-get update && sudo apt-get install -y autopoint gettext libusb-1.0-0-dev libcurl4-openssl-dev
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
As 4316f75ed4ce7a4ae5296264699665631c4e62d6 has removed gp2ddb with its use of `flex` and `bison`, we do not need `flex` and `bison` any more, and so the github workflows do not need to install `flex` and `bison` either.

I have made this a PR mainly to get github to actually run the workflows to check.