### PR TITLE
Replace all `#define _*_SOURCE` with centralised config

### DIFF
--- a/camlibs/aox/library.c
+++ b/camlibs/aox/library.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include <config.h>
 
 #include <stdlib.h>

--- a/camlibs/ax203/library.c
+++ b/camlibs/ax203/library.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <string.h>

--- a/camlibs/ax203/tinyjpeg.c
+++ b/camlibs/ax203/tinyjpeg.c
@@ -39,8 +39,6 @@
  *
  */
 
-#define _DEFAULT_SOURCE
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/camlibs/barbie/barbie.c
+++ b/camlibs/barbie/barbie.c
@@ -21,8 +21,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _POSIX_C_SOURCE 199309L
-
 #include "config.h"
 
 #include <ctype.h>

--- a/camlibs/canon/canon.c
+++ b/camlibs/canon/canon.c
@@ -15,7 +15,6 @@
  * and usb.c, keeping the common protocols/buses support in this
  * file.
  */
-#define _DEFAULT_SOURCE
 #include "config.h"
 
 #include <stdlib.h>

--- a/camlibs/canon/library.c
+++ b/camlibs/canon/library.c
@@ -20,8 +20,6 @@
  *
  ****************************************************************************/
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdlib.h>

--- a/camlibs/canon/serial.c
+++ b/camlibs/canon/serial.c
@@ -12,8 +12,6 @@
  *
  ****************************************************************************/
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdio.h>

--- a/camlibs/casio/ycctoppm.c
+++ b/camlibs/casio/ycctoppm.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdio.h>

--- a/camlibs/digigr8/library.c
+++ b/camlibs/digigr8/library.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include <config.h>
 
 #include <stdlib.h>

--- a/camlibs/digita/digita.c
+++ b/camlibs/digita/digita.c
@@ -19,8 +19,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdlib.h>

--- a/camlibs/digita/serial.c
+++ b/camlibs/digita/serial.c
@@ -21,8 +21,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdio.h>
@@ -336,4 +334,3 @@ int digita_serial_open(CameraPrivateLibrary *dev, Camera *camera)
 
 	return negotiated ? 0 : -1;
 }
-

--- a/camlibs/dimera/dimera3500.c
+++ b/camlibs/dimera/dimera3500.c
@@ -19,8 +19,6 @@
  *
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include "mesalib.h"

--- a/camlibs/directory/directory.c
+++ b/camlibs/directory/directory.c
@@ -20,8 +20,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <errno.h>

--- a/camlibs/fuji/library.c
+++ b/camlibs/fuji/library.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <string.h>

--- a/camlibs/gsmart300/gsmart300.c
+++ b/camlibs/gsmart300/gsmart300.c
@@ -25,8 +25,6 @@
 /* Boston, MA  02110-1301  USA					*/
 /****************************************************************/
 
-#define _DEFAULT_SOURCE
-
 #include <config.h>
 
 #include <stdio.h>

--- a/camlibs/gsmart300/library.c
+++ b/camlibs/gsmart300/library.c
@@ -25,8 +25,6 @@
 /* Boston, MA  02110-1301  USA					*/
 /****************************************************************/
 
-#define _DEFAULT_SOURCE
-
 #include <config.h>
 
 #include <stdlib.h>

--- a/camlibs/hp215/hp215.c
+++ b/camlibs/hp215/hp215.c
@@ -53,8 +53,6 @@
      0x03 = Endcode   for a command
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdio.h>

--- a/camlibs/iclick/library.c
+++ b/camlibs/iclick/library.c
@@ -19,8 +19,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include <config.h>
 
 #include <stdlib.h>

--- a/camlibs/jd11/serial.c
+++ b/camlibs/jd11/serial.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdio.h>

--- a/camlibs/jl2005c/jl2005bcd_decompress.c
+++ b/camlibs/jl2005c/jl2005bcd_decompress.c
@@ -24,8 +24,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/camlibs/jl2005c/jl2005c.c
+++ b/camlibs/jl2005c/jl2005c.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include <config.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/camlibs/kodak/dc120/dc120.c
+++ b/camlibs/kodak/dc120/dc120.c
@@ -18,9 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-#define _POSIX_C_SOURCE 199309L
-
 #include "config.h"
 
 #include <stdlib.h>

--- a/camlibs/kodak/dc120/library.c
+++ b/camlibs/kodak/dc120/library.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-#define _POSIX_C_SOURCE 199309L
 #include "config.h"
 
 #include <stdio.h>

