### PR TITLE
On win change default camlibs/iolibs directories

### DIFF
--- a/gphoto2/gphoto2-abilities-list.h
+++ b/gphoto2/gphoto2-abilities-list.h
@@ -196,6 +196,11 @@ const char *gp_message_codeset (const char *);
  */
 #ifdef _GPHOTO2_INTERNAL_CODE
 #define CAMLIBDIR_ENV "CAMLIBS"
+#ifdef WIN32
+#ifndef CAMLIBS
+#define CAMLIBS "./libgphoto2"
+#endif
+#endif
 #endif /* _GPHOTO2_INTERNAL_CODE */
 
 

--- a/gphoto2/gphoto2.h
+++ b/gphoto2/gphoto2.h
@@ -39,7 +39,7 @@ extern "C" {
 
 #ifdef WIN32
 #ifndef CAMLIBS
-#define CAMLIBS "."
+#define CAMLIBS "./libgphoto2"
 #endif
 #endif
 

--- a/libgphoto2_port/gphoto2/gphoto2-port-portability.h
+++ b/libgphoto2_port/gphoto2/gphoto2-port-portability.h
@@ -38,7 +38,7 @@
 # include <direct.h>
 
 # ifndef IOLIBS
-#  define IOLIBS			"."
+#  define IOLIBS		"./libgphoto2_port"
 # endif
 # define strcasecmp		_stricmp
 # ifndef snprintf


### PR DESCRIPTION
Currently, when cross-compiling for the win, it installs camlibs/iolibs to the cross-compiler environment, e.g. for the camlibs some strange path like `/home/user/crosscompiler-env/.../libgphoto2/2.5.27/`. But later when the bundled resulting package is installed on the win, the path needs to something like `C:\Program Files\Program\`. For the win it seems libgphoto2 defines the default camlibs/iolibs load dir as `.`, which should work. Unfortunately, when bundling packages for win, there can be hundreds of DLLs, which may slow down startup of the libgphoto2, because it's testing the DLLs, whether they are camlibs/iolibs. Defining the environment variables IOLIBS/CAMLIBS_ENV works, but it's complication.

This PR propose changing the default runtime load dir to the `./libgphoto2` for camlibs and `./libgphoto2_port` for iolibs.

But there is another problem, because the `configure` script doesn't have switch for the runtime dir and overrides the code defaults with the installdir. I.e. it explicitly adds to the CFLAGS `-DIOLIBS=IOLIBS_INSTALL_PATH` and `-DCAMLIBS=CAMLIBS_INSTALL_PATH` that are the 'strange' paths to the cross compiler. I temporally resolved it by:
```
--- a/configure.ac
+++ b/configure.ac
@@ -521,7 +534,6 @@ AC_ARG_WITH([camlibdir],[AS_HELP_STRING(
 ])
 AC_MSG_RESULT([${camlibdir}])
 AC_SUBST([camlibdir])
-AM_CPPFLAGS="$AM_CPPFLAGS -DCAMLIBS=\\\"\$(camlibdir)\\\""
 


--- a/libgphoto2_port/configure.ac
+++ b/libgphoto2_port/configure.ac
@@ -468,7 +468,6 @@ for x in ${IOLIB_LIST}; do
 done
 AC_SUBST(IOLIB_LTLIST)
 AC_SUBST([iolibdir],["\$(libdir)/\$(PACKAGE_TARNAME)/\$(VERSION)"])
-AM_CPPFLAGS="$AM_CPPFLAGS -DIOLIBS=\\\"${iolibdir}\\\""
 
 sorted_iolib_list="$(echo "${IOLIB_LIST}" | tr ' ' '\n' | sort | ${SED} '/^$/d' | tr '\n' ' ' | ${SED} 's/ $//')"
 AC_DEFINE_UNQUOTED([IOLIB_LIST], ["${sorted_iolib_list}"], [Define as string containing a list of the iolibs])
```

I think this should be resolved somehow, e.g.:
- on win do not explicitly add the -DIOLIBS/CAMLIBS
- add `configure` switch allowing override of the runtime load dirs

There is e.g. #251 which is related.
