### PR TITLE
Update Go bindings to new package in readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ libgphoto2 has _not_ (yet?) been ported to any operating system from MicroSoft.
 - Java: [gphoto2-java](https://github.com/mvysny/gphoto2-java), [libgphoto2-jna](https://github.com/angryelectron/libgphoto2-jna)
 - Python: [python-gphoto2](https://github.com/jim-easterbrook/python-gphoto2), [gphoto2-cffi](https://github.com/jbaiter/gphoto2-cffi)
 - C#: [libgphoto2-sharp](https://github.com/gphoto/libgphoto2-sharp)
-- Go: [go-gphoto2](https://github.com/aqiank/go-gphoto2)
+- Go: [gphoto2-go](https://github.com/weebney/gphoto2-go)
 - Rust: [gphoto-rs](https://github.com/dcuddeback/gphoto-rs)
 - Node.js: [node-gphoto2](https://github.com/lwille/node-gphoto2)
 - Ruby: [ffi-gphoto2](https://github.com/zaeleus/ffi-gphoto2)


### PR DESCRIPTION
I've forked the old (now 9 years without a commit, so presumably abandoned) Go bindings ([aqiank/go-gphoto2](https://github.com/aqiank/go-gphoto2)), and have done some work modernizing them for use with the modern Go toolchain which was not possible with the old bindings. The new bindings can be found at [weebney/gphoto2-go](https://github.com/weebney/gphoto2-go)—I intend to maintain them and do some major overhauling to these in the coming months as I would like to use them in a project.

This pull request updates the readme to recommend my fork instead of the out-of-date bindings.