--- a/camlibs/kodak/dc210/dc210.c
+++ b/camlibs/kodak/dc210/dc210.c
@@ -18,7 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
 #include "config.h"
 
 #include <stdlib.h>

--- a/camlibs/konica/library.c
+++ b/camlibs/konica/library.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdio.h>

--- a/camlibs/konica/qm150.c
+++ b/camlibs/konica/qm150.c
@@ -33,8 +33,6 @@
  * information header and use this number with all functions !!
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <string.h>

--- a/camlibs/largan/lmini/largan.c
+++ b/camlibs/largan/lmini/largan.c
@@ -24,8 +24,6 @@
  * Currently only largan lmini is supported
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <string.h>

--- a/camlibs/mars/mars.c
+++ b/camlibs/mars/mars.c
@@ -20,8 +20,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include <config.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/camlibs/minolta/dimagev/dimagev.c
+++ b/camlibs/minolta/dimagev/dimagev.c
@@ -19,8 +19,6 @@
 *                                                                     *
 **********************************************************************/
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdio.h>

--- a/camlibs/mustek/usb.c
+++ b/camlibs/mustek/usb.c
@@ -21,8 +21,6 @@
  * supports rs232 and USB.
  */
 
-#define _DEFAULT_SOURCE
-
 /*
 	Implemenation of the USB Version of ExecuteCommand
 */

--- a/camlibs/panasonic/coolshot/library.c
+++ b/camlibs/panasonic/coolshot/library.c
@@ -24,9 +24,6 @@
 /* Boston, MA  02110-1301  USA					*/
 /****************************************************************/
 
-#define _POSIX_C_SOURCE 199309L
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdio.h>
@@ -726,5 +723,3 @@ int coolshot_build_thumbnail (char *data, int *size)
 
 	return( GP_OK );
 }
-
-

--- a/camlibs/pentax/library.c
+++ b/camlibs/pentax/library.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #define GP_MODULE "pentax"

--- a/camlibs/polaroid/pdc320.c
+++ b/camlibs/polaroid/pdc320.c
@@ -29,8 +29,6 @@
  *	http://www.polaroid.com/service/software/index.html
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdlib.h>

--- a/camlibs/polaroid/pdc700.c
+++ b/camlibs/polaroid/pdc700.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <string.h>

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -17,7 +17,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _DEFAULT_SOURCE
 #include "config.h"
 
 #include <math.h>

--- a/camlibs/ptp2/fujiptpip.c
+++ b/camlibs/ptp2/fujiptpip.c
@@ -41,8 +41,6 @@
  * - event pipe , port 55741 (camera remote port starts listen when you run "InitiateOpenCapture")
  * - jpeg pipe , port 55742 (camera remote port starts listen when you run "InitiateOpenCapture")
  */
-#define _DEFAULT_SOURCE
-#define _DARWIN_C_SOURCE
 #include "config.h"
 
 #include <stdlib.h>

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -21,8 +21,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-#define _DARWIN_C_SOURCE
 #include "config.h"
 
 #include <stdlib.h>

--- a/camlibs/ptp2/olympus-wrap.c
+++ b/camlibs/ptp2/olympus-wrap.c
@@ -21,8 +21,6 @@
  * XDISCVRY.X3C file sent on start, empty.
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #ifdef HAVE_LIBXML2

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -22,7 +22,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
 #include "config.h"
 #include "ptp.h"
 

--- a/camlibs/ptp2/ptpip.c
+++ b/camlibs/ptp2/ptpip.c
@@ -28,8 +28,6 @@
  *
  * Nikon WU-1* adapters might use 0011223344556677 as GUID always...
  */
-#define _DEFAULT_SOURCE
-#define _DARWIN_C_SOURCE
 #include "config.h"
 
 #include <stdlib.h>

--- a/camlibs/ptp2/usb.c
+++ b/camlibs/ptp2/usb.c
@@ -21,7 +21,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
 #include <config.h>
 #include "ptp.h"
 #include "ptp-private.h"

--- a/camlibs/ricoh/library.c
+++ b/camlibs/ricoh/library.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdio.h>

--- a/camlibs/sierra/library.c
+++ b/camlibs/sierra/library.c
@@ -17,7 +17,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _DARWIN_C_SOURCE
 #include "config.h"
 #include "library.h"
 

