### PR TITLE
gh workflow: remove apt-get dist-upgrade

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -17,8 +17,6 @@ jobs:
       run: sudo apt-get update
     - name: apt-get 3rd party repo libgd-dev dependency workaround
       run: sudo apt-get remove nginx libgd3
-    - name: apt-get dist-upgrade
-      run: sudo apt-get dist-upgrade
     - name: apt-get install
       run: sudo apt-get install -y autopoint gettext libusb-1.0-0-dev libcurl4-openssl-dev libgd-dev
     - name: autoreconf


### PR DESCRIPTION
We probably do not need to dist-upgrade (or upgrade), and dist-upgrade
can take a long time on the github runners.

We only had this while trying to work out how to work around the
libgd-dev dependency issue, so we can remove the dist-upgrade step.