### PR TITLE
pc files: Fix gphoto2 builds, avoid builds with wrong headers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 libgphoto2 2.5.28.1 development snapshot
 
+general:
+* fixes build failures of libgphoto2 clients and builds using the
+  wrong libgphoto2 headers (issue #717)
+
 ptp2:
 * fixed a regression in Fuji preview capture which would lead to crashes
 * made the wait-event property extractor more robust (it sometimes gets NULL ptrs), hopefully fixing Sony crashes

--- a/libgphoto2.pc.in
+++ b/libgphoto2.pc.in
@@ -12,4 +12,4 @@ Version: @VERSION@
 Requires: libgphoto2_port >= 0.10.0
 Requires.private: @REQUIREMENTS_FOR_LIBEXIF@
 Libs: -L${libdir} -lgphoto2 -lm
-Cflags: -I${includedir}/gphoto2
+Cflags: -I${includedir} -I${includedir}/gphoto2

--- a/libgphoto2_port/libgphoto2_port.pc.in
+++ b/libgphoto2_port/libgphoto2_port.pc.in
@@ -10,4 +10,4 @@ Description: Device-independent access to serial, USB, and other ports
 URL: http://gphoto.org/proj/libgphoto2/
 Version: @VERSION@
 Libs: -L${libdir} -lgphoto2_port -lm
-Cflags: -I${includedir}/gphoto2
+Cflags: -I${includedir} -I${includedir}/gphoto2


### PR DESCRIPTION
In the *.pc files, use a C preprocessor include path both with
and without the gphoto2/ path component:

    Cflags: -I${includedir} -I${includedir}/gphoto2

This allows both the preferred way to include gphoto2 headers

    #include <gphoto2/gphoto2.h>
    #include <gphoto2/gphoto2-camera.h>

and also the early 2000s legacy way (still in use by kamera and
others because we did not properly communicate and enforce that
back when we were still stabilizing the API)

    #include <gphoto2.h>
    #include <gphoto2-camera.h>

to produce builds with the libgphoto2 headers actually corresponding
to the *.pc files in use.

Any other option for the *.pc file Cflags either produces
unintended build failures or builds which use the wrong header
files (the `-I${includedir}/gphoto2` option), or breaks the
`#include <...>` part of the libgphoto2 API from the early 2000s
still in use by kamera and others (the `-I${includedir}` option).

For details, see https://github.com/gphoto/libgphoto2/issues/717 and
https://github.com/gphoto/libgphoto2/issues/717#issuecomment-1018040615

Fixes: https://github.com/gphoto/libgphoto2/issues/717