### PR TITLE
Zero-fill CameraFileInfo

### DIFF
--- a/camlibs/jd11/serial.c
+++ b/camlibs/jd11/serial.c
@@ -418,6 +418,7 @@ jd11_index_reader(GPPort *port, CameraFilesystem *fs, GPContext *context) {
 		return ret;
 	}
 
+	memset (&info, 0, sizeof (info));
 	/* we also get the fs info for free, so just set it */
 	info.file.fields = GP_FILE_INFO_TYPE |
 			GP_FILE_INFO_WIDTH | GP_FILE_INFO_HEIGHT |

--- a/camlibs/konica/library.c
+++ b/camlibs/konica/library.c
@@ -564,6 +564,8 @@ camera_capture (Camera* camera, CameraCaptureType type, CameraFilePath* path,
 	C(gp_filesystem_append (camera->fs, path->folder,
 					     path->name, context));
 
+	memset (&info, 0, sizeof (info));
+
 	info.preview.fields = GP_FILE_INFO_SIZE | GP_FILE_INFO_TYPE;
 	info.preview.size = buffer_size;
 	strcpy (info.preview.type, GP_MIME_JPEG);
@@ -1268,4 +1270,3 @@ camera_init (Camera* camera, GPContext *context)
 						       timeout_func);
         return (GP_OK);
 }
-

--- a/camlibs/pccam600/library.c
+++ b/camlibs/pccam600/library.c
@@ -119,7 +119,7 @@ static int file_list_func (CameraFilesystem *fs, const char *folder,
 	  if( !((file_entry->state & 0x02) != 2)  &&
 	      !((file_entry->state & 0x08) == 8) )
 	    {
-	      info.file.fields = 0;
+	      memset (&info, 0, sizeof (info));
 	      temp = (char *)&(file_entry->name)[5];
 	      if (strncmp(temp,"JPG",3) == 0)
 		{

--- a/camlibs/pentax/library.c
+++ b/camlibs/pentax/library.c
@@ -415,6 +415,8 @@ camera_capture (Camera *camera, CameraCaptureType type, CameraFilePath *path,
 		}
 		/* We have now handed over the file, disclaim responsibility by unref. */
 		gp_file_unref (file);
+
+		memset (&info, 0, sizeof (info));
 		/* we also get the fs info for free, so just set it */
 		info.file.fields = GP_FILE_INFO_TYPE |
 				GP_FILE_INFO_SIZE | GP_FILE_INFO_MTIME;
@@ -574,6 +576,8 @@ camera_wait_for_event (Camera *camera, int timeout,
 			}
 			/* We have now handed over the file, disclaim responsibility by unref. */
 			gp_file_unref (file);
+
+			memset (&info, 0, sizeof (info));
 			/* we also get the fs info for free, so just set it */
 			info.file.fields = GP_FILE_INFO_TYPE |
 					GP_FILE_INFO_SIZE | GP_FILE_INFO_MTIME;

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -3291,6 +3291,7 @@ add_object_to_fs_and_path (Camera *camera, uint32_t handle, CameraFilePath *path
 	/* fetch ob pointer again, as gp_filesystem_append can change the object list */
 	C_PTP (ptp_object_want (params, handle, PTPOBJECT_OBJECTINFO_LOADED, &ob));
 
+	memset (&info, 0, sizeof (info));
 	/* we also get the fs info for free, so just set it */
 	info.file.fields = GP_FILE_INFO_TYPE |
 			GP_FILE_INFO_WIDTH | GP_FILE_INFO_HEIGHT |
@@ -4000,6 +4001,7 @@ add_objectid_and_upload (Camera *camera, CameraFilePath *path, GPContext *contex
 	/* We have now handed over the file, disclaim responsibility by unref. */
 	gp_file_unref (file);
 
+	memset (&info, 0, sizeof (info));
 	/* we also get the fs info for free, so just set it */
 	info.file.fields = GP_FILE_INFO_TYPE |
 			GP_FILE_INFO_WIDTH | GP_FILE_INFO_HEIGHT |
@@ -6930,6 +6932,7 @@ downloadnow:
 					return ret;
 				}
 
+				memset (&info, 0, sizeof (info));
 				/* we also get the fs info for free, so just set it */
 				info.file.fields = GP_FILE_INFO_TYPE |
 						GP_FILE_INFO_WIDTH | GP_FILE_INFO_HEIGHT |

--- a/camlibs/ricoh/g3.c
+++ b/camlibs/ricoh/g3.c
@@ -819,6 +819,7 @@ file_list_func (CameraFilesystem *fs, const char *folder, CameraList *list,
 				ret = gp_filesystem_append (fs, folder, xfn, context);
 				if (ret < GP_OK) goto out;
 
+				memset (&info, 0, sizeof (info));
 				/* we also get parts of fs info for free, so just set it */
 				info.file.fields =
 						GP_FILE_INFO_SIZE |

--- a/camlibs/sipix/blink.c
+++ b/camlibs/sipix/blink.c
@@ -881,6 +881,7 @@ file_list_func (CameraFilesystem *fs, const char *folder, CameraList *list,
 	/* gp_list_populate (list, "blink%03i.raw", numpics); */
 #if 1
 	for (i=0;i<numpics;i++) {
+		memset (&info, 0, sizeof (info));
 		/* we also get the fs info for free, so just set it */
 		info.file.fields = GP_FILE_INFO_TYPE |
 				GP_FILE_INFO_WIDTH | GP_FILE_INFO_HEIGHT |


### PR DESCRIPTION
I've noticed in my tests that for many files the CameraFileInfo incorrectly had `info.audio` marked as available (with various flags).

Thanks to valgrind I found that it's because `CameraFileInfo` is zero-filled in some places, but not others, so the `audio.fields` (as well as entire `audio`) was filled with uninitialized data.

I tried to find all usages of `info.file.fields = ...` and `info.preview.fields = ...` and zero-initialize them in the same way as it already is in other places.