### PR TITLE
Fix `GP_UNKNOWN_EVENT` leaks in examples

### DIFF
--- a/examples/best-iso.c
+++ b/examples/best-iso.c
@@ -302,6 +302,8 @@ camera_tether(Camera *camera, GPContext *context) {
 						free (val);
 					}
 				}
+				
+				free(evtdata);
 			} else {
 				printf("Unknown event.\n");
 			}

--- a/examples/sample-tether.c
+++ b/examples/sample-tether.c
@@ -78,6 +78,7 @@ camera_tether(Camera *camera, GPContext *context) {
 		case GP_EVENT_UNKNOWN:
 			if (evtdata) {
 				printf("Unknown event: %s.\n", (char*)evtdata);
+				free(evtdata);
 			} else {
 				printf("Unknown event.\n");
 			}

--- a/examples/sample-trigger-capture.c
+++ b/examples/sample-trigger-capture.c
@@ -61,6 +61,8 @@ wait_event_and_download (Camera *camera, int waittime, GPContext *context) {
 			fprintf (stderr, "wait for event CAPTURE_COMPLETE\n");
 			break;
 		case GP_EVENT_UNKNOWN:
+			free(data);
+			break;
 		case GP_EVENT_TIMEOUT:
 			break;
 		case GP_EVENT_FOLDER_ADDED:


### PR DESCRIPTION
Most of the examples give wrong impression that `GP_UNKNOWN_EVENT` data does not need to be freed / is not heap allocated, however it's not the case - those messages are always `malloc`'d by corresponding drivers.