### PR TITLE
Allow clang compile with initializer overrides

### DIFF
--- a/camlibs/pentax/js0n.c
+++ b/camlibs/pentax/js0n.c
@@ -4,6 +4,14 @@
 #include <string.h> // one strncmp() is used to do key comparison, and a strlen(key) if no len passed in
 #include "js0n.h"
 
+
+#ifdef __clang__
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winitializer-overrides"
+
+#else /* to clang or not to clang */
+
 // gcc started warning for the init syntax used here, is not helpful so don't generate the spam, suppressing the warning is really inconsistently supported across versions
 #if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
 #pragma GCC diagnostic push
@@ -12,6 +20,9 @@
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Winitializer-overrides"
 #pragma GCC diagnostic ignored "-Woverride-init"
+
+#endif /* to clang or not to clang */
+
 
 // only at depth 1, track start pointers to match key/value
 #define PUSH(i) if(depth == 1) { if(!index) { val = cur+i; }else{ if(klen && index == 1) start = cur+i; else index--; } }
@@ -158,6 +169,15 @@ const char *js0n(const char *key, size_t klen,
 
 }
 
+
+#ifdef __clang__
+
+#pragma clang diagnostic pop
+
+#else /* to clang or not to clang */
+
 #if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
 #pragma GCC diagnostic pop
 #endif
+
+#endif /* to clang or not to clang */

--- a/camlibs/pentax/js0n.c
+++ b/camlibs/pentax/js0n.c
@@ -10,6 +10,9 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winitializer-overrides"
 
+/* allow GNU style [0 ... 255] range designators in initializers */
+#pragma clang diagnostic ignored "-Wgnu-designator"
+
 #else /* to clang or not to clang */
 
 // gcc started warning for the init syntax used here, is not helpful so don't generate the spam, suppressing the warning is really inconsistently supported across versions
@@ -20,6 +23,9 @@
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Winitializer-overrides"
 #pragma GCC diagnostic ignored "-Woverride-init"
+
+/* allow GNU style [0 ... 255] range designators in initializer */
+#pragma GCC diagnostic ignored "-Wpedantic"
 
 #endif /* to clang or not to clang */
 


### PR DESCRIPTION
This catches clang in a clang specific C preprocessor conditional
before clang gets a chance to mess up at pretending to be gcc.

The camlibs/pentax/js0n.c state machine tables use a lot of both
GNU style range designators [ a ... b ], and later overrides some
of the values in the range. This is not very pure C, but relatively
effient to code, so we can accept silencing some warnings here.

Fixes: https://github.com/gphoto/libgphoto2/issues/761