### PR TITLE
Fix string overflow in camera_summary

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -7433,11 +7433,16 @@ snprintf_ptp_property (char *txt, int spaceleft, PTPPropertyValue *data, uint16_
 #define SPACE_LEFT ptp_max(0, (origtxt + spaceleft - txt))
 
 		txt += snprintf (txt, SPACE_LEFT, "a[%d] ", data->a.count);
-		for ( i=0; i<data->a.count; i++) {
+		unsigned int n_to_print = data->a.count;
+		if (n_to_print > 64)
+			n_to_print = 64;
+		for ( i=0; i<n_to_print; i++) {
 			txt += snprintf_ptp_property (txt, SPACE_LEFT, &data->a.v[i], dt & ~PTP_DTC_ARRAY_MASK);
-			if (i!=data->a.count-1)
+			if (i!=n_to_print-1)
 				txt += snprintf (txt, SPACE_LEFT, ",");
 		}
+		if (n_to_print < data->a.count)
+			txt += snprintf (txt, SPACE_LEFT, ", ...");
 		return txt - origtxt;
 #undef SPACE_LEFT
 	} else {

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -7417,6 +7417,11 @@ handleregular:
 	return GP_OK;
 }
 
+static int ptp_max(int a, int b) {
+	if (a > b) return a;
+	return b;
+}
+
 static int
 snprintf_ptp_property (char *txt, int spaceleft, PTPPropertyValue *data, uint16_t dt)
 {
@@ -7425,7 +7430,7 @@ snprintf_ptp_property (char *txt, int spaceleft, PTPPropertyValue *data, uint16_
 	if (dt & PTP_DTC_ARRAY_MASK) {
 		unsigned int i;
 		const char *origtxt = txt;
-#define SPACE_LEFT (origtxt + spaceleft - txt)
+#define SPACE_LEFT ptp_max(0, (origtxt + spaceleft - txt))
 
 		txt += snprintf (txt, SPACE_LEFT, "a[%d] ", data->a.count);
 		for ( i=0; i<data->a.count; i++) {
@@ -7570,11 +7575,6 @@ nikon_curve_put (CameraFilesystem *fs, const char *folder, CameraFile *file,
 {
 	/* not yet */
 	return (GP_OK);
-}
-
-static int ptp_max(int a, int b) {
-	if (a > b) return a;
-	return b;
 }
 
 static int


### PR DESCRIPTION
This fixes a crash running "gphoto2 --summary" when there is a PTP property which is a very long array overflowing the buffer. It also truncates the long array - not sure if 64 is the appropriate value to truncate at.

The problem was triggered by this property from an Olympus E-M1 II:

Property 0xd405:(read only) (type=0x4002) a[74752] 0,0,1,0,5,0,0,0,0,0,1,0,32,0,223,222,0,0,86,0,0,0,48,48,0,0,1,0,32,0,168,37,0,0,53,223,0,0,32,32,0,0,1,0,32,0,168,16,0,0,221,4,1,0,24,24,0,0,1,0,32,0,136,9, ...
