### PR TITLE
Add mode dial positions available on EOS RP or 5Div

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -2048,9 +2048,13 @@ static struct deviceproptableu16 canon_eos_autoexposuremode[] = {
 	{ N_("Closeup"),	0x000e, 0 },
 	{ N_("Flash Off"),	0x000f, 0 },
 
+	{ N_("C2"),			0x0010, 0 },
+	{ N_("C3"),			0x0011, 0 },
+	{ N_("Movie"),			0x0014, 0 },
 	{ N_("Auto"),			0x0016, 0 },	/* EOS M6 Mark 2 */
 	{ N_("Handheld Night Scene"),	0x0017, 0 },	/* EOS M6 Mark 2 */
 	{ N_("HDR Backlight Control"),	0x0018, 0 },	/* EOS M6 Mark 2 */
+	{ N_("SCN"),			0x0019, 0 },
 	{ N_("Food"),			0x001b, 0 },	/* EOS M6 Mark 2 */
 	{ N_("Grainy B/W"),		0x001e, 0 },	/* EOS M6 Mark 2 */
 	{ N_("Soft focus"),		0x001f, 0 },	/* EOS M6 Mark 2 */

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -2067,6 +2067,7 @@ static struct deviceproptableu16 canon_eos_autoexposuremode[] = {
 	{ N_("HDR art bold"),		0x0026, 0 },	/* EOS M6 Mark 2 */
 	{ N_("HDR art embossed"),	0x0027, 0 },	/* EOS M6 Mark 2 */
 	{ N_("Panning"),		0x002d, 0 },	/* EOS M6 Mark 2 */
+	{ N_("HDR"),			0x0031, 0 },
 	{ N_("Self Portrait"),		0x0032, 0 },	/* EOS M6 Mark 2 */
 	{ N_("Hybrid Auto"),		0x0033, 0 },	/* EOS M6 Mark 2 */
 	{ N_("Smooth skin"),		0x0034, 0 },	/* EOS M6 Mark 2 */


### PR DESCRIPTION
I picked C2 and C3 while the existing one is called "Custom"; I think the naming is a bit ad hoc (full words like "Manual" and "Bulb" vs. all-caps abbreviations "AV" and "TV" vs. "Fv" which is spelt as-is on the mode dial).

Also add the "HDR" thingy for HDR movies as available on RP.