### PR TITLE
Revert "keep canon eos remotemode=1 on exit, to keep the display on"

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -582,8 +582,7 @@ camera_unprepare_canon_eos_capture(Camera *camera, GPContext *context) {
 
 	/* Drain the rest set of the event data */
 	C_PTP (ptp_check_eos_events (params));
-	/* remotemode 1 should stay, as it keeps the display on for some reason */
-	/*C_PTP (ptp_canon_eos_setremotemode(params, 0));*/
+	C_PTP (ptp_canon_eos_setremotemode(params, 0));
 	C_PTP (ptp_canon_eos_seteventmode(params, 0));
 	params->eos_captureenabled = 0;
 	return GP_OK;

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -3121,8 +3121,6 @@ camera_exit (Camera *camera, GPContext *context)
 				if ((exit_gp_result = camera_unprepare_capture (camera, context)) < GP_OK)	/* note: gets gphoto resultcodes, not ptp retcodes */
 					goto exitfailed;
 			}
-			/* this switches the display back on ... */
-			C_PTP (ptp_canon_eos_setremotemode(params, 1));
 			break;
 		case PTP_VENDOR_NIKON:
 			if (ptp_operation_issupported(params, PTP_OC_NIKON_EndLiveView))


### PR DESCRIPTION
This reverts commit 07a2176e11f5601db730fe4c3bf5206c47fc1ee5.

Fixes #784 

Verified correct behaviour after this revert, connection gets closed and both the mirror and the shutter of the camera get closed as well.