### PR TITLE
Fix empty PTP strings not being null-terminated in parse_9301_value()

### DIFF
--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -733,8 +733,8 @@ parse_9301_value (PTPParams *params, const char *str, uint16_t type, PTPProperty
 					cx = ((xc>>8) & 0xff) | ((xc & 0xff) << 8);
 					xstr[i] = cx;
 				}
-				xstr[len] = 0;
 			}
+			xstr[len] = '\0';
 			ptp_debug( params, "\t%s", xstr);
 			propval->str = xstr;
 			break;


### PR DESCRIPTION
https://github.com/gphoto/libgphoto2/blob/129a2ab9fa35db05af78b9d6ecf2576d387e4828/camlibs/ptp2/ptp.c#L721-L744

This line clearly should follow the `for` loop instead of being part of it:

https://github.com/gphoto/libgphoto2/blob/129a2ab9fa35db05af78b9d6ecf2576d387e4828/camlibs/ptp2/ptp.c#L736

Since the `len` variable does not change, it makes no sense to repeat the assignment on every iteration.
At the same time, if the length is 0, then nothing will be assigned at all, resulting in a string without a null-terminator.