### PR TITLE
CI: add automake based example project using libgphoto2

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -30,6 +30,7 @@ jobs:
     - name: build and run example libgphoto2 frontend (ambs-lgp2-frontend)
       run: |
         set -x
+        exec 2>&1
         abs_top_builddir="$PWD"
         export PKG_CONFIG_PATH="${abs_top_builddir}/__prefix/lib/pkgconfig"
         export LD_LIBRARY_PATH="${abs_top_builddir}/__prefix/lib"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -18,10 +18,27 @@ jobs:
     - name: autoreconf
       run: autoreconf -i -f
     - name: configure
-      run: ./configure
+      run: ./configure --prefix=$PWD/__prefix
     - name: make
       run: make
     - name: make check
       run: make check
     - name: make distcheck
       run: make distcheck
+    - name: make install
+      run: make install
+    - name: build and run example libgphoto2 frontend (ambs-lgp2-frontend)
+      run: |
+        set -x
+        abs_top_builddir="$PWD"
+        export PKG_CONFIG_PATH="${abs_top_builddir}/__prefix/lib/pkgconfig"
+        export LD_LIBRARY_PATH="${abs_top_builddir}/__prefix/lib"
+        cd examples/ambs-lgp2-frontend
+        autoreconf -vis
+        ./configure --prefix="$PWD/__pref"
+        make
+        ldd ambs-lgp2-frontend
+        ./ambs-lgp2-frontend
+        make install
+        ldd __pref/bin/ambs-lgp2-frontend
+        __pref/bin/ambs-lgp2-frontend

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 libgphoto2 2.5.28.1 development snapshot
 
 general:
-* fixes build failures of libgphoto2 clients and builds using the
+* fixes build failures of libgphoto2 frontends and builds using the
   wrong libgphoto2 headers (issue #717)
 
 ptp2:

--- a/examples/ambs-lgp2-frontend/.gitignore
+++ b/examples/ambs-lgp2-frontend/.gitignore
@@ -1,0 +1,19 @@
+# autoreconf
+/aclocal.m4
+/auto-aux/
+/auto-config.h.in
+/autom4te.cache/
+/configure
+
+# ./configure
+/auto-config.h
+/config.log
+/config.status
+/stamp-h1
+
+# make
+/ambs-lgp2-frontend
+/ambs-lgp2-frontend.exe
+
+# make dist
+/ambs-lgp2-frontend-*.tar.gz

--- a/examples/ambs-lgp2-frontend/Makefile.am
+++ b/examples/ambs-lgp2-frontend/Makefile.am
@@ -1,0 +1,6 @@
+ACLOCAL_AMFLAGS = -I auto-m4
+
+bin_PROGRAMS             = ambs-lgp2-frontend
+ambs_lgp2_frontend_SOURCES = main.c
+ambs_lgp2_frontend_LDADD   = $(LIBGPHOTO2_LIBS)
+ambs_lgp2_frontend_CFLAGS  = $(LIBGPHOTO2_CFLAGS)

--- a/examples/ambs-lgp2-frontend/README.md
+++ b/examples/ambs-lgp2-frontend/README.md
@@ -1,0 +1,11 @@
+automake buildsystem based example libgphoto2 frontend
+====================================================
+
+This is an example libgphoto2 frontend project using an automake base
+build system.
+
+Its main purpose is to allow libgphoto2 CI builds to test building a
+libgphoto2 frontend against the built libgphoto2 without needing to
+clone and build the complete gphoto2 command line interface frontend.
+
+Additionally, it may serve as a bit of documentation by example.

--- a/examples/ambs-lgp2-frontend/configure.ac
+++ b/examples/ambs-lgp2-frontend/configure.ac
@@ -1,0 +1,30 @@
+AC_PREREQ([2.69])
+AC_INIT([automake buildsystem libgphoto2 frontend],
+        [0.0.1],
+	[https://github.com/gphoto/libgphoto2],
+	[ambs-lgp2-frontend])
+AC_CONFIG_SRCDIR([main.c])
+AC_CONFIG_HEADERS([auto-config.h])
+AC_CONFIG_AUX_DIR([auto-aux])
+AC_CONFIG_MACRO_DIR([auto-m4])
+
+AM_INIT_AUTOMAKE([
+  -Wall
+  foreign
+  1.16
+  subdir-objects
+])
+
+AM_SILENT_RULES([no])
+
+AC_PROG_CC
+
+
+m4_pattern_forbid([^PKG_CHECK_MODULES])dnl
+PKG_CHECK_MODULES([LIBGPHOTO2], [libgphoto2])
+
+
+AC_CONFIG_FILES([
+  Makefile
+])
+AC_OUTPUT

--- a/examples/ambs-lgp2-frontend/main.c
+++ b/examples/ambs-lgp2-frontend/main.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+
+#include <gphoto2/gphoto2-version.h>
+
+/* The purpose of this code is to use things defined in gphoto2 header
+ * files and then link to libgphoto2. */
+
+static
+struct {
+  const char *const title;
+  GPVersionFunc version_func;
+} versions[] = {
+  {"libgphoto2_port", gp_port_library_version},
+  {"libgphoto2",      gp_library_version}
+};
+
+int main()
+{
+  for (size_t i=0; i<(sizeof(versions)/sizeof(versions[0])); i++) {
+    const char *const title          = versions[i].title;
+    const GPVersionFunc version_func = versions[i].version_func;
+    const char **version_data = version_func(GP_VERSION_VERBOSE);
+    printf("%s\n", title);
+    for (size_t j=0; version_data[j]; j++) {
+      printf("  %s\n", version_data[j]);
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
Add automake based example project using libgphoto2 to have
the CI builds ensure that building a libgphoto2 client with
this libgphoto2 is possible.