--- a/camlibs/sierra/sierra.c
+++ b/camlibs/sierra/sierra.c
@@ -17,8 +17,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 #include "sierra.h"
 

--- a/camlibs/smal/ultrapocket.c
+++ b/camlibs/smal/ultrapocket.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include <config.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/camlibs/sonix/library.c
+++ b/camlibs/sonix/library.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include <config.h>
 
 #include <stdlib.h>

--- a/camlibs/sonydscf1/command.c
+++ b/camlibs/sonydscf1/command.c
@@ -21,7 +21,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
 #include "config.h"
 
 #include <stdio.h>

--- a/camlibs/sonydscf55/sony.c
+++ b/camlibs/sonydscf55/sony.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdio.h>

--- a/camlibs/spca50x/library.c
+++ b/camlibs/spca50x/library.c
@@ -22,8 +22,6 @@
 /* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,*/
 /* Boston, MA  02110-1301  USA					*/
 /****************************************************************/
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 

--- a/camlibs/spca50x/spca50x-flash.c
+++ b/camlibs/spca50x/spca50x-flash.c
@@ -26,8 +26,6 @@
 /* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,*/
 /* Boston, MA  02110-1301  USA					*/
 /****************************************************************/
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 #include <string.h>
 #include <stdio.h>

--- a/camlibs/spca50x/spca50x-sdram.c
+++ b/camlibs/spca50x/spca50x-sdram.c
@@ -23,8 +23,6 @@
 /* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,*/
 /* Boston, MA  02110-1301  USA					*/
 /****************************************************************/
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdio.h>

--- a/camlibs/spca50x/spca50x.c
+++ b/camlibs/spca50x/spca50x.c
@@ -25,8 +25,6 @@
 /* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,*/
 /* Boston, MA  02110-1301  USA					*/
 /****************************************************************/
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdio.h>

--- a/camlibs/sq905/library.c
+++ b/camlibs/sq905/library.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include <config.h>
 
 #include <stdlib.h>

--- a/camlibs/st2205/library.c
+++ b/camlibs/st2205/library.c
@@ -17,7 +17,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _DEFAULT_SOURCE
 #include "config.h"
 
 #include <string.h>

--- a/camlibs/st2205/st2205.c
+++ b/camlibs/st2205/st2205.c
@@ -17,9 +17,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _DEFAULT_SOURCE
-#define _POSIX_C_SOURCE 1
-#define _DARWIN_C_SOURCE
 #include "config.h"
 
 #include <stdio.h>

--- a/camlibs/topfield/puppy.c
+++ b/camlibs/topfield/puppy.c
@@ -21,8 +21,6 @@
   Boston, MA  02110-1301  USA
 
 */
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <string.h>

--- a/camlibs/tp6801/library.c
+++ b/camlibs/tp6801/library.c
@@ -18,7 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
 #include "config.h"
 
 #include <string.h>

--- a/camlibs/tp6801/tp6801.c
+++ b/camlibs/tp6801/tp6801.c
@@ -17,8 +17,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdio.h>

--- a/configure.ac
+++ b/configure.ac
@@ -211,6 +211,8 @@ dnl GP_CONDITIONAL_COMPILE_FLAGS([CFLAGS], [-Wno-stringop-truncation])
 dnl Every compile example after here will be using the C language
 AC_LANG([C])
 
+dnl Enable extra system functions like flock, strdup, re_compile_pattern and others.
+AC_USE_SYSTEM_EXTENSIONS
 
 dnl ---------------------------------------------------------------------------
 dnl Turn on (almost) all warnings when using gcc

--- a/examples/config.c
+++ b/examples/config.c
@@ -1,4 +1,3 @@
-#define _DARWIN_C_SOURCE
 #include "samples.h"
 
 #include <string.h>

--- a/libgphoto2/gphoto2-abilities-list.c
+++ b/libgphoto2/gphoto2-abilities-list.c
@@ -21,8 +21,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _DARWIN_C_SOURCE
-
 #include "config.h"
 #include <gphoto2/gphoto2-abilities-list.h>
 

--- a/libgphoto2/gphoto2-context.c
+++ b/libgphoto2/gphoto2-context.c
@@ -21,8 +21,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 #include <gphoto2/gphoto2-context.h>
 

--- a/libgphoto2/gphoto2-file.c
+++ b/libgphoto2/gphoto2-file.c
@@ -24,10 +24,6 @@
  * This file contains internal functions. Use of these functions from
  * external software modules is considered <strong>deprecated</strong>.
  */
