### PR TITLE
Add 2 new settings metadata for Sony A7R3

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -6783,6 +6783,12 @@ static struct deviceproptableu8 sony_sensorcrop[] = {
 };
 GENERIC8TABLE(Sony_SensorCrop,sony_sensorcrop)
 
+static struct deviceproptableu8 sony_liveviewsettingeffect[] = {
+		{ N_("On"),  0x01, 0 },
+		{ N_("Off"), 0x02, 0 },
+};
+GENERIC8TABLE(Sony_LiveViewSettingEffect,sony_liveviewsettingeffect)
+
 /* Sony specific, we need to wait for it settle (around 1 second), otherwise we get trouble later on */
 static int
 _put_Sony_CompressionSetting(CONFIG_PUT_ARGS) {
@@ -10644,7 +10650,7 @@ static struct submenu image_settings_menu[] = {
 	{ N_("Movie ISO Speed"),        "movieiso",             PTP_DPC_NIKON_MovieISO,                 PTP_VENDOR_NIKON,   PTP_DTC_UINT32, _get_INT,                       _put_INT },
 	{ N_("ISO Speed"),              "iso",                  PTP_DPC_CANON_EOS_ISOSpeed,             PTP_VENDOR_CANON,   PTP_DTC_UINT16, _get_Canon_ISO,                 _put_Canon_ISO },
 	{ N_("ISO Speed"),              "iso",                  PTP_DPC_SONY_QX_ISO,                    PTP_VENDOR_SONY,    PTP_DTC_UINT32, _get_Sony_ISO,                  _put_Sony_QX_ISO },
-	/* these 2 iso will overwrite and conflicht with each other... the older Sony do not have d226, so it should pick the next entry ... */
+	/* these 2 iso will overwrite and conflict with each other... the older Sony do not have d226, so it should pick the next entry ... */
 	{ N_("ISO Speed"),              "iso",                  PTP_DPC_SONY_ISO2,                      PTP_VENDOR_SONY,    PTP_DTC_UINT32, _get_Sony_ISO,                  _put_Sony_ISO2 },
 	{ N_("ISO Speed"),              "iso",                  PTP_DPC_SONY_ISO,                       PTP_VENDOR_SONY,    PTP_DTC_UINT32, _get_Sony_ISO,                  _put_Sony_ISO },
 	{ N_("ISO Speed"),              "iso",                  PTP_DPC_NIKON_1_ISO,                    PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_1_ISO,               _put_Nikon_1_ISO },
@@ -10820,6 +10826,7 @@ static struct submenu capture_settings_menu[] = {
 	{ N_("Live View Size"),                 "liveviewsize",             PTP_DPC_FUJI_LiveViewImageSize,         PTP_VENDOR_FUJI,    PTP_DTC_UINT16, _get_Fuji_LiveViewSize,             _put_Fuji_LiveViewSize },
 	{ N_("Live View Size"),                 "liveviewsize",             PTP_DPC_SONY_QX_LiveviewResolution,     PTP_VENDOR_SONY,    PTP_DTC_UINT8,  _get_Sony_QX_LiveViewSize,          _put_Sony_QX_LiveViewSize },
 	{ N_("Live View Size"),                 "liveviewsize",             PTP_DPC_CANON_EOS_EVFOutputDevice,      PTP_VENDOR_CANON,   PTP_DTC_UINT16, _get_Canon_LiveViewSize,            _put_Canon_LiveViewSize },
+	{ N_("Live View Setting Effect"),       "liveviewsettingeffect",    PTP_DPC_SONY_LiveViewSettingEffect,     PTP_VENDOR_SONY,    PTP_DTC_UINT8,  _get_Sony_LiveViewSettingEffect,    _put_Sony_LiveViewSettingEffect },
 	{ N_("File Number Sequencing"),         "filenrsequencing",         PTP_DPC_NIKON_FileNumberSequence,       PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_OnOff_UINT8,             _put_Nikon_OnOff_UINT8 },
 	{ N_("Flash Sign"),                     "flashsign",                PTP_DPC_NIKON_FlashSign,                PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_OnOff_UINT8,             _put_Nikon_OnOff_UINT8 },
 	{ N_("Modelling Flash"),                "modelflash",               PTP_DPC_NIKON_E4ModelingFlash,          PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_OffOn_UINT8,             _put_Nikon_OffOn_UINT8 },

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -4263,6 +4263,23 @@ static struct deviceproptableu8 nikon_afsensor[] = {
 };
 GENERIC8TABLE(Nikon_AutofocusArea,nikon_afsensor)
 
+static struct deviceproptableu16 sony_focusarea[] = {
+		{ N_("Wide"), 0x01, 0 },
+		{ N_("Zone"),	0x02, 0 },
+		{ N_("Center"),	0x03, 0 },
+		{ N_("Flexible Spot: S"),	0x101, 0 },
+		{ N_("Flexible Spot: M"),	0x102, 0 },
+		{ N_("Flexible Spot: L"),	0x103, 0 },
+		{ N_("Expand Flexible Spot"),	0x104, 0 },
+		{ N_("Lock-on AF: Wide"),	0x201, 0 },
+		{ N_("Lock-on AF: Zone"),	0x202, 0 },
+		{ N_("Lock-on AF: Center"),	0x203, 0 },
+		{ N_("Lock-on AF: Flexible Spot: S"),	0x204, 0 },
+		{ N_("Lock-on AF: Flexible Spot: M"),	0x205, 0 },
+		{ N_("Lock-on AF: Flexible Spot: L"),	0x206, 0 },
+		{ N_("Lock-on AF: Expand Flexible Spot"),	0x207, 0 },
+};
+GENERIC16TABLE(Sony_FocusArea,sony_focusarea)
 
 static struct deviceproptableu16 exposure_metering[] = {
 	{ N_("Average"),	0x0001, 0 },
@@ -10836,6 +10853,7 @@ static struct submenu capture_settings_menu[] = {
 	{ N_("Release without CF card"),        "nocfcardrelease",          PTP_DPC_NIKON_NoCFCard,                 PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_OnOff_UINT8,             _put_Nikon_OnOff_UINT8 },
 	{ N_("Flash Mode Manual Power"),        "flashmodemanualpower",     PTP_DPC_NIKON_FlashModeManualPower,     PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_FlashModeManualPower,    _put_Nikon_FlashModeManualPower },
 	{ N_("Auto Focus Area"),                "autofocusarea",            PTP_DPC_NIKON_AutofocusArea,            PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_AutofocusArea,           _put_Nikon_AutofocusArea },
+	{ N_("Focus Area"),                     "focusarea",                PTP_DPC_SONY_FocusArea,                 PTP_VENDOR_SONY,    PTP_DTC_UINT16, _get_Sony_FocusArea,                _put_Sony_FocusArea },
 	{ N_("Flash Exposure Compensation"),    "flashexposurecompensation", PTP_DPC_NIKON_FlashExposureCompensation, PTP_VENDOR_NIKON, PTP_DTC_INT8,   _get_Nikon_FlashExposureCompensation, _put_Nikon_FlashExposureCompensation },
 	{ N_("Bracketing"),                     "bracketing",               PTP_DPC_NIKON_Bracketing,               PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_OnOff_UINT8,             _put_Nikon_OnOff_UINT8 },
 	{ N_("Bracketing"),                     "bracketmode",              PTP_DPC_NIKON_E6ManualModeBracketing,   PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_ManualBracketMode,       _put_Nikon_ManualBracketMode },

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -7544,6 +7544,7 @@ ptp_get_property_description(PTPParams* params, uint16_t dpc)
 		{PTP_DPC_SONY_QX_ExposureCompensation, N_("Exposure Bias Compensation")},
 		{PTP_DPC_SONY_ISO2, N_("ISO")},				/* 0xD226 */
 		{PTP_DPC_SONY_ShutterSpeed2, N_("Shutter speed")},	/* 0xD229 */
+		{PTP_DPC_SONY_LiveViewSettingEffect, N_("Live View Setting Effect")},
 		{PTP_DPC_SONY_Movie, N_("Movie")},			/* 0xD2C8 */
 		{PTP_DPC_SONY_StillImage, N_("Still Image")},		/* 0xD2C7 */
 		{PTP_DPC_SONY_SensorCrop, N_("Sensor Crop")},

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -7549,6 +7549,7 @@ ptp_get_property_description(PTPParams* params, uint16_t dpc)
 		{PTP_DPC_SONY_StillImage, N_("Still Image")},		/* 0xD2C7 */
 		{PTP_DPC_SONY_SensorCrop, N_("Sensor Crop")},
 		{PTP_DPC_SONY_AutoFocus, N_("Autofocus")},
+		{PTP_DPC_SONY_FocusArea, N_("Focus Area")},
 		{PTP_DPC_SONY_Capture, N_("Capture")},
 		{PTP_DPC_WhiteBalance, N_("White Balance")},		/* 0x5005 */
 		{PTP_DPC_SONY_Zoom, N_("Zoom")},

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -3086,7 +3086,6 @@ typedef struct _PTPCanonEOSDeviceInfo {
 #define PTP_DPC_SONY_ISO				0xD21E	/* ? */
 #define PTP_DPC_SONY_StillImageStoreDestination		0xD222  /* (type=0x4) Enumeration [1,17,16] value: 17 */
 /* guessed DPC_SONY_DateTimeSettings 0xD223  error on query */
-/* guessed DPC_SONY_FocusArea 0xD22C  (type=0x4) Enumeration [1,2,3,257,258,259,260,513,514,515,516,517,518,519,261,520] value: 1 */
 /* guessed DPC_SONY_FileType 0xD235  (enum: 0,1) */
 /* guessed DPC_SONY_JpegQuality 0xD252 */
 /* d255 reserved 5 */
@@ -3094,6 +3093,7 @@ typedef struct _PTPCanonEOSDeviceInfo {
 #define PTP_DPC_SONY_ExposureCompensation		0xD224
 #define PTP_DPC_SONY_ISO2				0xD226
 #define PTP_DPC_SONY_ShutterSpeed2			0xD229
+#define PTP_DPC_SONY_FocusArea				0xD22C  /* (type=0x4) Enumeration [1,2,3,257,258,259,260,513,514,515,516,517,518,519,261,520] value: 1 */
 #define PTP_DPC_SONY_LiveViewSettingEffect  0xD231  /* (type=0x2) Enumeration [1,2] value: 1 */
 #define PTP_DPC_SONY_PriorityMode			0xD25A
 #define PTP_DPC_SONY_AutoFocus				0xD2C1 /* ? half-press */

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -3087,7 +3087,6 @@ typedef struct _PTPCanonEOSDeviceInfo {
 #define PTP_DPC_SONY_StillImageStoreDestination		0xD222  /* (type=0x4) Enumeration [1,17,16] value: 17 */
 /* guessed DPC_SONY_DateTimeSettings 0xD223  error on query */
 /* guessed DPC_SONY_FocusArea 0xD22C  (type=0x4) Enumeration [1,2,3,257,258,259,260,513,514,515,516,517,518,519,261,520] value: 1 */
-/* guessed DPC_SONY_LiveDisplayEffect 0xD231 (type=0x2) Enumeration [1,2] value: 1 */
 /* guessed DPC_SONY_FileType 0xD235  (enum: 0,1) */
 /* guessed DPC_SONY_JpegQuality 0xD252 */
 /* d255 reserved 5 */
@@ -3095,6 +3094,7 @@ typedef struct _PTPCanonEOSDeviceInfo {
 #define PTP_DPC_SONY_ExposureCompensation		0xD224
 #define PTP_DPC_SONY_ISO2				0xD226
 #define PTP_DPC_SONY_ShutterSpeed2			0xD229
+#define PTP_DPC_SONY_LiveViewSettingEffect  0xD231  /* (type=0x2) Enumeration [1,2] value: 1 */
 #define PTP_DPC_SONY_PriorityMode			0xD25A
 #define PTP_DPC_SONY_AutoFocus				0xD2C1 /* ? half-press */
 #define PTP_DPC_SONY_Capture				0xD2C2 /* ? full-press */


### PR DESCRIPTION
Adds the following A7R3/A7R3A settings:

- 'Focus Area'  => Auto focus area control

/main/capturesettings/focusarea
Label: Focus Area
Readonly: 0
Type: RADIO
Current: Wide
Choice: 0 Wide
Choice: 1 Zone
Choice: 2 Center
Choice: 3 Flexible Spot: S
Choice: 4 Flexible Spot: M
Choice: 5 Flexible Spot: L
Choice: 6 Expand Flexible Spot
END

- 'Live Display: Setting Effect ON/OFF' => Toggle exposure in live view / preview image

/main/capturesettings/liveviewsettingeffect
Label: Live View Setting Effect
Readonly: 0
Type: RADIO
Current: Off
Choice: 0 On
Choice: 1 Off
END


Likely these exist on other Sony cameras as the property ids were commented out in ptp.h previously.

Tried to name them like the Sony settings in the camera manual but slightly more concise, let me know if you want different naming.

[a7_settings.txt](https://github.com/gphoto/libgphoto2/files/10045465/a7_settings.txt)
