### PR TITLE
configure: Allow --with-jpeg=yes argument again

### DIFF
--- a/libgphoto2_port/gphoto-m4/gp-libjpeg.m4
+++ b/libgphoto2_port/gphoto-m4/gp-libjpeg.m4
@@ -2,9 +2,14 @@ dnl ####################################################################
 dnl GP_LIBJPEG
 dnl ####################################################################
 dnl
+dnl Define the libjpeg related compile and linker flags depending on
+dnl configure arguments and availability on the system.
+dnl
 dnl   * If --without-jpeg or --with-jpeg=no is given, build without
 dnl     libjpeg support.
-dnl   * If not explicitly disabled by --without-jpeg, autodetect libjpeg.
+dnl
+dnl   * If --with-jpeg=auto or --with-jpeg=autodetect is given,
+dnl     autodetect libjpeg:
 dnl       * If any of LIBJPEG_(CFLAGS|LIBS) is explicitly given, try
 dnl         compile+link using that.
 dnl          * If compile+link works, use that.
@@ -18,28 +23,87 @@ dnl          * If libjpeg.pc has not been found, try default location.
 dnl              * If compile+link works, use that.
 dnl              * If compile+link fails, build without libjpeg.
 dnl
+dnl   * If --with-jpeg or --with-jpeg=yes is given, autodetect as
+dnl     described above, but abort with an error message if libjpeg
+dnl     could not be found.
+dnl
+dnl   * If neither --with-jpeg nor --without-jpeg are explicitly given,
+dnl     run the above autodetect sequence.
+dnl
 AC_DEFUN([GP_LIBJPEG], [dnl
 dnl
 AC_MSG_CHECKING([whether to build with libjpeg])
 AC_ARG_WITH([jpeg],
             [AS_HELP_STRING([--without-jpeg],
-                            [Build without libjpeg (default: with libjpeg)])],
-            [dnl just keep the with-jpeg however it is given
-  AS_VAR_IF([with_jpeg], [no], [], [dnl
-    AC_MSG_ERROR([
-Unhandled value given to --with-jpeg / --without-jpeg: '$with_jpeg'
+                            [Build without libjpeg (default: autodetect)])],
+            [dnl Normalize --with-jpeg=ARG argument value
+  AS_CASE([$with_jpeg],
+    [autodetect], [with_jpeg=auto],
+  )
+], [dnl Default value
+  with_jpeg=auto
 ])
-  ])
-], [dnl
-  with_jpeg=autodetect
-])
+dnl
 AC_MSG_RESULT([$with_jpeg])
 dnl
-AS_VAR_IF([with_jpeg], [no], [dnl Not using libjpeg, so no checks are needed
+AS_CASE([$with_jpeg],
+[no], [
   # libjpeg explictly disabled from command line
   GP_CONFIG_MSG([JPEG mangling support],
                 [no (disabled by --without-jpeg)])
-], [dnl
+],
+[auto|yes], [
+  GP_LIBJPEG_AUTODETECT
+
+  AS_VAR_IF([have_libjpeg], [no], [dnl
+    AS_VAR_IF([with_jpeg], [yes], [dnl
+      AC_MSG_ERROR([
+libjpeg has been requested explicitly (--with-jpeg=yes), but could not be
+found and made to work.
+])
+    ], [dnl
+      GP_CONFIG_MSG([JPEG mangling support],
+                    [${have_libjpeg} (could not find working libjpeg)])
+    ])
+  ], [dnl
+    AC_DEFINE([HAVE_LIBJPEG], [1],
+              [define if building with libjpeg])
+    GP_CONFIG_MSG([JPEG mangling support],
+                  [${have_libjpeg}])
+  ])
+],
+[AC_MSG_ERROR([
+Unhandled value given to --with-jpeg: ${with_jpeg}
+
+To allow the auto-detection of libjpeg, set up the pkg-config related
+environment variables (PKG_CONFIG, PKG_CONFIG_PATH, PKG_CONFIG_LIBDIR)
+or have libjpeg installed in the standard location to include from and
+link to.
+
+To force specific compile and link flags for libjpeg, set the
+environment variables LIBJPEG_CFLAGS and $LIBJPEG_LIBS accordingly.
+])
+])
+])dnl
+dnl
+dnl
+dnl ####################################################################
+dnl GP_LIBJPEG_AUTODETECT
+dnl
+dnl Do the actual autodetection of libjpeg, setting
+dnl
+dnl   have_libjpeg=yes
+dnl     If libjpeg has been found and can be both compiled with and
+dnl     linked against.
+dnl
+dnl   have_libjpeg=no
+dnl     If libjpeg has not been found or cannot be compiled with or
+dnl     cannot be linked against.
+dnl
+dnl Used once: By GP_LIBJPEG to make the GP_LIBJPEG code more readable.
+dnl ####################################################################
+dnl
+AC_DEFUN([GP_LIBJPEG_AUTODETECT], [dnl
   have_libjpeg=no
 
   AC_MSG_CHECKING([for libjpeg via variables])
@@ -78,17 +142,6 @@ libjpeg not found despite LIBJPEG_CFLAGS and/or LIBJPEG_LIBS being set.
       ])
     ])
   ])
-
-  AS_VAR_IF([have_libjpeg], [no], [dnl
-    GP_CONFIG_MSG([JPEG mangling support],
-                  [${have_libjpeg} (requires libjpeg)])
-  ], [dnl
-    AC_DEFINE([HAVE_LIBJPEG], [1],
-              [define if building with libjpeg])
-    GP_CONFIG_MSG([JPEG mangling support],
-                  [${have_libjpeg}])
-  ])
-])
 ])dnl
 dnl
 dnl


### PR DESCRIPTION
Allow the `--with-jpeg=yes` `configure` argument again. This
was broken by commit ea00220b6f44a00c2efa792c538f1804ebe183c2.

The `GP_LIBJPEG` macro in the `configure` script now handles the following cases:

    --with-jpeg=no
    --without-jpeg
      Do not use libjpeg. Do not autodetect it either.

    --with-jpeg
    --with-jpeg=yes
      Autodetect libjpeg. If not found, abort.

    <no argument given>
    --with-jpeg=auto
    --with-jpeg=autodetect
      Autodetect libjpeg. If found, use it.

However, it does *NOT* handle

    --with-jpeg=/path/to/somewhere

at this time. Set `LIBJPEG_CFLAGS` and/or `LIBJPEG_LIBS`
instead to specify which `libjpeg` to compile with and
link against.

This mostly matches the behaviour from before commit
ea00220b6f44a00c2efa792c538f1804ebe183c2, which was

    --with-jpeg=no
    --without-jpeg
      Do not use libjpeg. Do not autodetect it either.

    --with-jpeg
    --with-jpeg=yes
    --with-jpeg=<any value other than "no">
      Autodetect libjpeg. If found, use it. Otherwise, silently
      ignore the user's wish to build with libjpeg.

    <no argument given>
      Autodetect libjpeg. If found, use it.

If someone is running configure with `--with-jpeg=yes` and
`libjpeg` cannot be used, we can assume that building without
using `libjpeg` is not the outcome the user expects.

Fixes: https://github.com/gphoto/libgphoto2/issues/759