### PR TITLE
LIBGPHOTO2_INTERNAL: Symbol gpi_gphoto_port_type_map is present

### DIFF
--- a/libgphoto2_port/gphoto2/gphoto2-port-info-list.h
+++ b/libgphoto2_port/gphoto2/gphoto2-port-info-list.h
@@ -62,7 +62,6 @@ extern "C" {
 
 #ifdef _GPHOTO2_INTERNAL_CODE
 #include <gphoto2/gphoto2-port-log.h>
-extern const StringFlagItem gpi_gphoto_port_type_map[];
 #endif
 
 int gp_port_info_new (GPPortInfo *info);

--- a/libgphoto2_port/libgphoto2_port/libgphoto2_port.ver
+++ b/libgphoto2_port/libgphoto2_port/libgphoto2_port.ver
@@ -73,7 +73,6 @@ LIBGPHOTO2_5_0 {
 
 # These are only supposed to be used by libgphoto2 internally.
 LIBGPHOTO2_INTERNAL {
-	gpi_gphoto_port_type_map;
 	gpi_enum_to_string;
 	gpi_string_to_enum;
 	gpi_string_to_flag;


### PR DESCRIPTION
in one of two versions of code, but not used anywhere. Noted in NEWS as removed. It breaks compilation in some systems.