### PR TITLE
Add function to initialise locale directory

### DIFF
--- a/gphoto2/gphoto2-abilities-list.h
+++ b/gphoto2/gphoto2-abilities-list.h
@@ -186,6 +186,8 @@ int gp_abilities_list_get_abilities (CameraAbilitiesList *list, int index,
 
 const char *gp_message_codeset (const char *);
 
+int gp_initialise_locale (const char *localedir);
+
 
 /**
  * Name of the environment variable which may contain the path where

--- a/libgphoto2/gphoto2-abilities-list.c
+++ b/libgphoto2/gphoto2-abilities-list.c
@@ -72,6 +72,26 @@ gp_message_codeset (const char *codeset)
 }
 
 /**
+ * \brief Initialise localisation.
+ * 
+ * Call bindtextdomain() with our locale directory. This is called by
+ * gp_abilities_list_new() so you don't need to call it unless you have a
+ * non-standard installation. 
+ * \param localedir Root directory of libgphoto2's localisation files.
+ * \return gphoto2 error code.
+ */
+int
+gp_initialise_locale (const char *localedir)
+{
+	static int locale_initialised = 0;
+	if (locale_initialised)
+		return GP_OK;
+	locale_initialised = 1;
+	bindtextdomain (GETTEXT_PACKAGE_LIBGPHOTO2, localedir);
+	return GP_OK;
+}
+
+/**
  * \brief Allocate the memory for a new abilities list.
  *
  * Function to allocate the memory for a new abilities list.
@@ -92,7 +112,7 @@ gp_abilities_list_new (CameraAbilitiesList **list)
 	 * an other way without introducing a global initialization
 	 * function...
 	 */
-	bindtextdomain (GETTEXT_PACKAGE_LIBGPHOTO2, LOCALEDIR);
+	gp_initialise_locale(LOCALEDIR);
 
 	C_MEM (*list = calloc (1, sizeof (CameraAbilitiesList)));
 

--- a/libgphoto2/libgphoto2.sym
+++ b/libgphoto2/libgphoto2.sym
@@ -122,6 +122,7 @@ gp_filesystem_set_funcs
 gp_file_unref
 gp_gamma_correct_single
 gp_gamma_fill_table
+gp_initialise_locale
 gp_library_version
 gp_list_append
 gp_list_count


### PR DESCRIPTION
The function is called from gp_abilities_list_new() so existing code
will carry on working as before. Non-standard installations of
libgphoto2 can call the initialisation function with their choice of
locale dir. The function includes code to ensure it's only run once.