-#define _POSIX_SOURCE
-#define _DEFAULT_SOURCE
-#define _DARWIN_C_SOURCE
-
 #include "config.h"
 #include <gphoto2/gphoto2-file.h>
 

--- a/libgphoto2/gphoto2-filesys.c
+++ b/libgphoto2/gphoto2-filesys.c
@@ -23,8 +23,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 #include <gphoto2/gphoto2-filesys.h>
 

--- a/libgphoto2/gphoto2-list.c
+++ b/libgphoto2/gphoto2-list.c
@@ -21,8 +21,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 #include <gphoto2/gphoto2-list.h>
 #include <gphoto2/gphoto2-port-log.h>

--- a/libgphoto2/gphoto2-setting.c
+++ b/libgphoto2/gphoto2-setting.c
@@ -21,8 +21,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 #include <gphoto2/gphoto2-setting.h>
 

--- a/libgphoto2/gphoto2-widget.c
+++ b/libgphoto2/gphoto2-widget.c
@@ -20,7 +20,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _DARWIN_C_SOURCE
 #include "config.h"
 #include <gphoto2/gphoto2-widget.h>
 

--- a/libgphoto2_port/configure.ac
+++ b/libgphoto2_port/configure.ac
@@ -25,6 +25,8 @@ AM_SILENT_RULES([no])
 
 AC_LANG([C])
 
+dnl Enable extra system functions like flock, strdup, re_compile_pattern and others.
+AC_USE_SYSTEM_EXTENSIONS
 
 
 dnl Flag all GP_ strings in result as error unless specifically allowed.

--- a/libgphoto2_port/libgphoto2_port/gphoto2-port-info-list.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port-info-list.c
@@ -20,9 +20,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _GNU_SOURCE
-#define _DARWIN_C_SOURCE
-
 #include "config.h"
 
 #include <gphoto2/gphoto2-port-info-list.h>

--- a/libgphoto2_port/libgphoto2_port/gphoto2-port-log.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port-log.c
@@ -21,8 +21,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 #include <gphoto2/gphoto2-port-log.h>
 

--- a/libgphoto2_port/libgphoto2_port/gphoto2-port.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port.c
@@ -23,8 +23,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 
 #include <stdarg.h>

--- a/libgphoto2_port/libusb1/libusb1.c
+++ b/libgphoto2_port/libusb1/libusb1.c
@@ -20,7 +20,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _DARWIN_C_SOURCE
 #include "config.h"
 #include <gphoto2/gphoto2-port-library.h>
 

--- a/libgphoto2_port/serial/unix.c
+++ b/libgphoto2_port/serial/unix.c
@@ -27,8 +27,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-#define _DARWIN_C_SOURCE
 /* Solaris needs this */
 #define __EXTENSIONS__
 

--- a/libgphoto2_port/usb/libusb.c
+++ b/libgphoto2_port/usb/libusb.c
@@ -20,8 +20,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 #include <gphoto2/gphoto2-port-library.h>
 

--- a/libgphoto2_port/usbdiskdirect/linux.c
+++ b/libgphoto2_port/usbdiskdirect/linux.c
@@ -17,8 +17,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 #include <gphoto2/gphoto2-port-library.h>
 

--- a/libgphoto2_port/usbscsi/linux.c
+++ b/libgphoto2_port/usbscsi/linux.c
@@ -18,8 +18,6 @@
  * Boston, MA  02110-1301  USA
  */
 
-#define _DEFAULT_SOURCE	/* for flock */
-
 #include "config.h"
 #include <gphoto2/gphoto2-port-library.h>
 

--- a/libgphoto2_port/vusb/vcamera.c
+++ b/libgphoto2_port/vusb/vcamera.c
@@ -18,7 +18,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _DARWIN_C_SOURCE
 #include "config.h"
 #include <gphoto2/gphoto2-port-library.h>
 #include <gphoto2/gphoto2-port-portability.h>

--- a/libgphoto2_port/vusb/vusb.c
+++ b/libgphoto2_port/vusb/vusb.c
@@ -18,7 +18,6 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA
  */
-#define _DARWIN_C_SOURCE
 #include "config.h"
 #include <gphoto2/gphoto2-port-library.h>
 


### PR DESCRIPTION
Slightly cleaner alternative to #843, #615, #552 and others that ensures we always have those extension functions at autoconf level instead of having individual (and inconsistent) `#define`s in source files.