### PR TITLE
Only allocate when a logging functions needs it

### DIFF
--- a/libgphoto2_port/libgphoto2_port/gphoto2-port-log.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port-log.c
@@ -307,15 +307,23 @@ gp_logv (GPLogLevel level, const char *domain, const char *format,
 	if (!log_funcs_count || level > log_max_level)
 		return;
 
-	str = gpi_vsnprintf(format, args);
-	if (!str) {
-		GP_LOG_E ("Malloc for expanding format string '%s' failed.", format);
-		return;
-	}
-
+    int has_allocated = 0;
 	for (i = 0; i < log_funcs_count; i++)
 		if (log_funcs[i].level >= level)
+        {
+            if (!has_allocated)
+            {
+                // Only allocate when any of the functions will log
+                str = gpi_vsnprintf(format, args);
+                if (!str) {
+                    GP_LOG_E ("Malloc for expanding format string '%s' failed.", format);
+                    return;
+                }
+                has_allocated = 1;
+            }
+
 			log_funcs[i].func (level, domain, str, log_funcs[i].data);
+        }
 	free (str);
 }
 


### PR DESCRIPTION
Issue: #996 

Instead of allocating _before_ knowing if it is necessary and thus wasting precious clock cycles, we instead allocate only when a log function shall log the data.

Example: When downloading a large video file from the Nikon Z9, we go from 60s to 6-8s, when using the log level "ERROR".  Before, we allocated for every log message that shouldn't even be logged.