### PR TITLE
gh workflow: trying to fix libgd-dev dependency issue

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,8 +13,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: apt-get update
+      run: sudo apt-get update
+    - name: apt-get 3rd party repo libgd-dev dependency workaround
+      run: sudo apt-get remove nginx libgd3
+    - name: apt-get dist-upgrade
+      run: sudo apt-get dist-upgrade
     - name: apt-get install
-      run: sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y autopoint gettext libusb-1.0-0-dev libcurl4-openssl-dev libgd-dev
+      run: sudo apt-get install -y autopoint gettext libusb-1.0-0-dev libcurl4-openssl-dev libgd-dev
     - name: autoreconf
       run: autoreconf -i -f
     - name: configure


### PR DESCRIPTION
On the `ubuntu-latest` workers (which appear to be the same as `ubuntu-20.04`, installing `libgd-dev` fails as follows:

```
The following packages have unmet dependencies:
 libgd-dev : Depends: libgd3 (= 2.2.5-5.2ubuntu2.1) but 2.3.3-5+ubuntu20.04.1+deb.sury.org+1 is to be installed
E: Unable to correct problems, you have held broken packages.
```

This tries to fix or work around that.

PR to make the workflow run.