### PR TITLE
Fix FreeBSD build

### DIFF
--- a/camlibs/kodak/dc120/dc120.c
+++ b/camlibs/kodak/dc120/dc120.c
@@ -23,11 +23,15 @@
 
 #include "config.h"
 
+/* Must be included before including unistd.h to define _XOPEN_SOURCE
+   before unistd.h on FreeBSD. */
+#include <gphoto2/gphoto2-port-portability.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
-#include	<unistd.h>
+#include <unistd.h>
 
 #include <gphoto2/gphoto2.h>
 #include <gphoto2/gphoto2-port.h>

--- a/camlibs/kodak/dc120/library.c
+++ b/camlibs/kodak/dc120/library.c
@@ -22,6 +22,10 @@
 #define _POSIX_C_SOURCE 199309L
 #include "config.h"
 
+/* Must be included before including unistd.h to define _XOPEN_SOURCE
+   before unistd.h on FreeBSD. */
+#include <gphoto2/gphoto2-port-portability.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/camlibs/panasonic/coolshot/library.c
+++ b/camlibs/panasonic/coolshot/library.c
@@ -29,6 +29,10 @@
 
 #include "config.h"
 
+/* Must be included before including unistd.h to define _XOPEN_SOURCE
+   before unistd.h on FreeBSD. */
+#include <gphoto2/gphoto2-port-portability.h>
+
 #include <stdio.h>
 #include <string.h>
 #include <gphoto2/gphoto2.h>

--- a/camlibs/ptp2/fujiptpip.c
+++ b/camlibs/ptp2/fujiptpip.c
@@ -62,6 +62,7 @@
 #else
 # include <sys/socket.h>
 # include <netinet/in.h>
+# include <arpa/inet.h>
 #endif
 #include "ptpip-private.h"
 

--- a/camlibs/ptp2/ptpip.c
+++ b/camlibs/ptp2/ptpip.c
@@ -51,6 +51,7 @@
 #else
 # include <sys/socket.h>
 # include <netinet/in.h>
+# include <arpa/inet.h>
 # include <fcntl.h>
 #endif
 

--- a/camlibs/st2205/st2205.c
+++ b/camlibs/st2205/st2205.c
@@ -18,7 +18,7 @@
  * Boston, MA  02110-1301  USA
  */
 #define _DEFAULT_SOURCE
-#define _POSIX_C_SOURCE 1
+#define _POSIX_C_SOURCE 199506
 #define _DARWIN_C_SOURCE
 #include "config.h"
 


### PR DESCRIPTION
Fix the FreeBSD build by defining the appropriate
C preprocessor macros such that the libc headers
define prototypes for the functions used.