### PR TITLE
Support the SetModeDialDisable opcode for Canon cameras

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -10216,6 +10216,26 @@ _put_CHDK(CONFIG_PUT_ARGS) {
 	return GP_OK;
 }
 
+static int
+_get_Canon_SetModeDialDisable(CONFIG_GET_ARGS) {
+	gp_widget_new (GP_WIDGET_TOGGLE, _(menu->label), widget);
+	gp_widget_set_name (*widget,menu->name);
+	int val = 0;
+	gp_widget_set_value  (*widget, &val);
+	return GP_OK;
+}
+
+static int
+_put_Canon_SetModeDialDisable(CONFIG_PUT_ARGS) {
+	PTPParams *params = &(camera->pl->params);
+	int val;
+	if (!ptp_operation_issupported(params, PTP_OC_CANON_SetModeDialDisable))
+		return (GP_ERROR_NOT_SUPPORTED);
+	CR (gp_widget_get_value(widget, &val));
+	C_PTP (ptp_canon_setmodedialdisable(params, val));
+	return GP_OK;
+}
+
 static struct {
 	char	*name;
 	char	*label;
@@ -10818,6 +10838,7 @@ static struct submenu camera_actions_menu[] = {
 	{ N_("Remote Key Down"),                "remotekeydown", PTP_DPC_SONY_RemoteKeyDown, PTP_VENDOR_SONY, PTP_DTC_UINT16,	_get_Sony_FocusMagnifyProp, _put_Sony_FocusMagnifyProp },
 	{ N_("Remote Key Left"),                "remotekeyleft", PTP_DPC_SONY_RemoteKeyLeft, PTP_VENDOR_SONY, PTP_DTC_UINT16,	_get_Sony_FocusMagnifyProp, _put_Sony_FocusMagnifyProp },
 	{ N_("Remote Key Right"),               "remotekeyright",PTP_DPC_SONY_RemoteKeyRight, PTP_VENDOR_SONY, PTP_DTC_UINT16, _get_Sony_FocusMagnifyProp,_put_Sony_FocusMagnifyProp },
+	{ N_("Canon Disable Mode Dial"),		"disablemodedial",	0,	PTP_VENDOR_CANON,	PTP_OC_CANON_SetModeDialDisable,	_get_Canon_SetModeDialDisable,	_put_Canon_SetModeDialDisable },
 	{ N_("PTP Opcode"),                     "opcode",           0,  0,                  PTP_OC_GetDeviceInfo,               _get_Generic_OPCode,            _put_Generic_OPCode },
 	{ 0,0,0,0,0,0,0 },
 };

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -3241,6 +3241,10 @@ camera_exit (Camera *camera, GPContext *context)
 			if (ptp_operation_issupported(params, PTP_OC_CANON_EOS_SetRemoteMode)) {
 				C_PTP (ptp_canon_eos_setremotemode(params, 1));
 			}
+			/* re-enable the mode dial (it may fail with PTP general error 0x2002 )*/
+			if (ptp_operation_issupported(params, PTP_OC_CANON_SetModeDialDisable)) {
+				ptp_canon_setmodedialdisable(params, 0);
+			}
 			break;
 		case PTP_VENDOR_NIKON:
 			if (ptp_operation_issupported(params, PTP_OC_NIKON_EndLiveView))
@@ -10083,6 +10087,10 @@ camera_init (Camera *camera, GPContext *context)
 				C_PTP (ptp_canon_eos_setremotemode(params, 1));
 			}
 		}
+		/* enable software setting of the mode dial (ignore potential error) */
+		if (ptp_operation_issupported(params, PTP_OC_CANON_SetModeDialDisable)) {
+			ptp_canon_setmodedialdisable(params, 1);
+		}		
 		break;
 	case PTP_VENDOR_NIKON:
 		if (ptp_operation_issupported(params, PTP_OC_NIKON_CurveDownload))

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -8963,6 +8963,7 @@ ptp_opcode_trans_t ptp_opcode_canon_trans[] = {
 	{PTP_OC_CANON_EOS_NotifySaveComplete,"EOS_NotifySaveComplete"},
 	{PTP_OC_CANON_EOS_GetObjectURL,"EOS_GetObjectURL"},
 	{PTP_OC_CANON_SetRemoteShootingMode,"SetRemoteShootingMode"},
+	{PTP_OC_CANON_SetModeDialDisable,"SetModeDialDisable"},
 	{PTP_OC_CANON_EOS_SetFELock,"EOS_SetFELock"},
 	{PTP_OC_CANON_DeleteWebServiceData,"DeleteWebServiceData"},
 	{PTP_OC_CANON_GetGpsMobilelinkObjectInfo,"GetGpsMobilelinkObjectInfo"},

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -329,6 +329,7 @@ typedef struct _PTPIPHeader PTPIPHeader;
 #define PTP_OC_CANON_RequestTranscodeCancel	0x9079 /* 1 arg: oid? */
 
 #define PTP_OC_CANON_SetRemoteShootingMode	0x9086
+#define PTP_OC_CANON_SetModeDialDisable		0x9088
 
 /* 9101: no args, 8 byte data (01 00 00 00 00 00 00 00), no resp data. */
 #define PTP_OC_CANON_EOS_GetStorageIDs		0x9101
@@ -4280,6 +4281,16 @@ uint16_t ptp_canon_checkevent (PTPParams* params,
  *
  **/
 #define ptp_canon_initiatecaptureinmemory(params) ptp_generic_no_data(params,PTP_OC_CANON_InitiateCaptureInMemory,0)
+/**
+ * ptp_canon_setmodedialdisable:
+ *
+ * This operation allows software setting of the mode dial. THe software setting is disabled by default.
+ * The operation has one parameter, with the value 0 or 1.
+ * Parameter 0 disables the software setting of the mode dial, 1 allows software setting of the mode dial.
+ * When software setting is allowed the physical mode dial is disabled. This situation remains until the camera is
+ * powered off, or the camera is disconnected.
+ */
+#define ptp_canon_setmodedialdisable(params, onoff) ptp_generic_no_data(params,PTP_OC_CANON_SetModeDialDisable,1, onoff)
 /**
  * ptp_canon_eos_requestdevicepropvalue:
  *


### PR DESCRIPTION
Several Canon EOS cameras allow software setting of the exposure mode dial. This is supported by `libgphoto2` via the `autoexposuremodedial` config.
This works as expected wit for instance the EOS 1200D and the EOS 2000D. 
In some Canon cameras, for instance the Canon EOS R50,  you need to unlock this feature before it can be used. 

The `SetModeDialDisable` opcode (`0x9088`) has to be sent to the camera with parameter 0 to disable the mode dial and allow software setting of the exposure mode.
The disabling is cancelled by sending the `SetModeDialDisable` command with parameter 1.

This pull request will allow software setting of the exposure mode during a camera session by issuing the `SetModeDialDisable` as described above, by enabling software setting in `camera_init` and disabling it in `camera_exit`.

It also adds a `disablemodedial`  camera action config so that the feature can be enabled / disabled during a camera session.

Being able to control the exposure mode via software is a valuable feature for many applications.

This pull request consists of 3 commits:
* b83256ce836c1574ca35356a1a36c3056017cefb adds the `PTP_OC_CANON_SetModeDialDisable` opcode in `ptp.h` and `ptp.c`
* ca241537c1b5dc0ad0a67e66f9d942649683243e adds the enabling/disabling to `camera_init` and `camera_exit` for supported cameras
* 26f4e49d6fb91aea598a511d7915159bf6e80411 adds `disablemodedial` command to camera actions for supported cameras