### PR TITLE
Add properties to control Sony focus assist magnification

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -8800,6 +8800,32 @@ _put_Sony_Bulb(CONFIG_PUT_ARGS)
 }
 
 static int
+_get_Sony_FocusMagnifyProp(CONFIG_GET_ARGS) {
+	int val;
+
+	gp_widget_new (GP_WIDGET_TOGGLE, _(menu->label), widget);
+	gp_widget_set_name (*widget,menu->name);
+	val = 2; /* always changed */
+	gp_widget_set_value  (*widget, &val);
+	return GP_OK;
+}
+
+static int
+_put_Sony_FocusMagnifyProp(CONFIG_PUT_ARGS)
+{
+	PTPParams *params = &(camera->pl->params);
+	int val;
+	PTPPropertyValue xpropval;
+
+	CR (gp_widget_get_value(widget, &val));
+	xpropval.u16 = val ? 2 : 1;
+
+	C_PTP (ptp_sony_setdevicecontrolvalueb (params, dpd->DevicePropertyCode, &xpropval, PTP_DTC_UINT16));
+
+	return GP_OK;
+}
+
+static int
 _get_Panasonic_Movie(CONFIG_GET_ARGS) {
 	int val;
 
@@ -10541,6 +10567,12 @@ static struct submenu camera_actions_menu[] = {
 	{ N_("Movie Capture"),                  "movie",            0,  PTP_VENDOR_SONY,    PTP_OC_SONY_QX_Connect,             _get_Sony_QX_Movie,             _put_Sony_QX_Movie },
 	{ N_("Movie Capture"),                  "movie",            0,  PTP_VENDOR_PANASONIC,PTP_OC_PANASONIC_MovieRecControl,  _get_Panasonic_Movie,           _put_Panasonic_Movie },
 	{ N_("Movie Mode"),                     "eosmoviemode",     0,  PTP_VENDOR_CANON,   0,                                  _get_Canon_EOS_MovieModeSw,     _put_Canon_EOS_MovieModeSw },
+	{ N_("Focus Magnify"),                  "focusmagnify",     PTP_DPC_SONY_FocusMagnify, PTP_VENDOR_SONY, PTP_DTC_UINT16, _get_Sony_FocusMagnifyProp,     _put_Sony_FocusMagnifyProp },
+	{ N_("Focus Magnify Exit"),             "focusmagnifyexit", PTP_DPC_SONY_FocusMagnifyExit, PTP_VENDOR_SONY, PTP_DTC_UINT16, _get_Sony_FocusMagnifyProp, _put_Sony_FocusMagnifyProp },
+	{ N_("Focus Magnify Up"),               "focusmagnifyup",   PTP_DPC_SONY_FocusMagnifyUp, PTP_VENDOR_SONY, PTP_DTC_UINT16, _get_Sony_FocusMagnifyProp,   _put_Sony_FocusMagnifyProp },
+	{ N_("Focus Magnify Down"),             "focusmagnifydown", PTP_DPC_SONY_FocusMagnifyDown, PTP_VENDOR_SONY, PTP_DTC_UINT16, _get_Sony_FocusMagnifyProp, _put_Sony_FocusMagnifyProp },
+	{ N_("Focus Magnify Left"),             "focusmagnifyleft", PTP_DPC_SONY_FocusMagnifyLeft, PTP_VENDOR_SONY, PTP_DTC_UINT16, _get_Sony_FocusMagnifyProp, _put_Sony_FocusMagnifyProp },
+	{ N_("Focus Magnify Right"),            "focusmagnifyright",PTP_DPC_SONY_FocusMagnifyRight, PTP_VENDOR_SONY, PTP_DTC_UINT16, _get_Sony_FocusMagnifyProp,_put_Sony_FocusMagnifyProp },
 	{ N_("PTP Opcode"),                     "opcode",           0,  0,                  PTP_OC_GetDeviceInfo,               _get_Generic_OPCode,            _put_Generic_OPCode },
 	{ 0,0,0,0,0,0,0 },
 };

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -3098,6 +3098,12 @@ typedef struct _PTPCanonEOSDeviceInfo {
 #define PTP_DPC_SONY_PriorityMode			0xD25A
 #define PTP_DPC_SONY_AutoFocus				0xD2C1 /* ? half-press */
 #define PTP_DPC_SONY_Capture				0xD2C2 /* ? full-press */
+#define PTP_DPC_SONY_FocusMagnify			0xD2CB
+#define PTP_DPC_SONY_FocusMagnifyExit			0xD2CC
+#define PTP_DPC_SONY_FocusMagnifyUp	    		0xD2CD
+#define PTP_DPC_SONY_FocusMagnifyDown			0xD2CE
+#define PTP_DPC_SONY_FocusMagnifyLeft			0xD2CF
+#define PTP_DPC_SONY_FocusMagnifyRight			0xD2D0
 /* D2DB (2) , D2D3 (2) , D2C8 (2) also seen in Camera Remote related to D2C2 */
 /* S1 ?
  * AEL - d2c3


### PR DESCRIPTION
This is useful for remotely dialing in focus when viewing the live view / preview images.

The following toggle actions control the focus assist magnification:

- focusmagnify      : enter focus magnification mode, toggles through magnification levels
- focusmagnifyexit  : exit focus magnification mode, back to normal live view / preview image
- focusmagnifyup    : move magnification zone up
- focusmagnifydown  : move magnification zone down
- focusmagnifyleft  : move magnification zone left
- focusmagnifyright : move magnification zone right

These are toggle actions and may need to be set twice to be noticed by the camera:

gphoto2 --set-config=focusmagnify=1 --set-config=focusmagnify=0
gphoto2 --set-config=focusmagnifyexit=1 --set-config=focusmagnifyexit=0