### PR TITLE
add fixes in case `PTP_DPC_FUJI_PriorityMode` not available (e.g. Fujifilm X100V)

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -633,7 +633,7 @@ camera_unprepare_capture (Camera *camera, GPContext *context)
 			if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
 				propval.u16 = 0x0001;
 				C_PTP (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
-            }
+			}
 
 			return GP_OK;
 		}

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -509,10 +509,10 @@ camera_prepare_capture (Camera *camera, GPContext *context)
 			propval.u16 = 0x0001;
 			LOG_ON_PTP_E (ptp_setdevicepropvalue (params, 0xd38c, &propval, PTP_DTC_UINT16));
 
-            if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
-			    propval.u16 = 0x0002;
-			    LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
-            }
+			if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
+				propval.u16 = 0x0002;
+				LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+			}
 
 			return GP_OK;
 		}
@@ -630,9 +630,9 @@ camera_unprepare_capture (Camera *camera, GPContext *context)
 				params->inliveview = 0;
 			}
 
-            if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
-                propval.u16 = 0x0001;
-                C_PTP (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+			if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
+				propval.u16 = 0x0001;
+				C_PTP (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
             }
 
 			return GP_OK;

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -509,8 +509,10 @@ camera_prepare_capture (Camera *camera, GPContext *context)
 			propval.u16 = 0x0001;
 			LOG_ON_PTP_E (ptp_setdevicepropvalue (params, 0xd38c, &propval, PTP_DTC_UINT16));
 
-			propval.u16 = 0x0002;
-			LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+            if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
+			    propval.u16 = 0x0002;
+			    LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+            }
 
 			return GP_OK;
 		}
@@ -628,8 +630,11 @@ camera_unprepare_capture (Camera *camera, GPContext *context)
 				params->inliveview = 0;
 			}
 
-			propval.u16 = 0x0001;
-			C_PTP (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+            if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
+                propval.u16 = 0x0001;
+                C_PTP (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+            }
+
 			return GP_OK;
 		}
 		break;

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -5259,8 +5259,10 @@ camera_fuji_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pat
 		C_PTP (ptp_terminateopencapture (params,params->opencapture_transid));
 	}
 
-	propval.u16 = 0x0002;
-	LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+    if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
+	    propval.u16 = 0x0002;
+	    LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+    }
 
 	C_PTP (ptp_getobjecthandles (params, PTP_HANDLER_SPECIAL, 0x000000, 0x000000, &beforehandles));
 
@@ -5310,8 +5312,10 @@ camera_fuji_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pat
 		propval.u16 = 0x0004;
 		C_PTP_REP (ptp_setdevicepropvalue (params, 0xd208, &propval, PTP_DTC_UINT16));
 		C_PTP_REP (ptp_initiatecapture(params, 0x00000000, 0x00000000));
-		propval.u16 = 0x0001;
-		LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+        if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
+		    propval.u16 = 0x0001;
+		    LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+        }
 		return GP_ERROR;
 	}
 
@@ -7159,8 +7163,10 @@ sonyout:
 		PTPPropertyValue propval;
 
 		/* reenable event wait mode */
-		propval.u16 = 0x0001;
-		LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+        if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
+		    propval.u16 = 0x0001;
+		    LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+        }
 
 		/* current strategy ... as the camera (currently) does not send us ObjectAdded events for some reason...
 		 * we just synthesize them for the generic PTP event handler code */

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -5259,10 +5259,10 @@ camera_fuji_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pat
 		C_PTP (ptp_terminateopencapture (params,params->opencapture_transid));
 	}
 
-    if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
-	    propval.u16 = 0x0002;
-	    LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
-    }
+	if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
+		propval.u16 = 0x0002;
+		LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+	}
 
 	C_PTP (ptp_getobjecthandles (params, PTP_HANDLER_SPECIAL, 0x000000, 0x000000, &beforehandles));
 
@@ -5312,10 +5312,12 @@ camera_fuji_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pat
 		propval.u16 = 0x0004;
 		C_PTP_REP (ptp_setdevicepropvalue (params, 0xd208, &propval, PTP_DTC_UINT16));
 		C_PTP_REP (ptp_initiatecapture(params, 0x00000000, 0x00000000));
-        if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
-		    propval.u16 = 0x0001;
-		    LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+
+		if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
+			propval.u16 = 0x0001;
+			LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
         }
+
 		return GP_ERROR;
 	}
 
@@ -6520,10 +6522,12 @@ camera_trigger_capture (Camera *camera, GPContext *context)
 			propval.u16 = 0x0004;
 			C_PTP_REP (ptp_setdevicepropvalue (params, 0xd208, &propval, PTP_DTC_UINT16));
 			C_PTP_REP (ptp_initiatecapture(params, 0x00000000, 0x00000000));
+
 			if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
 				propval.u16 = 0x0001;
 				LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
 			}
+
 			return GP_ERROR;
 		}
 
@@ -7163,10 +7167,10 @@ sonyout:
 		PTPPropertyValue propval;
 
 		/* reenable event wait mode */
-        if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
-		    propval.u16 = 0x0001;
-		    LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
-        }
+		if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
+			propval.u16 = 0x0001;
+			LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
+		}
 
 		/* current strategy ... as the camera (currently) does not send us ObjectAdded events for some reason...
 		 * we just synthesize them for the generic PTP event handler code */

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -5316,7 +5316,7 @@ camera_fuji_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pat
 		if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
 			propval.u16 = 0x0001;
 			LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
-        }
+		}
 
 		return GP_ERROR;
 	}


### PR DESCRIPTION
Fix had already been applied for one instance (https://github.com/gphoto/libgphoto2/commit/5f9f6c87189d3223fb26d2db9a6a1a825bda9cf2), I've found all instances and applied the same fix.

I believe this fixes (at least) #950 