### PR TITLE
fix white-space and indentation inconsistencies in ptp2 driver

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -182,7 +182,7 @@ camera_prepare_canon_powershot_capture(Camera *camera, GPContext *context) {
 	PTPParams		*params = &camera->pl->params;
 	int 			found, oldtimeout;
 
-        if (ptp_property_issupported(params, PTP_DPC_CANON_FlashMode)) {
+	if (ptp_property_issupported(params, PTP_DPC_CANON_FlashMode)) {
 		GP_LOG_D ("Canon capture mode is already set up.");
 		C_PTP (ptp_getdevicepropvalue(params, PTP_DPC_CANON_EventEmulateMode, &propval, PTP_DTC_UINT16));
 		GP_LOG_D ("Event emulate mode 0x%04x", propval.u16);
@@ -3084,16 +3084,16 @@ _get_Fuji_FocusPoint(CONFIG_GET_ARGS) {
 
 static int
 _put_Fuji_FocusPoint(CONFIG_PUT_ARGS) {
-        PTPParams *params = &(camera->pl->params);
-        GPContext *context = ((PTPData *) params->data)->context;
-        PTPPropertyValue pval;
-        char *focus_point;
+	PTPParams *params = &(camera->pl->params);
+	GPContext *context = ((PTPData *) params->data)->context;
+	PTPPropertyValue pval;
+	char *focus_point;
 
-        CR (gp_widget_get_value(widget, &focus_point));
-        C_MEM (pval.str = strdup(focus_point));
-        C_PTP_REP(ptp_setdevicepropvalue(params, PTP_DPC_FUJI_FocusArea4, &pval, PTP_DTC_STR));
+	CR (gp_widget_get_value(widget, &focus_point));
+	C_MEM (pval.str = strdup(focus_point));
+	C_PTP_REP(ptp_setdevicepropvalue(params, PTP_DPC_FUJI_FocusArea4, &pval, PTP_DTC_STR));
 	*alreadyset = 1;
-        return GP_OK;
+	return GP_OK;
 }
 
 
@@ -6756,10 +6756,10 @@ static struct deviceproptableu8 nikon_d7100_padvpvalue[] = {
 	{ "1/30",	0x15, 0 },
 	{ "1/15",	0x16, 0 },
 	{ "1/8",	0x17, 0 },
-        { "1/4",	0x18, 0 },
-        { "1/2",	0x19, 0 },
-        { "1",		0x1a, 0 },
-        { "Auto",	0x1b, 0 },
+	{ "1/4",	0x18, 0 },
+	{ "1/2",	0x19, 0 },
+	{ "1",		0x1a, 0 },
+	{ "Auto",	0x1b, 0 },
 };
 GENERIC8TABLE(Nikon_D7100_PADVPValue,nikon_d7100_padvpvalue)
 
@@ -8302,7 +8302,7 @@ _put_Canon_EOS_ViewFinder(CONFIG_PUT_ARGS) {
 		xval.u32 = 0;
 	C_PTP_MSG (ptp_canon_eos_setdevicepropvalue (params, PTP_DPC_CANON_EOS_EVFOutputDevice, &xval, PTP_DTC_UINT32),
 		   "ptp2_eos_viewfinder enable: failed to set evf outputmode to %d", xval.u32);
-        return GP_OK;
+	return GP_OK;
 }
 
 static int
@@ -8331,7 +8331,7 @@ _put_Canon_EOS_TestOLC(CONFIG_PUT_ARGS) {
 		}
 		C_PTP (ptp_canon_eos_setrequestolcinfogroup(params, 0x1fff));
 	}
-        return GP_OK;
+	return GP_OK;
 }
 
 static int
@@ -8598,7 +8598,7 @@ _put_Sony_Movie(CONFIG_PUT_ARGS)
 		value.u16 = 2;
 	else
 		value.u16 = 1;
-        C_PTP_REP (ptp_sony_setdevicecontrolvalueb (params, 0xD2C8, &value, PTP_DTC_UINT16 ));
+	C_PTP_REP (ptp_sony_setdevicecontrolvalueb (params, 0xD2C8, &value, PTP_DTC_UINT16 ));
 	return GP_OK;
 }
 
@@ -8626,7 +8626,7 @@ _put_Sony_QX_Movie(CONFIG_PUT_ARGS)
 		value.u16 = 2;
 	else
 		value.u16 = 1;
-        C_PTP_REP (ptp_sony_qx_setdevicecontrolvalueb (params, PTP_DPC_SONY_QX_Movie_Rec, &value, PTP_DTC_UINT16 ));
+	C_PTP_REP (ptp_sony_qx_setdevicecontrolvalueb (params, PTP_DPC_SONY_QX_Movie_Rec, &value, PTP_DTC_UINT16 ));
 	*alreadyset = 1;
 	return GP_OK;
 }
@@ -8749,15 +8749,15 @@ _put_Nikon_Movie(CONFIG_PUT_ARGS)
 			C_PTP (ptp_nikon_changeapplicationmode (params, 1));
 		}
 
-                ret = ptp_getdevicepropvalue (params, PTP_DPC_NIKON_LiveViewStatus, &value, PTP_DTC_UINT8);
-                if (ret != PTP_RC_OK)
-                        value.u8 = 0;
+		ret = ptp_getdevicepropvalue (params, PTP_DPC_NIKON_LiveViewStatus, &value, PTP_DTC_UINT8);
+		if (ret != PTP_RC_OK)
+			value.u8 = 0;
 
-                if (!value.u8) {
-                        value.u8 = 1;
-                        LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_NIKON_RecordingMedia, &value, PTP_DTC_UINT8));
-                        C_PTP_REP_MSG (ptp_nikon_start_liveview (params),
-                                       _("Nikon enable liveview failed"));
+		if (!value.u8) {
+			value.u8 = 1;
+			LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_NIKON_RecordingMedia, &value, PTP_DTC_UINT8));
+			C_PTP_REP_MSG (ptp_nikon_start_liveview (params),
+				       _("Nikon enable liveview failed"));
 			C_PTP_REP_MSG (nikon_wait_busy(params, 50, 1000),
 				       _("Nikon enable liveview failed"));
 		}
@@ -9274,378 +9274,378 @@ struct {
 static int
 _put_Panasonic_AdjustGM(CONFIG_PUT_ARGS)
 {
-    PTPParams *params = &(camera->pl->params);
-    char *xval;
-    uint32_t val;
+	PTPParams *params = &(camera->pl->params);
+	char *xval;
+	uint32_t val;
 
-    CR (gp_widget_get_value(widget, &xval));
-    int16_t adj;
-    sscanf (xval, "%hd", &adj);
-    if (adj < 0) {
-        adj = abs(adj) + 0x8000;
-    }
-    val = adj;
+	CR (gp_widget_get_value(widget, &xval));
+	int16_t adj;
+	sscanf (xval, "%hd", &adj);
+	if (adj < 0) {
+		adj = abs(adj) + 0x8000;
+	}
+	val = adj;
 
-    return translate_ptp_result (ptp_panasonic_setdeviceproperty(params, PTP_DPC_PANASONIC_WhiteBalance_ADJ_GM, (unsigned char*)&val, 2));
+	return translate_ptp_result (ptp_panasonic_setdeviceproperty(params, PTP_DPC_PANASONIC_WhiteBalance_ADJ_GM, (unsigned char*)&val, 2));
 }
 
 static int
 _get_Panasonic_AdjustGM(CONFIG_GET_ARGS) {
-    uint32_t currentVal = 0;
-    char buf[32];
-    PTPParams *params = &(camera->pl->params);
-    GPContext *context = ((PTPData *) params->data)->context;
+	uint32_t currentVal = 0;
+	char buf[32];
+	PTPParams *params = &(camera->pl->params);
+	GPContext *context = ((PTPData *) params->data)->context;
 
-    uint16_t valsize;
-    C_PTP_REP (ptp_panasonic_getdeviceproperty(params, PTP_DPC_PANASONIC_WhiteBalance_ADJ_GM, &valsize, &currentVal));
+	uint16_t valsize;
+	C_PTP_REP (ptp_panasonic_getdeviceproperty(params, PTP_DPC_PANASONIC_WhiteBalance_ADJ_GM, &valsize, &currentVal));
 
-    //printf("retrieved %x with size %x\n", currentVal, valsize);
-    if (currentVal & 0x8000) {
-        currentVal = (currentVal & 0x7FFF) * -1;
-    }
-    sprintf(buf, "%d\n", currentVal);
+	//printf("retrieved %x with size %x\n", currentVal, valsize);
+	if (currentVal & 0x8000) {
+		currentVal = (currentVal & 0x7FFF) * -1;
+	}
+	sprintf(buf, "%d\n", currentVal);
 
-    gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
-    gp_widget_set_name (*widget, menu->name);
+	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
+	gp_widget_set_name (*widget, menu->name);
 
-    gp_widget_set_value(*widget, &buf);
-    return GP_OK;
+	gp_widget_set_value(*widget, &buf);
+	return GP_OK;
 }
 
 static int
 _put_Panasonic_AdjustAB(CONFIG_PUT_ARGS)
 {
-    PTPParams *params = &(camera->pl->params);
-    char *xval;
-    uint32_t val;
+	PTPParams *params = &(camera->pl->params);
+	char *xval;
+	uint32_t val;
 
-    CR (gp_widget_get_value(widget, &xval));
-    int16_t adj;
-    sscanf (xval, "%hd", &adj);
-    if (adj < 0) {
-        adj = abs(adj) + 0x8000;
-    }
-    val = adj;
+	CR (gp_widget_get_value(widget, &xval));
+	int16_t adj;
+	sscanf (xval, "%hd", &adj);
+	if (adj < 0) {
+		adj = abs(adj) + 0x8000;
+	}
+	val = adj;
 
-    return translate_ptp_result (ptp_panasonic_setdeviceproperty(params, PTP_DPC_PANASONIC_WhiteBalance_ADJ_AB, (unsigned char*)&val, 2));
+	return translate_ptp_result (ptp_panasonic_setdeviceproperty(params, PTP_DPC_PANASONIC_WhiteBalance_ADJ_AB, (unsigned char*)&val, 2));
 }
 
 static int
 _get_Panasonic_AdjustAB(CONFIG_GET_ARGS) {
-    uint32_t currentVal = 0;
-    char buf[32];
-    PTPParams *params = &(camera->pl->params);
-    GPContext *context = ((PTPData *) params->data)->context;
+	uint32_t currentVal = 0;
+	char buf[32];
+	PTPParams *params = &(camera->pl->params);
+	GPContext *context = ((PTPData *) params->data)->context;
 
-    uint16_t valsize;
-    C_PTP_REP (ptp_panasonic_getdeviceproperty(params, PTP_DPC_PANASONIC_WhiteBalance_ADJ_AB, &valsize, &currentVal));
+	uint16_t valsize;
+	C_PTP_REP (ptp_panasonic_getdeviceproperty(params, PTP_DPC_PANASONIC_WhiteBalance_ADJ_AB, &valsize, &currentVal));
 
-    //printf("retrieved %x with size %x\n", currentVal, valsize);
-    if (currentVal & 0x8000) {
-        currentVal = (currentVal & 0x7FFF) * -1;
-    }
-    sprintf(buf, "%d\n", currentVal);
+	//printf("retrieved %x with size %x\n", currentVal, valsize);
+	if (currentVal & 0x8000) {
+		currentVal = (currentVal & 0x7FFF) * -1;
+	}
+	sprintf(buf, "%d\n", currentVal);
 
-    gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
-    gp_widget_set_name (*widget, menu->name);
+	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
+	gp_widget_set_name (*widget, menu->name);
 
-    gp_widget_set_value(*widget, &buf);
-    return GP_OK;
+	gp_widget_set_value(*widget, &buf);
+	return GP_OK;
 }
 
 static int
 _put_Panasonic_ColorTemp(CONFIG_PUT_ARGS)
 {
-    PTPParams *params = &(camera->pl->params);
-    char *xval;
-    uint32_t val;
+	PTPParams *params = &(camera->pl->params);
+	char *xval;
+	uint32_t val;
 
-    CR (gp_widget_get_value(widget, &xval));
-    uint16_t KSet;
-    sscanf (xval, "%hd", &KSet);
-    val = KSet;
+	CR (gp_widget_get_value(widget, &xval));
+	uint16_t KSet;
+	sscanf (xval, "%hd", &KSet);
+	val = KSet;
 
-    return translate_ptp_result (ptp_panasonic_setdeviceproperty(params, PTP_DPC_PANASONIC_WhiteBalance_KSet, (unsigned char*)&val, 2));
+	return translate_ptp_result (ptp_panasonic_setdeviceproperty(params, PTP_DPC_PANASONIC_WhiteBalance_KSet, (unsigned char*)&val, 2));
 }
 
 static int
 _get_Panasonic_ColorTemp(CONFIG_GET_ARGS) {
-    uint32_t currentVal;
-    uint32_t listCount;
-    uint32_t *list;
-    uint32_t i;
-    int	valset = 0;
-    char	buf[32];
-    PTPParams *params = &(camera->pl->params);
-    GPContext *context = ((PTPData *) params->data)->context;
+	uint32_t currentVal;
+	uint32_t listCount;
+	uint32_t *list;
+	uint32_t i;
+	int	valset = 0;
+	char	buf[32];
+	PTPParams *params = &(camera->pl->params);
+	GPContext *context = ((PTPData *) params->data)->context;
 
-    C_PTP_REP (ptp_panasonic_getdevicepropertydesc(params, PTP_DPC_PANASONIC_WhiteBalance_KSet, 2, &currentVal, &list, &listCount));
+	C_PTP_REP (ptp_panasonic_getdevicepropertydesc(params, PTP_DPC_PANASONIC_WhiteBalance_KSet, 2, &currentVal, &list, &listCount));
 
-    //printf("retrieved %lu property values\n", listCount);
+	//printf("retrieved %lu property values\n", listCount);
 
-    gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
-    gp_widget_set_name (*widget, menu->name);
+	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
+	gp_widget_set_name (*widget, menu->name);
 
-    for (i = 0; i < listCount; i++) {
-        sprintf(buf,"%d", list[i]);
-        if (list[i] == currentVal) {
-            gp_widget_set_value (*widget, buf);
-            valset = 1;
-        }
+	for (i = 0; i < listCount; i++) {
+		sprintf(buf,"%d", list[i]);
+		if (list[i] == currentVal) {
+		gp_widget_set_value (*widget, buf);
+		valset = 1;
+		}
 
-        gp_widget_add_choice (*widget, buf);
-    }
-    free(list);
-    if (!valset) {
-        sprintf(buf,_("Unknown 0x%04x"), currentVal);
-        gp_widget_set_value (*widget, buf);
-    }
-    return GP_OK;
+		gp_widget_add_choice (*widget, buf);
+	}
+	free(list);
+	if (!valset) {
+		sprintf(buf,_("Unknown 0x%04x"), currentVal);
+		gp_widget_set_value (*widget, buf);
+	}
+	return GP_OK;
 }
 
 static
 struct {
-    char*	str;
-    uint16_t val;
+	char*	str;
+	uint16_t val;
 } panasonic_aftable[] = {
-    { N_("AF"),             0x0000	},
-    { N_("AF macro"),       0x0001	},
-    { N_("AF macro (D)"),   0x0002	},
-    { N_("MF"),             0x0003	},
-    { N_("AF_S"),           0x0004	},
-    { N_("AF_C"),           0x0005	},
-    { N_("AF_F"),           0x0006	},
+	{ N_("AF"),             0x0000	},
+	{ N_("AF macro"),       0x0001	},
+	{ N_("AF macro (D)"),   0x0002	},
+	{ N_("MF"),             0x0003	},
+	{ N_("AF_S"),           0x0004	},
+	{ N_("AF_C"),           0x0005	},
+	{ N_("AF_F"),           0x0006	},
 };
 
 static int
 _put_Panasonic_AFMode(CONFIG_PUT_ARGS)
 {
-    PTPParams *params = &(camera->pl->params);
-    char *xval;
-    uint32_t val = 0;
-    uint32_t i, found;
+	PTPParams *params = &(camera->pl->params);
+	char *xval;
+	uint32_t val = 0;
+	uint32_t i, found;
 
-    CR (gp_widget_get_value(widget, &xval));
+	CR (gp_widget_get_value(widget, &xval));
 
-    for (i=0;i<sizeof(panasonic_aftable)/sizeof(panasonic_aftable[0]);i++) {
-        if (!strcmp(panasonic_aftable[i].str, xval)) {
-            val = panasonic_aftable[i].val;
-	    found = 1;
-            break;
-        }
-    }
-    if (!found) return GP_ERROR;
+	for (i=0;i<sizeof(panasonic_aftable)/sizeof(panasonic_aftable[0]);i++) {
+		if (!strcmp(panasonic_aftable[i].str, xval)) {
+			val = panasonic_aftable[i].val;
+			found = 1;
+			break;
+		}
+	}
+	if (!found) return GP_ERROR;
 
-    return translate_ptp_result (ptp_panasonic_setdeviceproperty(params, PTP_DPC_PANASONIC_AFArea_AFModeParam, (unsigned char*)&val, 2));
+	return translate_ptp_result (ptp_panasonic_setdeviceproperty(params, PTP_DPC_PANASONIC_AFArea_AFModeParam, (unsigned char*)&val, 2));
 }
 
 static int
 _get_Panasonic_AFMode(CONFIG_GET_ARGS) {
-    uint32_t currentVal;
-    uint32_t listCount;
-    uint32_t *list;
-    uint32_t i, j;
-    int	valset = 0;
-    char	buf[32];
-    PTPParams *params = &(camera->pl->params);
-    GPContext *context = ((PTPData *) params->data)->context;
+	uint32_t currentVal;
+	uint32_t listCount;
+	uint32_t *list;
+	uint32_t i, j;
+	int	valset = 0;
+	char	buf[32];
+	PTPParams *params = &(camera->pl->params);
+	GPContext *context = ((PTPData *) params->data)->context;
 
-    C_PTP_REP (ptp_panasonic_getdevicepropertydesc(params, PTP_DPC_PANASONIC_AFArea_AFModeParam, 2, &currentVal, &list, &listCount));
+	C_PTP_REP (ptp_panasonic_getdevicepropertydesc(params, PTP_DPC_PANASONIC_AFArea_AFModeParam, 2, &currentVal, &list, &listCount));
 
-    //printf("retrieved %lu property values\n", listCount);
+	//printf("retrieved %lu property values\n", listCount);
 
-    gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
-    gp_widget_set_name (*widget, menu->name);
+	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
+	gp_widget_set_name (*widget, menu->name);
 
-    for (i = 0; i < listCount; i++) {
-        for (j=0;j<sizeof(panasonic_aftable)/sizeof(panasonic_aftable[0]);j++) {
-            sprintf(buf,"%d", list[i]);
-            if ((list[i] == currentVal) && (j == currentVal)) {
-                gp_widget_set_value (*widget, panasonic_aftable[j].str);
-                valset = 1;
-                break;
-            }
-        }
-    }
-    for (j=0;j<sizeof(panasonic_aftable)/sizeof(panasonic_aftable[0]);j++) {
-        gp_widget_add_choice (*widget, panasonic_aftable[j].str);
-    }
-    free(list);
-    if (!valset) {
-        sprintf(buf,_("Unknown 0x%04x"), currentVal);
-        gp_widget_set_value (*widget, buf);
-    }
-    return GP_OK;
-}
+	for (i = 0; i < listCount; i++) {
+		for (j=0;j<sizeof(panasonic_aftable)/sizeof(panasonic_aftable[0]);j++) {
+		sprintf(buf,"%d", list[i]);
+		if ((list[i] == currentVal) && (j == currentVal)) {
+			gp_widget_set_value (*widget, panasonic_aftable[j].str);
+			valset = 1;
+			break;
+		}
+		}
+	}
+	for (j=0;j<sizeof(panasonic_aftable)/sizeof(panasonic_aftable[0]);j++) {
+		gp_widget_add_choice (*widget, panasonic_aftable[j].str);
+	}
+	free(list);
+	if (!valset) {
+		sprintf(buf,_("Unknown 0x%04x"), currentVal);
+		gp_widget_set_value (*widget, buf);
+	}
+	return GP_OK;
+	}
 
 static
 struct {
-    char*	str;
-    uint16_t val;
+	char*	str;
+	uint16_t val;
 } panasonic_mftable[] = {
-    { N_("Stop"),        0x0000	},
-    { N_("Far fast"),    0x0001	},
-    { N_("Far slow"),    0x0002	},
-    { N_("Near slow"),   0x0003	},
-    { N_("Near fast"),   0x0004	},
+	{ N_("Stop"),        0x0000	},
+	{ N_("Far fast"),    0x0001	},
+	{ N_("Far slow"),    0x0002	},
+	{ N_("Near slow"),   0x0003	},
+	{ N_("Near fast"),   0x0004	},
 };
 
 static int
 _put_Panasonic_MFAdjust(CONFIG_PUT_ARGS)
 {
-    PTPParams *params = &(camera->pl->params);
-    char *xval;
-    uint32_t val = 0;
-    uint32_t i;
+	PTPParams *params = &(camera->pl->params);
+	char *xval;
+	uint32_t val = 0;
+	uint32_t i;
 
-    CR (gp_widget_get_value(widget, &xval));
-    for (i=0;i<sizeof(panasonic_mftable)/sizeof(panasonic_mftable[0]);i++) {
-        if(!strcmp(panasonic_mftable[i].str, xval)) {
-            val = panasonic_mftable[i].val;
-            break;
-        }
-    }
+	CR (gp_widget_get_value(widget, &xval));
+	for (i=0;i<sizeof(panasonic_mftable)/sizeof(panasonic_mftable[0]);i++) {
+		if(!strcmp(panasonic_mftable[i].str, xval)) {
+		val = panasonic_mftable[i].val;
+		break;
+		}
+	}
 
-    return translate_ptp_result (ptp_panasonic_manualfocusdrive (params, (uint16_t)val));
+	return translate_ptp_result (ptp_panasonic_manualfocusdrive (params, (uint16_t)val));
 }
 
 static int
 _get_Panasonic_MFAdjust(CONFIG_GET_ARGS) {
-    uint32_t i;
-    gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
-    gp_widget_set_name (*widget,menu->name);
+	uint32_t i;
+	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
+	gp_widget_set_name (*widget,menu->name);
 
-    for (i=0;i<sizeof(panasonic_mftable)/sizeof(panasonic_mftable[0]);i++) {
-        gp_widget_add_choice (*widget, panasonic_mftable[i].str);
-    }
-    gp_widget_set_value (*widget, _("None"));
-    return GP_OK;
+	for (i=0;i<sizeof(panasonic_mftable)/sizeof(panasonic_mftable[0]);i++) {
+		gp_widget_add_choice (*widget, panasonic_mftable[i].str);
+	}
+	gp_widget_set_value (*widget, _("None"));
+	return GP_OK;
 }
 
 static
 struct {
-    char*	str;
-    uint16_t val;
+	char*	str;
+	uint16_t val;
 } panasonic_rmodetable[] = {
-    { N_("P"),   0x0000	},
-    { N_("A"),   0x0001	},
-    { N_("S"),   0x0002	},
-    { N_("M"),   0x0003	},
+	{ N_("P"),   0x0000	},
+	{ N_("A"),   0x0001	},
+	{ N_("S"),   0x0002	},
+	{ N_("M"),   0x0003	},
 };
 
 static int
 _get_Panasonic_ExpMode(CONFIG_GET_ARGS) {
 
-    uint32_t currentVal;
-    uint32_t listCount;
-    uint32_t *list;
-    uint32_t i,j;
-    int	valset = 0;
-    char	buf[32];
-    PTPParams *params = &(camera->pl->params);
-    GPContext *context = ((PTPData *) params->data)->context;
+	uint32_t currentVal;
+	uint32_t listCount;
+	uint32_t *list;
+	uint32_t i,j;
+	int	valset = 0;
+	char	buf[32];
+	PTPParams *params = &(camera->pl->params);
+	GPContext *context = ((PTPData *) params->data)->context;
 
-    C_PTP_REP (ptp_panasonic_getdevicepropertydesc(params, 0x06000011, 2, &currentVal, &list, &listCount));
+	C_PTP_REP (ptp_panasonic_getdevicepropertydesc(params, 0x06000011, 2, &currentVal, &list, &listCount));
 
-    //printf("retrieved %lu property values\n", listCount);
+	//printf("retrieved %lu property values\n", listCount);
 
-    gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
-    gp_widget_set_name (*widget, menu->name);
+	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
+	gp_widget_set_name (*widget, menu->name);
 
-    for (j=0;j<sizeof(panasonic_rmodetable)/sizeof(panasonic_rmodetable[0]);j++) {
-        gp_widget_add_choice (*widget, panasonic_rmodetable[j].str);
-    }
+	for (j=0;j<sizeof(panasonic_rmodetable)/sizeof(panasonic_rmodetable[0]);j++) {
+		gp_widget_add_choice (*widget, panasonic_rmodetable[j].str);
+	}
 
-    for (i = 0; i < listCount; i++) {
-        for (j=0;j<sizeof(panasonic_rmodetable)/sizeof(panasonic_rmodetable[0]);j++) {
-            sprintf(buf,"%d", list[i]);
-            if ((list[i] == currentVal) && (j == currentVal)) {
-                gp_widget_set_value (*widget, panasonic_rmodetable[j].str);
-                valset = 1;
-                break;
-            }
-    	}
-    }
-    free(list);
-    if (!valset) {
-        sprintf(buf,_("Unknown 0x%04x"), currentVal);
-        gp_widget_set_value (*widget, buf);
-    }
-    return GP_OK;
+	for (i = 0; i < listCount; i++) {
+		for (j=0;j<sizeof(panasonic_rmodetable)/sizeof(panasonic_rmodetable[0]);j++) {
+			sprintf(buf,"%d", list[i]);
+			if ((list[i] == currentVal) && (j == currentVal)) {
+				gp_widget_set_value (*widget, panasonic_rmodetable[j].str);
+				valset = 1;
+				break;
+			}
+		}
+	}
+	free(list);
+	if (!valset) {
+		sprintf(buf,_("Unknown 0x%04x"), currentVal);
+		gp_widget_set_value (*widget, buf);
+	}
+	return GP_OK;
 }
 
 static int
 _put_Panasonic_ExpMode(CONFIG_PUT_ARGS)
 {
-    PTPParams *params = &(camera->pl->params);
-    char *xval;
-    uint32_t val = 0;
-    uint32_t i;
+	PTPParams *params = &(camera->pl->params);
+	char *xval;
+	uint32_t val = 0;
+	uint32_t i;
 
-    CR (gp_widget_get_value(widget, &xval));
-    for (i=0;i<sizeof(panasonic_rmodetable)/sizeof(panasonic_rmodetable[0]);i++) {
-        if(!strcmp(panasonic_rmodetable[i].str, xval)) {
-            val = panasonic_rmodetable[i].val;
-            break;
-        }
-    }
+	CR (gp_widget_get_value(widget, &xval));
+	for (i=0;i<sizeof(panasonic_rmodetable)/sizeof(panasonic_rmodetable[0]);i++) {
+		if(!strcmp(panasonic_rmodetable[i].str, xval)) {
+			val = panasonic_rmodetable[i].val;
+			break;
+		}
+	}
 
-    //printf("val : %d\n", val);
-    return translate_ptp_result (ptp_panasonic_recordmode(params, (uint16_t)val));
+	//printf("val : %d\n", val);
+	return translate_ptp_result (ptp_panasonic_recordmode(params, (uint16_t)val));
 }
 static
 struct {
-    char*	str;
-    uint16_t val;
+	char*	str;
+	uint16_t val;
 } panasonic_recordtable[] = {
-    { N_("Standby"),        0x0000	},
-    { N_("Recording"),      0x0001	},
-    { N_("Playing"),        0x0002	},
-    { N_("Other process."), 0x0003	},
-    { N_("Other playing"),  0x0004	},
-    { N_("Noise reduction"),0x0005	},
-    { N_("Displaying menu"),0x0006	},
-    { N_("Streaming"),   	0x0007	},
+	{ N_("Standby"),        0x0000	},
+	{ N_("Recording"),      0x0001	},
+	{ N_("Playing"),        0x0002	},
+	{ N_("Other process."), 0x0003	},
+	{ N_("Other playing"),  0x0004	},
+	{ N_("Noise reduction"),0x0005	},
+	{ N_("Displaying menu"),0x0006	},
+	{ N_("Streaming"),      0x0007	},
 };
 
 static int
 _get_Panasonic_Recording(CONFIG_GET_ARGS) {
-    uint32_t currentVal = 0;
-    char buf[32];
-    uint32_t i;
-    PTPParams *params = &(camera->pl->params);
-    GPContext *context = ((PTPData *) params->data)->context;
+	uint32_t currentVal = 0;
+	char buf[32];
+	uint32_t i;
+	PTPParams *params = &(camera->pl->params);
+	GPContext *context = ((PTPData *) params->data)->context;
 
-    uint16_t valsize;
-    C_PTP_REP (ptp_panasonic_getrecordingstatus(params, 0x12000013, &valsize, &currentVal));
+	uint16_t valsize;
+	C_PTP_REP (ptp_panasonic_getrecordingstatus(params, 0x12000013, &valsize, &currentVal));
 
-    gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
-    gp_widget_set_name (*widget, menu->name);
+	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
+	gp_widget_set_name (*widget, menu->name);
 
-    for(i = 0; i < sizeof(panasonic_recordtable) / sizeof(panasonic_recordtable[0]); i++) {
-        if (currentVal == panasonic_recordtable[i].val) {
-            strcpy(buf, panasonic_recordtable[i].str);
-        }
-    }
+	for(i = 0; i < sizeof(panasonic_recordtable) / sizeof(panasonic_recordtable[0]); i++) {
+		if (currentVal == panasonic_recordtable[i].val) {
+			strcpy(buf, panasonic_recordtable[i].str);
+		}
+	}
 
-    gp_widget_set_value(*widget, &buf);
-    return GP_OK;
+	gp_widget_set_value(*widget, &buf);
+	return GP_OK;
 }
 
-    static int
+static int
 _put_Panasonic_Recording(CONFIG_PUT_ARGS)
 {
-    PTPParams *params = &(camera->pl->params);
-    char *xval;
+	PTPParams *params = &(camera->pl->params);
+	char *xval;
 
-    CR (gp_widget_get_value(widget, &xval));
-    if (!strcmp(xval, "start")) {
-        return translate_ptp_result (ptp_panasonic_startrecording(params));
-    } else if (!strcmp(xval, "stop")) {
-        return translate_ptp_result (ptp_panasonic_stoprecording(params));
-    } else {
-        return GP_ERROR;
-    }
+	CR (gp_widget_get_value(widget, &xval));
+	if (!strcmp(xval, "start")) {
+		return translate_ptp_result (ptp_panasonic_startrecording(params));
+	} else if (!strcmp(xval, "stop")) {
+		return translate_ptp_result (ptp_panasonic_stoprecording(params));
+	} else {
+		return GP_ERROR;
+	}
 }
 
 static int
@@ -9806,7 +9806,7 @@ _get_Panasonic_LiveViewSize(CONFIG_GET_ARGS) {
 
 	for (i = 0;i < nrofliveviewsizes; i++) {
 		sprintf(buf,"%dx%d %d %dHZ", liveviewsizes[i].width, liveviewsizes[i].height, liveviewsizes[i].x, liveviewsizes[i].freq);
-                gp_widget_add_choice (*widget, buf);
+		gp_widget_add_choice (*widget, buf);
 	}
 	free (liveviewsizes);
 
@@ -11455,8 +11455,8 @@ static struct menu menus[] = {
 	{ N_("Capture Settings"),           "capturesettings",  0x4b0,  0x044b, nikon_z6_capture_settings,      NULL,   NULL }, /* Z7_2 guessed */
 	{ N_("Capture Settings"),           "capturesettings",  0x4b0,  0x044c, nikon_z6_capture_settings,      NULL,   NULL }, /* Z6_2 guessed */
 	{ N_("Capture Settings"),           "capturesettings",  0x4b0,  0x044f, nikon_z6_capture_settings,      NULL,   NULL }, /* Zfc guessed */
-        { N_("Capture Settings"),           "capturesettings",  0x4b0,  0x0450, nikon_z6_capture_settings,      NULL,   NULL }, /* Z9 */
-        { N_("Capture Settings"),           "capturesettings",  0x4b0,  0x0451, nikon_z6_capture_settings,      NULL,   NULL }, /* Z8 */
+	{ N_("Capture Settings"),           "capturesettings",  0x4b0,  0x0450, nikon_z6_capture_settings,      NULL,   NULL }, /* Z9 */
+	{ N_("Capture Settings"),           "capturesettings",  0x4b0,  0x0451, nikon_z6_capture_settings,      NULL,   NULL }, /* Z8 */
 	{ N_("Capture Settings"),           "capturesettings",  0x4b0,  0x0452, nikon_z6_capture_settings,      NULL,   NULL }, /* Z30 guessed */
 	{ N_("Capture Settings"),           "capturesettings",  0x4b0,  0,      nikon_generic_capture_settings, NULL,   NULL },
 	{ N_("Capture Settings"),           "capturesettings",  0,      0,      capture_settings_menu,          NULL,   NULL },

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -201,18 +201,18 @@ time_since (const struct timeval start) {
 static int
 waiting_for_timeout (int *current_wait, struct timeval start, int timeout) {
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-        int time_to_timeout = timeout - time_since (start);
+	int time_to_timeout = timeout - time_since (start);
 
 	if (time_to_timeout <= 0) /* we timed out already ... */
 		return 0;
-        *current_wait += 50; /* increase sleep time by 50ms per cycle */
-        if (*current_wait > 200)
-                *current_wait = 200; /* 200ms is the maximum sleep time */
-        if (*current_wait > time_to_timeout)
-                *current_wait = time_to_timeout; /* never sleep 'into' the timeout */
-        if (*current_wait > 0)
-                usleep (*current_wait * 1000);
-        return *current_wait > 0;
+	*current_wait += 50; /* increase sleep time by 50ms per cycle */
+	if (*current_wait > 200)
+		*current_wait = 200; /* 200ms is the maximum sleep time */
+	if (*current_wait > time_to_timeout)
+		*current_wait = time_to_timeout; /* never sleep 'into' the timeout */
+	if (*current_wait > 0)
+		usleep (*current_wait * 1000);
+	return *current_wait > 0;
 #else
 	/* Wait always timeout during fuzzing! */
 	return 0;
@@ -227,7 +227,7 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 	CameraAbilities a;
 	PTPParams	*params = &camera->pl->params;
 
-        gp_camera_get_abilities(camera, &a);
+	gp_camera_get_abilities(camera, &a);
 
 	/* Panasonic GH5, GC9 */
 	if (    (di->VendorExtensionID == PTP_VENDOR_PANASONIC) &&
@@ -848,9 +848,9 @@ nikon_wait_busy(PTPParams *params, int waitms, int timeout) {
 
 	do {
 		res = ptp_nikon_device_ready(params);
-                if (    (res != PTP_RC_DeviceBusy) &&
-                        (res != PTP_RC_NIKON_Bulb_Release_Busy)
-                ) {
+		if (    (res != PTP_RC_DeviceBusy) &&
+			(res != PTP_RC_NIKON_Bulb_Release_Busy)
+		) {
 			if (res == PTP_RC_NIKON_Silent_Release_Busy)	/* seems to mean something like "not relevant" ... will repeat forever */
 				return PTP_RC_OK;
 			return res;
@@ -1037,7 +1037,7 @@ static struct {
 	{"HP:PhotoSmart 733 (PTP mode)", 0x03f0, 0x6c02, 0},
 	{"HP:PhotoSmart 607 (PTP mode)", 0x03f0, 0x6d02, 0},
 	{"HP:PhotoSmart 507 (PTP mode)", 0x03f0, 0x6e02, 0},
-        {"HP:PhotoSmart 635 (PTP mode)", 0x03f0, 0x7102, 0},
+	{"HP:PhotoSmart 635 (PTP mode)", 0x03f0, 0x7102, 0},
 	/* report from Federico Prat Villar <fprat@lsi.uji.es> */
 	{"HP:PhotoSmart 43x (PTP mode)", 0x03f0, 0x7202, 0},
 	{"HP:PhotoSmart M307 (PTP mode)", 0x03f0, 0x7302, 0},
@@ -1290,10 +1290,10 @@ static struct {
 	{"Sony:Alpha-A7III (Control)",  0x054c, 0x096f, PTP_CAP|PTP_CAP_PREVIEW},
 
 	/* Adrian Schroeter */
-	{"Sony:ILCE-7R M2 (MTP)",        	0x054c, 0x09e7, 0},
+	{"Sony:ILCE-7R M2 (MTP)",		0x054c, 0x09e7, 0},
 
 	/* https://sourceforge.net/p/gphoto/feature-requests/472/ */
-	{"Sony:DSC-HX90V (MTP)",        	0x054c, 0x09e8, 0},
+	{"Sony:DSC-HX90V (MTP)",		0x054c, 0x09e8, 0},
 
 	/* titan232@gmail.com */
 	{"Sony:ILCE-7M2 (Control)",     	0x054c, 0x0a6a, PTP_CAP|PTP_CAP_PREVIEW},
@@ -1302,7 +1302,7 @@ static struct {
 	{"Sony:Alpha-A7r II (Control)",		0x054c, 0x0a6b, PTP_CAP|PTP_CAP_PREVIEW},
 
 	/* Andre Crone <andre@elysia.nl> */
-	{"Sony:DSC-RX100M4",          		0x054c, 0x0a6d, PTP_CAP|PTP_CAP_PREVIEW},
+	{"Sony:DSC-RX100M4",			0x054c, 0x0a6d, PTP_CAP|PTP_CAP_PREVIEW},
 
 	/* via email to gphoto-devel */
 	{"Sony:Alpha-RX1R II (Control)",	0x054c,0x0a70, PTP_CAP|PTP_CAP_PREVIEW},
@@ -1479,7 +1479,7 @@ static struct {
 	/* https://sourceforge.net/tracker/index.php?func=detail&aid=2589245&group_id=8874&atid=108874 */
 	{"Nikon:Coolpix P50 (PTP mode)",  0x04b0, 0x0169, 0},
 	/* Clodoaldo <clodoaldo.pinto.neto@gmail.com> via
-         * https://bugs.kde.org/show_bug.cgi?id=315268 */
+	 * https://bugs.kde.org/show_bug.cgi?id=315268 */
 	{"Nikon:Coolpix P80 (PTP mode)",  0x04b0, 0x016b, PTP_CAP|PTP_NIKON_BROKEN_CAP},
 
 	/* TJ <wxtofly@gmail.com> */
@@ -1902,7 +1902,7 @@ static struct {
 	/* http://callendor.zongo.be/wiki/OlympusMju500 */
 	{"Olympus:mju 500",               0x07b4, 0x0113, 0},
 
-        /* Olympus wrap test code */
+	/* Olympus wrap test code */
 	{"Olympus:E series (Control)",	  0x07b4, 0x0110, PTP_OLYMPUS_XML},
 
 #if 0 /* talks PTP via SCSI vendor command backchannel, like above. */
@@ -3151,7 +3151,7 @@ camera_abilities (CameraAbilitiesList *list)
 	a.usb_subclass = 1;
 	a.usb_protocol = 1;
 	a.operations =	GP_OPERATION_CAPTURE_IMAGE | /*GP_OPERATION_TRIGGER_CAPTURE |*/
-		        GP_OPERATION_CAPTURE_PREVIEW |
+			GP_OPERATION_CAPTURE_PREVIEW |
 			GP_OPERATION_CONFIG;
 	a.file_operations   = GP_FILE_OPERATION_PREVIEW|
 				GP_FILE_OPERATION_DELETE;
@@ -3317,7 +3317,7 @@ exitfailed:
 		camera->pl = NULL;
 	}
 	/* This code hangs USB 3 devices after the first bulk image transmission.
-         * For some unknown reason. */
+	 * For some unknown reason. */
 	if (0 && (camera->port!=NULL) && (camera->port->type == GP_PORT_USB)) {
 		/* clear halt */
 		gp_port_usb_clear_halt
@@ -3697,8 +3697,7 @@ camera_capture_preview (Camera *camera, CameraFile *file, GPContext *context)
 		int 			tries, firstimage = 0;
 
 		if (!ptp_operation_issupported(params, PTP_OC_NIKON_StartLiveView)) {
-			gp_context_error (context,
-				_("Sorry, your Nikon camera does not support LiveView mode"));
+			gp_context_error (context, _("Sorry, your Nikon camera does not support LiveView mode"));
 			return GP_ERROR_NOT_SUPPORTED;
 		}
 		SET_CONTEXT_P(params, context);
@@ -4093,13 +4092,13 @@ add_objectid_and_upload (Camera *camera, CameraFilePath *path, GPContext *contex
 	}
 	GP_LOG_D ("append to fs");
 	ret = gp_filesystem_append(camera->fs, path->folder, path->name, context);
-        if (ret != GP_OK) {
+	if (ret != GP_OK) {
 		gp_file_free (file);
 		return ret;
 	}
 	GP_LOG_D ("adding filedata to fs");
 	ret = gp_filesystem_set_file_noop(camera->fs, path->folder, path->name, GP_FILE_TYPE_NORMAL, file, context);
-        if (ret != GP_OK) {
+	if (ret != GP_OK) {
 		gp_file_free (file);
 		return ret;
 	}
@@ -4157,7 +4156,7 @@ camera_nikon_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pa
 	int			i, ret, burstnumber = 1, done, tries;
 	uint32_t		newobject;
 	int			back_off_wait = 0;
-	struct timeval          capture_start;
+	struct timeval		capture_start;
 	int			loops;
 	PTPContainer		*storedevents = NULL;
 	unsigned int		nrstoredevents = 0;
@@ -4183,8 +4182,7 @@ camera_nikon_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pa
 		!ptp_operation_issupported(params,PTP_OC_NIKON_AfCaptureSDRAM) &&
 		!ptp_operation_issupported(params,PTP_OC_NIKON_InitiateCaptureRecInMedia)
 	) {
-		gp_context_error(context,
-               	_("Sorry, your camera does not support Nikon capture"));
+		gp_context_error(context, _("Sorry, your camera does not support Nikon capture"));
 		return GP_ERROR_NOT_SUPPORTED;
 	}
 
@@ -4201,7 +4199,7 @@ camera_nikon_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pa
 				GP_LOG_D ("burstnumber %d", burstnumber);
 			}
 			ptp_free_devicepropdesc (&burstdesc);
-		    }
+		}
 		ptp_free_devicepropdesc (&propdesc);
 	}
 
@@ -4454,14 +4452,13 @@ camera_canon_eos_capture (Camera *camera, CameraCaptureType type, CameraFilePath
 	CameraFileInfo		info;
 	PTPObjectInfo		oi;
 	int			back_off_wait = 0;
-	struct timeval          capture_start;
+	struct timeval		capture_start;
 	char			*mime;
 
 	if (!	(ptp_operation_issupported(params, PTP_OC_CANON_EOS_RemoteRelease) ||
 		 ptp_operation_issupported(params, PTP_OC_CANON_EOS_RemoteReleaseOn))
 	) {
-		gp_context_error (context,
-		_("Sorry, your Canon camera does not support Canon EOS Capture"));
+		gp_context_error (context, _("Sorry, your Canon camera does not support Canon EOS Capture"));
 		return GP_ERROR_NOT_SUPPORTED;
 	}
 
@@ -4712,8 +4709,7 @@ camera_canon_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pa
 	struct timeval		event_start;
 
 	if (!ptp_operation_issupported(params, PTP_OC_CANON_InitiateCaptureInMemory)) {
-		gp_context_error (context,
-		_("Sorry, your Canon camera does not support Canon Capture initiation"));
+		gp_context_error (context, _("Sorry, your Canon camera does not support Canon Capture initiation"));
 		return GP_ERROR_NOT_SUPPORTED;
 	}
 
@@ -4722,7 +4718,7 @@ camera_canon_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pa
 
 	if (!params->canon_event_mode) {
 		propval.u16 = 0;
-	        ret = ptp_getdevicepropvalue(params, PTP_DPC_CANON_EventEmulateMode, &propval, PTP_DTC_UINT16);
+		ret = ptp_getdevicepropvalue(params, PTP_DPC_CANON_EventEmulateMode, &propval, PTP_DTC_UINT16);
 		if (ret == PTP_RC_OK) params->canon_event_mode = propval.u16;
 	}
 
@@ -5825,8 +5821,7 @@ camera_capture (Camera *camera, CameraCaptureType type, CameraFilePath *path,
 	}
 
 	if (!ptp_operation_issupported(params,PTP_OC_InitiateCapture)) {
-		gp_context_error(context,
-               	_("Sorry, your camera does not support generic capture"));
+		gp_context_error(context, _("Sorry, your camera does not support generic capture"));
 		return GP_ERROR_NOT_SUPPORTED;
 	}
 
@@ -5875,7 +5870,7 @@ fallback:
 		PTPObjectHandles	handles;
 
 		tries = 5;
-            	GP_LOG_D ("PTPBUG_NIKON_BROKEN_CAPTURE bug workaround");
+		GP_LOG_D ("PTPBUG_NIKON_BROKEN_CAPTURE bug workaround");
 		while (tries--) {
 			unsigned int i;
 			uint16_t ret = ptp_getobjecthandles (params, PTP_HANDLER_SPECIAL, 0x000000, 0x000000, &handles);
@@ -5918,7 +5913,7 @@ fallback:
 		}
 		free (beforehandles.Handler);
 		if (!newobject)
-            		GP_LOG_D ("PTPBUG_NIKON_BROKEN_CAPTURE no new file found after 5 seconds?!?");
+			GP_LOG_D ("PTPBUG_NIKON_BROKEN_CAPTURE no new file found after 5 seconds?!?");
 		goto out;
 	}
 
@@ -6018,8 +6013,8 @@ camera_trigger_canon_eos_capture (Camera *camera, GPContext *context)
 		return GP_ERROR_CAMERA_BUSY;
 
 	if (have_eos_prop(params, PTP_VENDOR_CANON, PTP_DPC_CANON_EOS_CaptureDestination)) {
-                C_PTP (ptp_canon_eos_getdevicepropdesc (params, PTP_DPC_CANON_EOS_CaptureDestination, &dpd));
-                if (dpd.CurrentValue.u32 == PTP_CANON_EOS_CAPTUREDEST_HD) {
+		C_PTP (ptp_canon_eos_getdevicepropdesc (params, PTP_DPC_CANON_EOS_CaptureDestination, &dpd));
+		if (dpd.CurrentValue.u32 == PTP_CANON_EOS_CAPTUREDEST_HD) {
 			C_PTP (ptp_canon_eos_getdevicepropdesc (params, PTP_DPC_CANON_EOS_AvailableShots, &dpd));
 			if (dpd.CurrentValue.u32 < 100) {
 				/* Tell the camera we have enough free space on the PC */
@@ -6335,8 +6330,7 @@ camera_trigger_capture (Camera *camera, GPContext *context)
 			/* did not call --set-config capture=on, do it for user */
 			CR (camera_prepare_capture (camera, context));
 			if (!ptp_property_issupported(params, PTP_DPC_CANON_FlashMode)) {
-				gp_context_error (context,
-				_("Sorry, initializing your camera did not work. Please report this."));
+				gp_context_error (context, _("Sorry, initializing your camera did not work. Please report this."));
 				return GP_ERROR_NOT_SUPPORTED;
 			}
 		}
@@ -6576,8 +6570,7 @@ camera_trigger_capture (Camera *camera, GPContext *context)
 	}
 
 	if (!ptp_operation_issupported(params,PTP_OC_InitiateCapture)) {
-		gp_context_error(context,
-               	_("Sorry, your camera does not support generic capture"));
+		gp_context_error(context, _("Sorry, your camera does not support generic capture"));
 		return GP_ERROR_NOT_SUPPORTED;
 	}
 	C_PTP_REP (ptp_initiatecapture(params, 0x00000000, 0x00000000));
@@ -6612,9 +6605,9 @@ camera_wait_for_event (Camera *camera, int timeout,
 	}
 
 	event_start = time_now();
-	if (	(params->deviceinfo.VendorExtensionID == PTP_VENDOR_CANON) &&
-	        (ptp_operation_issupported(params, PTP_OC_CANON_EOS_RemoteRelease) ||
-	     	 ptp_operation_issupported(params, PTP_OC_CANON_EOS_RemoteReleaseOn))
+	if ((params->deviceinfo.VendorExtensionID == PTP_VENDOR_CANON) &&
+	    (ptp_operation_issupported(params, PTP_OC_CANON_EOS_RemoteRelease) ||
+	     ptp_operation_issupported(params, PTP_OC_CANON_EOS_RemoteReleaseOn))
 	) {
 
 		if (!params->eos_captureenabled)
@@ -7648,7 +7641,7 @@ canon_theme_put (CameraFilesystem *fs, const char *folder, CameraFile *file,
 
 static int
 nikon_curve_get (CameraFilesystem *fs, const char *folder, const char *filename,
-	         CameraFileType type, CameraFile *file, void *data,
+		 CameraFileType type, CameraFile *file, void *data,
 		 GPContext *context)
 {
 	Camera		*camera = (Camera*)data;
@@ -7978,7 +7971,7 @@ camera_summary (Camera* camera, CameraText* summary, GPContext *context)
 	 */
 	C_PTP_REP (ptp_getdeviceinfo (params, &pdi));
 	CR (fixup_cached_deviceinfo (camera, &pdi));
-        for (i=0;i<pdi.DevicePropertiesSupported_len;i++) {
+	for (i=0;i<pdi.DevicePropertiesSupported_len;i++) {
 		PTPDevicePropDesc dpd;
 		unsigned int dpc = pdi.DevicePropertiesSupported[i];
 		const char *propname = ptp_get_property_description (params, dpc);
@@ -8059,7 +8052,7 @@ camera_summary (Camera* camera, CameraText* summary, GPContext *context)
 		}
 		APPEND_TXT ("\n");
 		ptp_free_devicepropdesc (&dpd);
-        }
+	}
 	ptp_free_DI (&pdi);
 	return (GP_OK);
 #undef SPACE_LEFT
@@ -8140,101 +8133,101 @@ static int
 file_list_func (CameraFilesystem *fs, const char *folder, CameraList *list,
 		void *data, GPContext *context)
 {
-    Camera *camera = (Camera *)data;
-    PTPParams *params = &camera->pl->params;
-    uint32_t parent, storage=0x0000000;
-    unsigned int i, hasgetstorageids;
-    SET_CONTEXT_P(params, context);
-    unsigned int	lastnrofobjects = params->nrofobjects, redoneonce = 0;
+	Camera *camera = (Camera *)data;
+	PTPParams *params = &camera->pl->params;
+	uint32_t parent, storage=0x0000000;
+	unsigned int i, hasgetstorageids;
+	SET_CONTEXT_P(params, context);
+	unsigned int	lastnrofobjects = params->nrofobjects, redoneonce = 0;
 
-    GP_LOG_D ("file_list_func(%s)", folder);
+	GP_LOG_D ("file_list_func(%s)", folder);
 
-    /* There should be NO files in root folder */
-    if (!strcmp(folder, "/"))
-        return (GP_OK);
+	/* There should be NO files in root folder */
+	if (!strcmp(folder, "/"))
+		return (GP_OK);
 
-    if (!strcmp(folder, "/special")) {
-	for (i=0; i<nrofspecial_files; i++)
-		CR (gp_list_append (list, special_files[i].name, NULL));
-	return (GP_OK);
-    }
+	if (!strcmp(folder, "/special")) {
+		for (i=0; i<nrofspecial_files; i++)
+			CR (gp_list_append (list, special_files[i].name, NULL));
+		return (GP_OK);
+	}
 
-    /* compute storage ID value from folder patch */
-    folder_to_storage(folder,storage);
+	/* compute storage ID value from folder patch */
+	folder_to_storage(folder,storage);
 
-    /* Get (parent) folder handle omitting storage pseudofolder */
-    find_folder_handle(params,folder,storage,parent);
+	/* Get (parent) folder handle omitting storage pseudofolder */
+	find_folder_handle(params,folder,storage,parent);
 
-    C_PTP_REP (ptp_list_folder (params, storage, parent));
-    GP_LOG_D ("after list folder");
+	C_PTP_REP (ptp_list_folder (params, storage, parent));
+	GP_LOG_D ("after list folder");
 
-    hasgetstorageids = ptp_operation_issupported(params,PTP_OC_GetStorageIDs);
+	hasgetstorageids = ptp_operation_issupported(params,PTP_OC_GetStorageIDs);
 
 retry:
-    for (i = 0; i < params->nrofobjects; i++) {
-	PTPObject	*ob;
-	uint16_t	ret;
-	uint32_t	oid;
+	for (i = 0; i < params->nrofobjects; i++) {
+		PTPObject	*ob;
+		uint16_t	ret;
+		uint32_t	oid;
 
-	/* not our parent -> next */
-	C_PTP_REP (ptp_object_want (params, params->objects[i].oid, PTPOBJECT_PARENTOBJECT_LOADED|PTPOBJECT_STORAGEID_LOADED, &ob));
+		/* not our parent -> next */
+		C_PTP_REP (ptp_object_want (params, params->objects[i].oid, PTPOBJECT_PARENTOBJECT_LOADED|PTPOBJECT_STORAGEID_LOADED, &ob));
 
-	/* DANGER DANGER: i is now invalid as objects might have been inserted in the list! */
+		/* DANGER DANGER: i is now invalid as objects might have been inserted in the list! */
 
-	if (ob->oi.ParentObject!=parent)
-		continue;
+		if (ob->oi.ParentObject!=parent)
+			continue;
 
-	/* not on our storage devices -> next */
-	if ((hasgetstorageids && (ob->oi.StorageID != storage)))
-		continue;
+		/* not on our storage devices -> next */
+		if ((hasgetstorageids && (ob->oi.StorageID != storage)))
+			continue;
 
-	oid = ob->oid; /* ob might change or even become invalid in the function below */
-	ret = ptp_object_want (params, oid, PTPOBJECT_OBJECTINFO_LOADED, &ob);
-	if (ret != PTP_RC_OK) {
-		/* we might raced another delete or ongoing addition, seen on a D810 */
-		if (ret == PTP_RC_InvalidObjectHandle) {
-			GP_LOG_D ("Handle %08x was in list, but not/no longer found via getobjectinfo.\n", oid);
-			/* remove it for now, we will readd it later if we see it again. */
-			ptp_remove_object_from_cache(params, oid);
+		oid = ob->oid; /* ob might change or even become invalid in the function below */
+		ret = ptp_object_want (params, oid, PTPOBJECT_OBJECTINFO_LOADED, &ob);
+		if (ret != PTP_RC_OK) {
+			/* we might raced another delete or ongoing addition, seen on a D810 */
+			if (ret == PTP_RC_InvalidObjectHandle) {
+				GP_LOG_D ("Handle %08x was in list, but not/no longer found via getobjectinfo.\n", oid);
+				/* remove it for now, we will readd it later if we see it again. */
+				ptp_remove_object_from_cache(params, oid);
+				continue;
+			}
+			C_PTP_REP (ret);
+		}
+		/* Is a directory -> next */
+		if (ob->oi.ObjectFormat == PTP_OFC_Association)
+			continue;
+
+		debug_objectinfo(params, ob->oid, &ob->oi);
+
+		if (!ob->oi.Filename)
+			continue;
+
+		if (1) {
+		/* HP Photosmart 850, the camera tends to duplicate filename in the list.
+		* Original patch by clement.rezvoy@gmail.com */
+		/* search backwards, likely gets hits faster. */
+		/* FIXME Marcus: This is also O(n^2) ... bad for large directories. */
+		if (GP_OK == gp_list_find_by_name(list, NULL, ob->oi.Filename)) {
+			GP_LOG_E (
+				"Duplicate filename '%s' in folder '%s'. Ignoring nth entry.\n",
+				ob->oi.Filename, folder);
 			continue;
 		}
-		C_PTP_REP (ret);
+		}
+		CR(gp_list_append (list, ob->oi.Filename, NULL));
 	}
-	/* Is a directory -> next */
-	if (ob->oi.ObjectFormat == PTP_OFC_Association)
-		continue;
 
-	debug_objectinfo(params, ob->oid, &ob->oi);
-
-	if (!ob->oi.Filename)
-	    continue;
-
-	if (1) {
-	    /* HP Photosmart 850, the camera tends to duplicate filename in the list.
-             * Original patch by clement.rezvoy@gmail.com */
-	    /* search backwards, likely gets hits faster. */
-	    /* FIXME Marcus: This is also O(n^2) ... bad for large directories. */
-	    if (GP_OK == gp_list_find_by_name(list, NULL, ob->oi.Filename)) {
-		GP_LOG_E (
-			"Duplicate filename '%s' in folder '%s'. Ignoring nth entry.\n",
-			ob->oi.Filename, folder);
-		continue;
-	    }
+	/* Did we change the object tree list during our traversal? if yes, redo the scan. */
+	if (params->nrofobjects != lastnrofobjects) {
+		if (redoneonce++) {
+			GP_LOG_E("list changed again on second pass, returning anyway");
+			return GP_OK;
+		}
+		lastnrofobjects = params->nrofobjects;
+		gp_list_reset(list);
+		goto retry;
 	}
-	CR(gp_list_append (list, ob->oi.Filename, NULL));
-    }
-
-    /* Did we change the object tree list during our traversal? if yes, redo the scan. */
-    if (params->nrofobjects != lastnrofobjects) {
-	if (redoneonce++) {
-		GP_LOG_E("list changed again on second pass, returning anyway");
-		return GP_OK;
-	}
-	lastnrofobjects = params->nrofobjects;
-	gp_list_reset(list);
-	goto retry;
-    }
-    return GP_OK;
+	return GP_OK;
 }
 
 static int
@@ -8294,7 +8287,7 @@ folder_list_func (CameraFilesystem *fs, const char *folder, CameraList *list,
 	/* list this directory */
 	C_PTP_REP (ptp_list_folder (params, storage, handler));
 
-        GP_LOG_D ("after list folder (storage=0x%08x, handler=0x08%x)", storage, handler);
+	GP_LOG_D ("after list folder (storage=0x%08x, handler=0x08%x)", storage, handler);
 
 	/* Look for objects we can present as directories.
 	 * Currently we specify *any* PTP association as directory.
@@ -8794,7 +8787,7 @@ ptp_exit_camerafile_handler (PTPDataHandler *handler) {
 
 static int
 read_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
-	        CameraFileType type,
+		CameraFileType type,
 		uint64_t offset64, char *buf, uint64_t *size64,
 		void *data, GPContext *context)
 {
@@ -9369,7 +9362,7 @@ delete_file_func (CameraFilesystem *fs, const char *folder,
 
 	/* On some Canon firmwares, a DeleteObject causes a ObjectRemoved event
 	 * to be sent. At least on Digital IXUS II and PowerShot A85. But
-         * not on 350D.
+	 * not on 350D.
 	 */
 	if (DELETE_SENDS_EVENT(params) &&
 	    ptp_event_issupported(params, PTP_EC_ObjectRemoved)) {
@@ -9764,7 +9757,7 @@ static CameraFilesystemFuncs fsfuncs = {
 int
 camera_init (Camera *camera, GPContext *context)
 {
-    	CameraAbilities a;
+	CameraAbilities a;
 	unsigned int i;
 	int ret, tries = 0;
 	PTPParams *params;
@@ -9812,7 +9805,7 @@ camera_init (Camera *camera, GPContext *context)
 	else
 		camloc = "UCS-2BE";
 
-        gp_camera_get_abilities(camera, &a);
+	gp_camera_get_abilities(camera, &a);
 
 #if defined(HAVE_ICONV) && defined(HAVE_LANGINFO_H)
 	curloc = nl_langinfo (CODESET);
@@ -9827,24 +9820,24 @@ camera_init (Camera *camera, GPContext *context)
 	}
 #endif
 
-        for (i = 0; i<sizeof(models)/sizeof(models[0]); i++) {
-            if ((a.usb_vendor == models[i].usb_vendor) &&
-                (a.usb_product == models[i].usb_product)){
-                params->device_flags = models[i].device_flags;
-                break;
-            }
-	    /* do not run the funny MTP stuff on the cameras for now */
-	    params->device_flags |= DEVICE_FLAG_BROKEN_MTPGETOBJPROPLIST_ALL;
-	    params->device_flags |= DEVICE_FLAG_BROKEN_MTPGETOBJPROPLIST;
-        }
+	for (i = 0; i<sizeof(models)/sizeof(models[0]); i++) {
+		if ((a.usb_vendor == models[i].usb_vendor) &&
+		    (a.usb_product == models[i].usb_product)) {
+			params->device_flags = models[i].device_flags;
+			break;
+		}
+		/* do not run the funny MTP stuff on the cameras for now */
+		params->device_flags |= DEVICE_FLAG_BROKEN_MTPGETOBJPROPLIST_ALL;
+		params->device_flags |= DEVICE_FLAG_BROKEN_MTPGETOBJPROPLIST;
+	}
 	/* map the libmtp flags to ours. Currently its just 1 flag. */
-        for (i = 0; i<sizeof(mtp_models)/sizeof(mtp_models[0]); i++) {
-            if ((a.usb_vendor == mtp_models[i].usb_vendor) &&
-                (a.usb_product == mtp_models[i].usb_product)) {
+	for (i = 0; i<sizeof(mtp_models)/sizeof(mtp_models[0]); i++) {
+		if ((a.usb_vendor == mtp_models[i].usb_vendor) &&
+		    (a.usb_product == mtp_models[i].usb_product)) {
 			params->device_flags = mtp_models[i].flags;
-                break;
-            }
-        }
+			break;
+		}
+	}
 
 
 	switch (camera->port->type) {
@@ -10024,7 +10017,7 @@ camera_init (Camera *camera, GPContext *context)
 #if 1
 	/* Special fuji wlan init code */
 	if ((camera->port->type == GP_PORT_PTPIP)  && strstr(a.model,"Fuji")) {
-		PTPPropertyValue        propval;
+		PTPPropertyValue	propval;
 		GPPortInfo		info;
 		char 			*xpath;
 
@@ -10267,7 +10260,7 @@ camera_init (Camera *camera, GPContext *context)
 			ptp_getstorageinfo(params, params->storageids.Storage[0], &storageinfo);
 		}
 
-		PTPPropertyValue        propval;
+		PTPPropertyValue	propval;
 		if (!strncmp(params->deviceinfo.Model,"E-M5",4)) {
 			ptp_olympus_init_pc_mode(params);
 		}

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -141,35 +141,35 @@ static uint16_t ptp_exit_send_memory_handler (PTPDataHandler *handler);
 void
 ptp_debug (PTPParams *params, const char *format, ...)
 {
-        va_list args;
+	va_list args;
 
-        va_start (args, format);
-        if (params->debug_func!=NULL)
-                params->debug_func (params->data, format, args);
-        else
+	va_start (args, format);
+	if (params->debug_func!=NULL)
+		params->debug_func (params->data, format, args);
+	else
 	{
-                vfprintf (stderr, format, args);
+		vfprintf (stderr, format, args);
 		fprintf (stderr,"\n");
 		fflush (stderr);
 	}
-        va_end (args);
+	va_end (args);
 }
 
 void
 ptp_error (PTPParams *params, const char *format, ...)
 {
-        va_list args;
+	va_list args;
 
-        va_start (args, format);
-        if (params->error_func!=NULL)
-                params->error_func (params->data, format, args);
-        else
+	va_start (args, format);
+	if (params->error_func!=NULL)
+		params->error_func (params->data, format, args);
+	else
 	{
-                vfprintf (stderr, format, args);
+		vfprintf (stderr, format, args);
 		fprintf (stderr,"\n");
 		fflush (stderr);
 	}
-        va_end (args);
+	va_end (args);
 }
 
 /* Pack / unpack functions */
@@ -390,8 +390,8 @@ typedef struct {
 
 static uint16_t
 fd_getfunc(PTPParams* params, void* private,
-	       unsigned long wantlen, unsigned char *data,
-	       unsigned long *gotlen
+	unsigned long wantlen, unsigned char *data,
+	unsigned long *gotlen
 ) {
 	PTPFDHandlerPrivate* priv = (PTPFDHandlerPrivate*)private;
 	int		got;
@@ -406,7 +406,7 @@ fd_getfunc(PTPParams* params, void* private,
 
 static uint16_t
 fd_putfunc(PTPParams* params, void* private,
-	       unsigned long sendlen, unsigned char *data
+	unsigned long sendlen, unsigned char *data
 ) {
 	ssize_t	written;
 	PTPFDHandlerPrivate* priv = (PTPFDHandlerPrivate*)private;
@@ -1014,19 +1014,19 @@ ptp_olympus_omd_bulbend (PTPParams* params)
 uint16_t
 ptp_panasonic_liveview_image (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 
 	PTP_CNT_INIT(ptp, PTP_OC_PANASONIC_LiveviewImage);
-        return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
+	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
 }
 
 uint16_t
 ptp_sigma_fp_liveview_image (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetCamViewFrame);
-        return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
+	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
 }
 
 static uint16_t
@@ -1086,7 +1086,7 @@ ptp_sigma_fp_parse_ifdlist (PTPParams* params, unsigned char *data, unsigned int
 uint16_t
 ptp_sigma_fp_9035 (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 	uint16_t	ret;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetCameraInfo);
@@ -1099,7 +1099,7 @@ ptp_sigma_fp_9035 (PTPParams* params, unsigned char **data, unsigned int *size)
 uint16_t
 ptp_sigma_fp_getcamcansetinfo5 (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 	uint16_t	ret;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetCamCanSetInfo5);
@@ -1112,7 +1112,7 @@ ptp_sigma_fp_getcamcansetinfo5 (PTPParams* params, unsigned char **data, unsigne
 uint16_t
 ptp_sigma_fp_getcamdatagroupfocus (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 	uint16_t	ret;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetCamDataGroupFocus);
@@ -1125,7 +1125,7 @@ ptp_sigma_fp_getcamdatagroupfocus (PTPParams* params, unsigned char **data, unsi
 uint16_t
 ptp_sigma_fp_getcamdatagroupmovie (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 	uint16_t	ret;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetCamDataGroupMovie);
@@ -1138,7 +1138,7 @@ ptp_sigma_fp_getcamdatagroupmovie (PTPParams* params, unsigned char **data, unsi
 uint16_t
 ptp_sigma_fp_getdatagroup1 (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetDataGroup1);
 	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
@@ -1147,7 +1147,7 @@ ptp_sigma_fp_getdatagroup1 (PTPParams* params, unsigned char **data, unsigned in
 uint16_t
 ptp_sigma_fp_getdatagroup2 (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetDataGroup2);
 	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
@@ -1156,7 +1156,7 @@ ptp_sigma_fp_getdatagroup2 (PTPParams* params, unsigned char **data, unsigned in
 uint16_t
 ptp_sigma_fp_getdatagroup3 (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetDataGroup3);
 	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
@@ -1165,7 +1165,7 @@ ptp_sigma_fp_getdatagroup3 (PTPParams* params, unsigned char **data, unsigned in
 uint16_t
 ptp_sigma_fp_getdatagroup4 (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetDataGroup4);
 	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
@@ -1174,7 +1174,7 @@ ptp_sigma_fp_getdatagroup4 (PTPParams* params, unsigned char **data, unsigned in
 uint16_t
 ptp_sigma_fp_getdatagroup5 (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetDataGroup5);
 	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
@@ -1183,7 +1183,7 @@ ptp_sigma_fp_getdatagroup5 (PTPParams* params, unsigned char **data, unsigned in
 uint16_t
 ptp_sigma_fp_getdatagroup6 (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetDataGroup6);
 	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
@@ -1192,7 +1192,7 @@ ptp_sigma_fp_getdatagroup6 (PTPParams* params, unsigned char **data, unsigned in
 uint16_t
 ptp_sigma_fp_setdatagroup1 (PTPParams* params, unsigned char *data, unsigned int size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_SetDataGroup1);
 	return ptp_transaction(params, &ptp, PTP_DP_SENDDATA, size, &data, 0);
@@ -1202,13 +1202,13 @@ ptp_sigma_fp_setdatagroup1 (PTPParams* params, unsigned char *data, unsigned int
 uint16_t
 ptp_sigma_fp_getcapturestatus (PTPParams* params, unsigned int p1, SIGMAFP_CaptureStatus*status)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 	uint16_t	ret;
 	unsigned char	*data = NULL;
 	unsigned int	size = 0;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetCaptureStatus, p1);
-        ret = ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size);
+	ret = ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size);
 	if (ret != PTP_RC_OK) return ret;
 
 	if (size < 7) {
@@ -1234,23 +1234,23 @@ ptp_sigma_fp_getcapturestatus (PTPParams* params, unsigned int p1, SIGMAFP_Captu
 uint16_t
 ptp_sigma_fp_getcamstatus2 (PTPParams* params, uint32_t canset, uint32_t datagroup, uint32_t other, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetCamStatus2, canset, datagroup, other);
-        return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
+	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
 }
 
 uint16_t
 ptp_sigma_fp_getpictfileinfo2 (PTPParams* params, SIGMAFP_PictFileInfo2Ex *pictinfo)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 	uint16_t	ret;
 	unsigned int	off;
 	char		*data = NULL;
 	unsigned int	size = 0;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetPictFileInfo2);
-        ret = ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, (unsigned char**)&data, &size);
+	ret = ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, (unsigned char**)&data, &size);
 	if (ret != PTP_RC_OK) return ret;
 
 	if (size < 60) {
@@ -1305,16 +1305,16 @@ uint32_t        fileaddress;	/* 12,13,14,15 */
 uint16_t
 ptp_sigma_fp_getbigpartialpictfile (PTPParams* params, unsigned int p1, unsigned int off, unsigned int insize, unsigned char **data, unsigned int *size)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_GetBigPartialPictFile, p1, off, insize);
-        return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
+	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
 }
 
 uint16_t
 ptp_sigma_fp_snap (PTPParams* params, unsigned int mode, unsigned int amount)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 	unsigned char	*data = malloc(4);
 	uint16_t	ret;
 
@@ -1324,7 +1324,7 @@ ptp_sigma_fp_snap (PTPParams* params, unsigned int mode, unsigned int amount)
 	data[3] = 0x02+mode+amount;	/* checksum, just add everything */
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_Snap);
-        ret = ptp_transaction(params, &ptp, PTP_DP_SENDDATA, 4, (unsigned char**)&data, 0);
+	ret = ptp_transaction(params, &ptp, PTP_DP_SENDDATA, 4, (unsigned char**)&data, 0);
 	free (data);
 	return ret;
 }
@@ -1332,12 +1332,12 @@ ptp_sigma_fp_snap (PTPParams* params, unsigned int mode, unsigned int amount)
 uint16_t
 ptp_sigma_fp_clearimagedbsingle (PTPParams* params, uint32_t id)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 	unsigned char	*data = calloc(8,1);
 	uint16_t	ret;
 
 	PTP_CNT_INIT(ptp, PTP_OC_SIGMA_FP_ClearImageDBSingle, id);
-        ret = ptp_transaction(params, &ptp, PTP_DP_SENDDATA, 8, (unsigned char**)&data, 0);
+	ret = ptp_transaction(params, &ptp, PTP_DP_SENDDATA, 8, (unsigned char**)&data, 0);
 	free (data);
 	return ret;
 }
@@ -1347,7 +1347,7 @@ ptp_olympus_init_pc_mode (PTPParams* params)
 {
 	uint16_t		ret;
 	PTPPropertyValue	propval;
-	PTPContainer    	event;
+	PTPContainer		event;
 	int			i;
 
 	ptp_debug (params,"PTP: (Olympus Init) switching to PC mode...");
@@ -1409,7 +1409,7 @@ ptp_olympus_sdram_image (PTPParams* params, unsigned char **data, unsigned int *
 uint16_t
 ptp_panasonic_9401 (PTPParams* params, uint32_t param1)
 {
-        PTPContainer    ptp;
+	PTPContainer	ptp;
 	uint16_t	ret;
 	unsigned int	*size = 0;
 	unsigned char   *data = NULL;
@@ -1427,7 +1427,7 @@ ptp_panasonic_9401 (PTPParams* params, uint32_t param1)
 uint16_t
 ptp_panasonic_9414_0d800012 (PTPParams* params, PanasonicLiveViewSize **liveviewsizes, unsigned int *nrofliveviewsizes)
 {
-        PTPContainer    ptp;
+	PTPContainer	ptp;
 	unsigned int	i;
 	unsigned int	size = 0;
 	unsigned char   *data = NULL;
@@ -1488,9 +1488,9 @@ c0 03 00 05 bc 02 1e 00
 uint16_t
 ptp_panasonic_9414_0d800011 (PTPParams* params, PanasonicLiveViewSize *liveviewsize)
 {
-        PTPContainer    ptp;
+	PTPContainer	ptp;
 	unsigned int	size = 0;
-	unsigned char   *data = NULL;
+	unsigned char	*data = NULL;
 	uint32_t	blobsize;
 
 	PTP_CNT_INIT(ptp, PTP_OC_PANASONIC_GetLiveViewParameters, 0x0d800011);
@@ -1527,8 +1527,8 @@ e0 01 80 02
 uint16_t
 ptp_panasonic_9415 (PTPParams* params, PanasonicLiveViewSize *liveviewsize)
 {
-        PTPContainer    ptp;
-	unsigned char   *data;
+	PTPContainer	ptp;
+	unsigned char	*data;
 	uint16_t	ret;
 
 	PTP_CNT_INIT(ptp, PTP_OC_PANASONIC_SetLiveViewParameters, 0x0d800011);
@@ -1593,8 +1593,8 @@ ptp_panasonic_getdevicepropertysize (PTPParams *params, uint32_t propcode)
 uint16_t
 ptp_panasonic_manualfocusdrive (PTPParams* params, uint16_t mode)
 {
-	PTPContainer   	ptp;
-	unsigned char  	data[10];
+	PTPContainer	ptp;
+	unsigned char	data[10];
 	unsigned char	*xdata = data;
 	uint32_t 	propcode = 0x03010011;
 	uint32_t 	type = 2;
@@ -1610,44 +1610,44 @@ ptp_panasonic_manualfocusdrive (PTPParams* params, uint16_t mode)
 uint16_t
 ptp_panasonic_recordmode (PTPParams* params, uint16_t mode)
 {
-    PTPContainer   	ptp;
-    unsigned char  	data[10];
-    unsigned char	*xdata = data;
-    uint32_t 	propcode = 0x06000011;
-    uint32_t 	type = 2;
+	PTPContainer	ptp;
+	unsigned char	data[10];
+	unsigned char	*xdata = data;
+	uint32_t 	propcode = 0x06000011;
+	uint32_t 	type = 2;
 
-    htod32a(data, propcode);	/* memcpy(data, &propcode, 4); */
-    htod32a(&data[4], type);	/* memcpy(&data[4], &type, 4); */
-    htod16a(&data[8], mode);	/* memcpy(&data[8], &mode, 2); */
+	htod32a(data, propcode);	/* memcpy(data, &propcode, 4); */
+	htod32a(&data[4], type);	/* memcpy(&data[4], &type, 4); */
+	htod16a(&data[8], mode);	/* memcpy(&data[8], &mode, 2); */
 
-    PTP_CNT_INIT(ptp, PTP_OC_PANASONIC_9409, propcode);
-    return ptp_transaction(params, &ptp, PTP_DP_SENDDATA, sizeof(data), &xdata, NULL);
+	PTP_CNT_INIT(ptp, PTP_OC_PANASONIC_9409, propcode);
+	return ptp_transaction(params, &ptp, PTP_DP_SENDDATA, sizeof(data), &xdata, NULL);
 }
 
 uint16_t
 ptp_panasonic_startrecording (PTPParams* params)
 {
-    PTPContainer   	ptp;
-    uint32_t 	propcode = 0x07000011;
+	PTPContainer	ptp;
+	uint32_t	propcode = 0x07000011;
 
-    PTP_CNT_INIT(ptp, PTP_OC_PANASONIC_MovieRecControl, propcode);
-    return ptp_transaction(params, &ptp, PTP_DP_NODATA, 0, NULL, NULL);
+	PTP_CNT_INIT(ptp, PTP_OC_PANASONIC_MovieRecControl, propcode);
+	return ptp_transaction(params, &ptp, PTP_DP_NODATA, 0, NULL, NULL);
 }
 
 uint16_t
 ptp_panasonic_stoprecording (PTPParams* params)
 {
-    PTPContainer   	ptp;
-    uint32_t 	propcode = 0x07000012;
+	PTPContainer	ptp;
+	uint32_t 	propcode = 0x07000012;
 
-    PTP_CNT_INIT(ptp, PTP_OC_PANASONIC_MovieRecControl, propcode);
-    return ptp_transaction(params, &ptp, PTP_DP_NODATA, 0, NULL, NULL);
+	PTP_CNT_INIT(ptp, PTP_OC_PANASONIC_MovieRecControl, propcode);
+	return ptp_transaction(params, &ptp, PTP_DP_NODATA, 0, NULL, NULL);
 }
 
 uint16_t
 ptp_panasonic_getcapturetarget (PTPParams* params, uint16_t *target)
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 	unsigned char	*data;
 	unsigned int	size;
 
@@ -1667,7 +1667,7 @@ ptp_panasonic_getcapturetarget (PTPParams* params, uint16_t *target)
 uint16_t
 ptp_panasonic_setcapturetarget (PTPParams* params, uint16_t mode) // mode == 1 == RAM, mode == 0 == SD, 2 = BOTH
 {
-	PTPContainer    ptp;
+	PTPContainer	ptp;
 	unsigned char	data[10];
 	unsigned char	*xdata = (unsigned char*)data;
 
@@ -1746,33 +1746,35 @@ ptp_panasonic_getdevicepropertydesc (PTPParams *params, uint32_t propcode, uint1
 	return ret;
 }
 
-    uint16_t
+uint16_t
 ptp_panasonic_getrecordingstatus (PTPParams *params, uint32_t propcode, uint16_t *valuesize, uint32_t *currentValue)
 {
-    PTPContainer	ptp;
-    unsigned char	*data = NULL;
-    unsigned int 	size = 0;
-    uint16_t	ret = PTP_RC_OK;
+	PTPContainer	ptp;
+	unsigned char	*data = NULL;
+	unsigned int 	size = 0;
+	uint16_t	ret = PTP_RC_OK;
 
-    PTP_CNT_INIT(ptp, PTP_OC_PANASONIC_PollEvents, propcode);
-    CHECK_PTP_RC(ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size));
-    if (!data) return PTP_RC_GeneralError;
+	PTP_CNT_INIT(ptp, PTP_OC_PANASONIC_PollEvents, propcode);
+	CHECK_PTP_RC(ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size));
+	if (!data)
+		return PTP_RC_GeneralError;
 
-    if(size < 8) return PTP_RC_GeneralError;
-    *valuesize = dtoh32a( (data + 4) );
+	if(size < 8)
+		return PTP_RC_GeneralError;
+	*valuesize = dtoh32a( (data + 4) );
 
-    if(size < 8u + (*valuesize)) return PTP_RC_GeneralError;
-    if(*valuesize == 4) {
-        *currentValue = dtoh32a( (data + 8) );
-    } else if(*valuesize == 2) {
-        *currentValue = (uint32_t) dtoh16a( (data + 8) );
-    } else {
-        return PTP_RC_GeneralError;
-    }
-    //printf("ptp_panasonic_getdeviceproperty: size: %lu, valuesize: %d, currentValue: %lu\n", size, *valuesize, *currentValue);
+	if(size < 8u + (*valuesize)) return PTP_RC_GeneralError;
+	if(*valuesize == 4) {
+		*currentValue = dtoh32a( (data + 8) );
+	} else if(*valuesize == 2) {
+		*currentValue = (uint32_t) dtoh16a( (data + 8) );
+	} else {
+		return PTP_RC_GeneralError;
+	}
+	//printf("ptp_panasonic_getdeviceproperty: size: %lu, valuesize: %d, currentValue: %lu\n", size, *valuesize, *currentValue);
 
-    free (data);
-    return ret;
+	free (data);
+	return ret;
 }
 
 uint16_t
@@ -1808,37 +1810,37 @@ ptp_panasonic_getdeviceproperty (PTPParams *params, uint32_t propcode, uint16_t 
 static uint16_t
 ptp_olympus_parse_output_xml(PTPParams* params, char*data, int len, xmlNodePtr *code)
 {
-        xmlDocPtr       docin;
-        xmlNodePtr      docroot, output, next;
+	xmlDocPtr	docin;
+	xmlNodePtr	docroot, output, next;
 	int 		result, xcode;
 
 	*code = NULL;
 
-        docin = xmlReadMemory ((char*)data, len, "http://gphoto.org/", "utf-8", 0);
-        if (!docin) return PTP_RC_GeneralError;
-        docroot = xmlDocGetRootElement (docin);
-        if (!docroot) {
+	docin = xmlReadMemory ((char*)data, len, "http://gphoto.org/", "utf-8", 0);
+	if (!docin) return PTP_RC_GeneralError;
+	docroot = xmlDocGetRootElement (docin);
+	if (!docroot) {
 		xmlFreeDoc (docin);
 		return PTP_RC_GeneralError;
 	}
 
-        if (strcmp((char*)docroot->name,"x3c")) {
-                ptp_debug (params, "olympus: docroot is not x3c, but %s", docroot->name);
+	if (strcmp((char*)docroot->name,"x3c")) {
+		ptp_debug (params, "olympus: docroot is not x3c, but %s", docroot->name);
 		xmlFreeDoc (docin);
-                return PTP_RC_GeneralError;
-        }
-        if (xmlChildElementCount(docroot) != 1) {
-                ptp_debug (params, "olympus: x3c: expected 1 child, got %ld", xmlChildElementCount(docroot));
-		xmlFreeDoc (docin);
-                return PTP_RC_GeneralError;
-        }
-        output = xmlFirstElementChild (docroot);
-        if (strcmp((char*)output->name, "output") != 0) {
-                ptp_debug (params, "olympus: x3c node: expected child 'output', but got %s", (char*)output->name);
-		xmlFreeDoc (docin);
-                return PTP_RC_GeneralError;
+		return PTP_RC_GeneralError;
 	}
-        next = xmlFirstElementChild (output);
+	if (xmlChildElementCount(docroot) != 1) {
+		ptp_debug (params, "olympus: x3c: expected 1 child, got %ld", xmlChildElementCount(docroot));
+		xmlFreeDoc (docin);
+		return PTP_RC_GeneralError;
+	}
+	output = xmlFirstElementChild (docroot);
+	if (strcmp((char*)output->name, "output") != 0) {
+		ptp_debug (params, "olympus: x3c node: expected child 'output', but got %s", (char*)output->name);
+		xmlFreeDoc (docin);
+		return PTP_RC_GeneralError;
+	}
+	next = xmlFirstElementChild (output);
 
 	result = PTP_RC_GeneralError;
 
@@ -2213,7 +2215,7 @@ ptp_getobjecthandles (PTPParams* params, uint32_t storage,
 uint16_t
 ptp_getfilesystemmanifest (PTPParams* params, uint32_t storage,
 	uint32_t objectformatcode, uint32_t associationOH,
-        uint64_t *numoifs, PTPObjectFilesystemInfo **oifs
+	uint64_t *numoifs, PTPObjectFilesystemInfo **oifs
 ) {
 	PTPContainer	ptp;
 	unsigned int	size = 0;
@@ -2280,7 +2282,7 @@ ptp_canon_eos_bulbstart (PTPParams* params)
 /**
  * ptp_eos_capture:
  * params:	PTPParams*
- *              uint32_t*	result
+ *		uint32_t*	result
  *
  * This starts a EOS400D style capture. You have to use the
  * get_eos_events to find out what resulted.
@@ -2411,7 +2413,7 @@ ptp_getobject_to_handler (PTPParams* params, uint32_t handle, PTPDataHandler *ha
  * ptp_getobject_tofd:
  * params:	PTPParams*
  *		handle			- Object handle
- *		fd                      - File descriptor to write() to
+ *		fd			- File descriptor to write() to
  *
  * Get object 'handle' from device and write the data to the
  * given file descriptor.
@@ -2709,8 +2711,8 @@ ptp_sendobject (PTPParams* params, unsigned char* object, uint64_t size)
 /**
  * ptp_sendobject_from_handler:
  * params:	PTPParams*
- *		PTPDataHandler*         - File descriptor to read() object from
- *              uint64_t size           - File/object size
+ *		PTPDataHandler*		- File descriptor to read() object from
+ *		uint64_t size		- File/object size
  *
  * Sends object from file descriptor by consecutive reads from this
  * descriptor.
@@ -2730,8 +2732,8 @@ ptp_sendobject_from_handler (PTPParams* params, PTPDataHandler *handler, uint64_
 /**
  * ptp_sendobject_fromfd:
  * params:	PTPParams*
- *		fd                      - File descriptor to read() object from
- *              uint64_t size           - File/object size
+ *		fd			- File descriptor to read() object from
+ *		uint64_t size		- File/object size
  *
  * Sends object from file descriptor by consecutive reads from this
  * descriptor.
@@ -3042,7 +3044,7 @@ ptp_ek_sendfileobject_from_handler (PTPParams* params, PTPDataHandler*handler, u
  * Return values: Some PTP_RC_* code.
  * Upon success : uint32_t* size	- The object size
  *		  uint32_t* rp2		- Still unknown return parameter
- *                                        (perhaps upper 32bit of size)
+ *					  (perhaps upper 32bit of size)
  *
  *
  **/
@@ -3075,7 +3077,7 @@ ptp_canon_get_mac_address (PTPParams* params, unsigned char **mac)
 {
 	PTPContainer ptp;
 
-        PTP_CNT_INIT(ptp, PTP_OC_CANON_GetMACAddress);
+	PTP_CNT_INIT(ptp, PTP_OC_CANON_GetMACAddress);
 	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, mac, NULL);
 }
 
@@ -5020,10 +5022,10 @@ ptp_nikon_getfileinfoinblock ( PTPParams* params,
 uint16_t
 ptp_nikon_get_liveview_image (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-        PTPContainer ptp;
+	PTPContainer ptp;
 
-        PTP_CNT_INIT(ptp, PTP_OC_NIKON_GetLiveViewImg);
-        return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
+	PTP_CNT_INIT(ptp, PTP_OC_NIKON_GetLiveViewImg);
+	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
 }
 
 /**
@@ -5042,7 +5044,7 @@ ptp_nikon_get_preview_image (PTPParams* params, unsigned char **xdata, unsigned 
 {
 	PTPContainer	ptp;
 
-        PTP_CNT_INIT(ptp, PTP_OC_NIKON_GetPreviewImg);
+	PTP_CNT_INIT(ptp, PTP_OC_NIKON_GetPreviewImg);
 
 	/* FIXME:
 	 * pdslrdashboard passes 3 parameters:
@@ -5069,7 +5071,7 @@ ptp_canon_eos_getremotemode (PTPParams* params, uint32_t *mode)
 {
 	PTPContainer	ptp;
 
-        PTP_CNT_INIT(ptp, PTP_OC_CANON_EOS_GetRemoteMode);
+	PTP_CNT_INIT(ptp, PTP_OC_CANON_EOS_GetRemoteMode);
 
 	CHECK_PTP_RC(ptp_transaction(params, &ptp, PTP_DP_NODATA, 0, NULL, NULL));
 	*mode = 0;
@@ -5091,21 +5093,21 @@ ptp_canon_eos_getremotemode (PTPParams* params, uint32_t *mode)
 uint16_t
 ptp_canon_eos_get_viewfinder_image (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-        PTPContainer ptp;
+	PTPContainer ptp;
 
 	/* Saw 3 arguments ... 0x00200000 for EOS1000D, also used 0x00100000 */
-        PTP_CNT_INIT(ptp, PTP_OC_CANON_EOS_GetViewFinderData, 0x00200000 /* from trace */, 0, 0);
-        return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
+	PTP_CNT_INIT(ptp, PTP_OC_CANON_EOS_GetViewFinderData, 0x00200000 /* from trace */, 0, 0);
+	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
 }
 
 uint16_t
 ptp_canon_eos_get_viewfinder_image_handler (PTPParams* params, PTPDataHandler*handler)
 {
-        PTPContainer ptp;
+	PTPContainer ptp;
 
 	/* Saw 3 arguments ... 0x00200000 for EOS1000D, also used 0x00100000 */
-        PTP_CNT_INIT(ptp, PTP_OC_CANON_EOS_GetViewFinderData, 0x00200000 /* from trace */, 0, 0);
-        return ptp_transaction_new(params, &ptp, PTP_DP_GETDATA, 0, handler);
+	PTP_CNT_INIT(ptp, PTP_OC_CANON_EOS_GetViewFinderData, 0x00200000 /* from trace */, 0, 0);
+	return ptp_transaction_new(params, &ptp, PTP_DP_GETDATA, 0, handler);
 }
 
 /**
@@ -5177,10 +5179,10 @@ ptp_nikon_check_eventex (PTPParams* params, PTPContainer** event, unsigned int* 
 uint16_t
 ptp_nikon_getptpipinfo (PTPParams* params, unsigned char **data, unsigned int *size)
 {
-        PTPContainer ptp;
+	PTPContainer ptp;
 
-        PTP_CNT_INIT(ptp, PTP_OC_NIKON_GetDevicePTPIPInfo);
-        return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
+	PTP_CNT_INIT(ptp, PTP_OC_NIKON_GetDevicePTPIPInfo);
+	return ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, data, size);
 }
 
 /**
@@ -5203,7 +5205,7 @@ ptp_nikon_getwifiprofilelist (PTPParams* params)
 	char		*buffer;
 	uint8_t		len;
 
-        PTP_CNT_INIT(ptp, PTP_OC_NIKON_GetProfileAllData);
+	PTP_CNT_INIT(ptp, PTP_OC_NIKON_GetProfileAllData);
 	CHECK_PTP_RC(ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size));
 
 	ret = PTP_RC_Undefined; /* FIXME: Add more precise error code */
@@ -5405,7 +5407,7 @@ ptp_mtp_getobjectpropssupported (PTPParams* params, uint16_t ofc,
 	unsigned char	*data = NULL;
 	unsigned int	xsize = 0;
 
-        PTP_CNT_INIT(ptp, PTP_OC_MTP_GetObjectPropsSupported, ofc);
+	PTP_CNT_INIT(ptp, PTP_OC_MTP_GetObjectPropsSupported, ofc);
 	CHECK_PTP_RC(ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &xsize));
 	if (!data) return PTP_RC_GeneralError;
 	*propnum=ptp_unpack_uint16_t_array (params, data, 0, xsize, props);
@@ -5433,8 +5435,8 @@ ptp_mtp_getobjectpropdesc (
 	unsigned char	*data = NULL;
 	unsigned int	size;
 
-        PTP_CNT_INIT(ptp, PTP_OC_MTP_GetObjectPropDesc, opc, ofc);
-        CHECK_PTP_RC(ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size));
+	PTP_CNT_INIT(ptp, PTP_OC_MTP_GetObjectPropDesc, opc, ofc);
+	CHECK_PTP_RC(ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size));
 	ptp_unpack_OPD (params, data, opd, size);
 	free(data);
 	return PTP_RC_OK;
@@ -5462,12 +5464,12 @@ ptp_mtp_getobjectpropvalue (
 	unsigned char	*data = NULL;
 	unsigned int	size, offset = 0;
 
-        PTP_CNT_INIT(ptp, PTP_OC_MTP_GetObjectPropValue, oid, opc);
-        CHECK_PTP_RC(ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size));
-        if (!ptp_unpack_DPV(params, data, &offset, size, value, datatype)) {
-                ptp_debug (params, "ptp_mtp_getobjectpropvalue: unpacking DPV failed");
-                ret = PTP_RC_GeneralError;
-        }
+	PTP_CNT_INIT(ptp, PTP_OC_MTP_GetObjectPropValue, oid, opc);
+	CHECK_PTP_RC(ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size));
+	if (!ptp_unpack_DPV(params, data, &offset, size, value, datatype)) {
+		ptp_debug (params, "ptp_mtp_getobjectpropvalue: unpacking DPV failed");
+		ret = PTP_RC_GeneralError;
+	}
 	free(data);
 	return ret;
 }
@@ -5494,9 +5496,9 @@ ptp_mtp_setobjectpropvalue (
 	unsigned char	*data = NULL;
 	uint32_t	size;
 
-        PTP_CNT_INIT(ptp, PTP_OC_MTP_SetObjectPropValue, oid, opc);
+	PTP_CNT_INIT(ptp, PTP_OC_MTP_SetObjectPropValue, oid, opc);
 	size = ptp_pack_DPV(params, value, &data, datatype);
-        ret = ptp_transaction(params, &ptp, PTP_DP_SENDDATA, size, &data, NULL);
+	ret = ptp_transaction(params, &ptp, PTP_DP_SENDDATA, size, &data, NULL);
 	free(data);
 	return ret;
 }
@@ -5555,12 +5557,12 @@ uint16_t
 ptp_mtp_getobjectproplist_level (PTPParams* params, uint32_t handle, uint32_t level, MTPProperties **props, int *nrofprops)
 {
 	return ptp_mtp_getobjectproplist_generic (params, handle,
-		     0x00000000U,  /* 0x00000000U should be "all formats" */
-		     0xFFFFFFFFU,  /* 0xFFFFFFFFU should be "all properties" */
-		     0,
-		     level,
-		     props,
-		     nrofprops
+		0x00000000U,  /* 0x00000000U should be "all formats" */
+		0xFFFFFFFFU,  /* 0xFFFFFFFFU should be "all properties" */
+		0,
+		level,
+		props,
+		nrofprops
 	);
 }
 
@@ -5950,14 +5952,14 @@ ptp_android_sendpartialobject (PTPParams* params, uint32_t handle, uint64_t offs
 uint16_t
 ptp_fuji_getdeviceinfo (PTPParams* params, uint16_t **props, unsigned int *numprops)
 {
-        PTPContainer	ptp;
+	PTPContainer	ptp;
 	uint16_t	ret;
 	unsigned char	*xdata;
 	unsigned char	*data = NULL;
 	unsigned int	nums, i, newoffset, xsize, size  = 0;
 
-        PTP_CNT_INIT(ptp, PTP_OC_FUJI_GetDeviceInfo);
-        ret = ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size);
+	PTP_CNT_INIT(ptp, PTP_OC_FUJI_GetDeviceInfo);
+	ret = ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size);
 
 	if (ret != PTP_RC_OK) return ret;
 
@@ -5997,13 +5999,13 @@ ptp_fuji_getevents (PTPParams* params, uint16_t** events, uint16_t* count)
 	CHECK_PTP_RC(ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size));
 	ptp_debug(params, "ptp_fuji_getevents");
 	*count = 0;
-        if(size >= 2)
-        {
-                *count = dtoh16a(data);
-                ptp_debug(params, "event count: %d", *count);
-                *events = calloc(*count, sizeof(uint16_t));
-                if(size >= 2u + *count * 6)
-                {
+	if(size >= 2)
+	{
+		*count = dtoh16a(data);
+		ptp_debug(params, "event count: %d", *count);
+		*events = calloc(*count, sizeof(uint16_t));
+		if(size >= 2u + *count * 6)
+		{
 			uint16_t	param;
 			uint32_t	value;
 			int		i;
@@ -6063,8 +6065,8 @@ void
 ptp_free_objectinfo (PTPObjectInfo *oi)
 {
 	if (!oi) return;
-        free (oi->Filename); oi->Filename = NULL;
-        free (oi->Keywords); oi->Keywords = NULL;
+	free (oi->Filename); oi->Filename = NULL;
+	free (oi->Keywords); oi->Keywords = NULL;
 }
 
 void
@@ -7080,31 +7082,31 @@ ptp_get_property_description(PTPParams* params, uint32_t dpc)
 		/* nikon 1 stuff */
 		{PTP_DPC_NIKON_1_ISO,				/* 0xf002 */
 		 N_("ISO")},
-		{PTP_DPC_NIKON_1_FNumber,				/* 0xf003 */
+		{PTP_DPC_NIKON_1_FNumber,			/* 0xf003 */
 		 N_("Aperture")},
-		{PTP_DPC_NIKON_1_FNumber2,				/* 0xf006 */
+		{PTP_DPC_NIKON_1_FNumber2,			/* 0xf006 */
 		 N_("Aperture")},
-		{PTP_DPC_NIKON_1_ShutterSpeed,				/* 0xf004 */
+		{PTP_DPC_NIKON_1_ShutterSpeed,			/* 0xf004 */
 		 N_("Shutterspeed")},
-		{PTP_DPC_NIKON_1_ShutterSpeed2,				/* 0xf007 */
+		{PTP_DPC_NIKON_1_ShutterSpeed2,			/* 0xf007 */
 		 N_("Shutterspeed")},
 		{PTP_DPC_NIKON_1_ImageSize,			/* 0xf00a */
 		 N_("Image Size")},
-		{PTP_DPC_NIKON_1_LongExposureNoiseReduction,    /* 0xF00D */
+		{PTP_DPC_NIKON_1_LongExposureNoiseReduction,	/* 0xF00D */
 		 N_("Long Exposure Noise Reduction")},
-		{PTP_DPC_NIKON_1_Language,                      /* 0xF018 */
+		{PTP_DPC_NIKON_1_Language,			/* 0xF018 */
 		 N_("Camera Language")},
-		{PTP_DPC_NIKON_1_ReleaseWithoutCard,            /* 0xF019 */
+		{PTP_DPC_NIKON_1_ReleaseWithoutCard,		/* 0xF019 */
 		 N_("Release without SD card")},
-		{PTP_DPC_NIKON_1_MovQuality,                    /* 0xF01C */
+		{PTP_DPC_NIKON_1_MovQuality,			/* 0xF01C */
 		 N_("Movie Quality")},
-		{PTP_DPC_NIKON_1_HiISONoiseReduction,           /* 0xF00E */
+		{PTP_DPC_NIKON_1_HiISONoiseReduction,		/* 0xF00E */
 		 N_("High ISO Noise Reduction")},
-		{PTP_DPC_NIKON_1_WhiteBalance,           	/* 0xF00C */
+		{PTP_DPC_NIKON_1_WhiteBalance,			/* 0xF00C */
 		 N_("White Balance")},
-		{PTP_DPC_NIKON_1_ImageCompression,           	/* 0xF009 */
+		{PTP_DPC_NIKON_1_ImageCompression,		/* 0xF009 */
 		 N_("Image Compression")},
-		{PTP_DPC_NIKON_1_ActiveDLighting,           	/* 0xF00F */
+		{PTP_DPC_NIKON_1_ActiveDLighting,		/* 0xF00F */
 		 N_("Active D-Lighting")},
 		{PTP_DPC_NIKON_FaceDetection,"FaceDetection"},
 		{PTP_DPC_NIKON_MovRecProhibitCondition,"MovRecProhibitCondition"},
@@ -7296,10 +7298,10 @@ ptp_get_property_description(PTPParams* params, uint32_t dpc)
 		{PTP_DPC_NIKON_MovieLoopLength,"MovieLoopLength"},
 		{0,NULL}
 	};
-        struct {
+	struct {
 		uint16_t dpc;
 		const char *txt;
-        } ptp_device_properties_MTP[] = {
+	} ptp_device_properties_MTP[] = {
 		{PTP_DPC_MTP_SecureTime,        N_("Secure Time")},		/* D101 */
 		{PTP_DPC_MTP_DeviceCertificate, N_("Device Certificate")},	/* D102 */
 		{PTP_DPC_MTP_RevocationInfo,    N_("Revocation Info")},		/* D103 */
@@ -7318,11 +7320,11 @@ ptp_get_property_description(PTPParams* params, uint32_t dpc)
 		{PTP_DPC_MTP_PlaybackPosition,  N_("Playback Position")},	/* D413 */
 		{PTP_DPC_MTP_PlaysForSureID,    N_("PlaysForSure ID")},		/* D131 (?) */
 		{0,NULL}
-        };
-        struct {
+	};
+	struct {
 		uint16_t dpc;
 		const char *txt;
-        } ptp_device_properties_FUJI[] = {
+	} ptp_device_properties_FUJI[] = {
 		{PTP_DPC_FUJI_FilmSimulation, N_("Film Simulation")},	/* 0xD001 */
 		{PTP_DPC_FUJI_ColorTemperature, N_("Color Temperature")},	/* 0xD017 */
 		{PTP_DPC_FUJI_Quality, N_("Quality")},				/* 0xD018 */
@@ -7534,12 +7536,12 @@ ptp_get_property_description(PTPParams* params, uint32_t dpc)
 		{PTP_DPC_FUJI_FunctionLockCategory1,"FunctionLockCategory1"},
 		{PTP_DPC_FUJI_FunctionLockCategory2,"FunctionLockCategory2"},
 		{0,NULL}
-        };
+	};
 
-        struct {
+	struct {
 		uint16_t dpc;
 		const char *txt;
-        } ptp_device_properties_SONY[] = {
+	} ptp_device_properties_SONY[] = {
 		{PTP_DPC_SONY_DPCCompensation, ("DOC Compensation")},	/* 0xD200 */
 		{PTP_DPC_SONY_DRangeOptimize, ("DRangeOptimize")},	/* 0xD201 */
 		{PTP_DPC_SONY_ImageSize, N_("Image size")},		/* 0xD203 */
@@ -7665,12 +7667,12 @@ ptp_get_property_description(PTPParams* params, uint32_t dpc)
 		{PTP_DPC_SONY_QX_AutoSlowShutter, "AutoSlowShutter"},
 		{PTP_DPC_SONY_QX_DynamicRangeOptimizer, "DynamicRangeOptimizer"},
 		{0,NULL}
-        };
+	};
 
-        struct {
+	struct {
 		uint16_t dpc;
 		const char *txt;
-        } ptp_device_properties_PARROT[] = {
+	} ptp_device_properties_PARROT[] = {
 		{PTP_DPC_PARROT_PhotoSensorEnableMask,		"PhotoSensorEnableMask"}, /* 0xD201 */
 		{PTP_DPC_PARROT_PhotoSensorsKeepOn,		"PhotoSensorsKeepOn"}, /* 0xD202 */
 		{PTP_DPC_PARROT_MultispectralImageSize,		"MultispectralImageSize"}, /* 0xD203 */
@@ -7695,7 +7697,7 @@ ptp_get_property_description(PTPParams* params, uint32_t dpc)
 		{PTP_DPC_PARROT_MultisensorsIrradianceIntegrationTime,"MultisensorsIrradianceIntegrationTime"}, /* 0xD218 */
 		{PTP_DPC_PARROT_OverlapRate,			"OverlapRate"}, /* 0xD219 */
 		{0,NULL}
-        };
+	};
 
 
 	for (i=0; ptp_device_properties[i].txt!=NULL; i++)
@@ -8406,7 +8408,7 @@ ptp_render_property_value(PTPParams* params, uint16_t dpc,
 	for (i=0; ptp_value_trans[i].dpc!=0; i++) {
 		if ((ptp_value_trans[i].dpc == dpc) &&
 			(((ptp_value_trans[i].dpc & 0xf000) == 0x5000) ||
-		         (ptp_value_trans[i].vendor == params->deviceinfo.VendorExtensionID))
+			 (ptp_value_trans[i].vendor == params->deviceinfo.VendorExtensionID))
 		) {
 			double value = _value_to_num(&(dpd->CurrentValue), dpd->DataType);
 
@@ -8421,7 +8423,7 @@ ptp_render_property_value(PTPParams* params, uint16_t dpc,
 	for (i=0; ptp_value_list[i].dpc!=0; i++) {
 		if ((ptp_value_list[i].dpc == dpc) &&
 			(((ptp_value_list[i].dpc & 0xf000) == 0x5000) ||
-		          (ptp_value_list[i].vendor == params->deviceinfo.VendorExtensionID)) &&
+			  (ptp_value_list[i].vendor == params->deviceinfo.VendorExtensionID)) &&
 		    (ptp_value_list[i].key==kval)
 		) {
 			return snprintf(out, length, "%s", _(ptp_value_list[i].value));
@@ -9478,28 +9480,28 @@ ptp_get_new_object_prop_entry(MTPProperties **props, int *nrofprops)
 void
 ptp_destroy_object_prop(MTPProperties *prop)
 {
-  if (!prop)
-    return;
+	if (!prop)
+		return;
 
-  if (prop->datatype == PTP_DTC_STR && prop->propval.str != NULL)
-    free(prop->propval.str);
-  else if ((prop->datatype == PTP_DTC_AINT8 || prop->datatype == PTP_DTC_AINT16 ||
-            prop->datatype == PTP_DTC_AINT32 || prop->datatype == PTP_DTC_AINT64 || prop->datatype == PTP_DTC_AINT128 ||
-            prop->datatype == PTP_DTC_AUINT8 || prop->datatype == PTP_DTC_AUINT16 ||
-            prop->datatype == PTP_DTC_AUINT32 || prop->datatype == PTP_DTC_AUINT64 || prop->datatype ==  PTP_DTC_AUINT128)
-            && prop->propval.a.v != NULL)
-    free(prop->propval.a.v);
+	if (prop->datatype == PTP_DTC_STR && prop->propval.str != NULL)
+		free(prop->propval.str);
+	else if ((prop->datatype == PTP_DTC_AINT8 || prop->datatype == PTP_DTC_AINT16 ||
+		  prop->datatype == PTP_DTC_AINT32 || prop->datatype == PTP_DTC_AINT64 || prop->datatype == PTP_DTC_AINT128 ||
+		  prop->datatype == PTP_DTC_AUINT8 || prop->datatype == PTP_DTC_AUINT16 ||
+		  prop->datatype == PTP_DTC_AUINT32 || prop->datatype == PTP_DTC_AUINT64 || prop->datatype ==  PTP_DTC_AUINT128)
+		&& prop->propval.a.v != NULL)
+	free(prop->propval.a.v);
 }
 
 void
 ptp_destroy_object_prop_list(MTPProperties *props, int nrofprops)
 {
-  int i;
-  MTPProperties *prop = props;
+	int i;
+	MTPProperties *prop = props;
 
-  for (i=0;i<nrofprops;i++,prop++)
-    ptp_destroy_object_prop(prop);
-  free(props);
+	for (i=0;i<nrofprops;i++,prop++)
+		ptp_destroy_object_prop(prop);
+	free(props);
 }
 
 /*

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -101,8 +101,8 @@ struct _PTPUSBBulkContainer {
 			uint32_t param4;
 			uint32_t param5;
 		} params;
-       /* this must be set to the maximum of PTP_USB_BULK_PAYLOAD_LEN_WRITE
-        * and PTP_USB_BULK_PAYLOAD_LEN_READ */
+		/* this must be set to the maximum of PTP_USB_BULK_PAYLOAD_LEN_WRITE
+		* and PTP_USB_BULK_PAYLOAD_LEN_READ */
 		unsigned char data[PTP_USB_BULK_PAYLOAD_LEN_READ];
 	} payload;
 };
@@ -3969,12 +3969,12 @@ uint16_t ptp_generic_no_data	(PTPParams* params, uint16_t opcode, unsigned int c
 uint16_t ptp_opensession	(PTPParams *params, uint32_t session);
 
 uint16_t ptp_transaction_new (PTPParams* params, PTPContainer* ptp,
-                uint16_t flags, uint64_t sendlen,
-                PTPDataHandler *handler
+		uint16_t flags, uint64_t sendlen,
+		PTPDataHandler *handler
 );
 uint16_t ptp_transaction (PTPParams* params, PTPContainer* ptp,
-                uint16_t flags, uint64_t sendlen,
-                unsigned char **data, unsigned int *recvlen
+		uint16_t flags, uint64_t sendlen,
+		unsigned char **data, unsigned int *recvlen
 );
 
 /**
@@ -4045,7 +4045,7 @@ uint16_t ptp_getpartialobject	(PTPParams* params, uint32_t handle, uint32_t offs
 				uint32_t maxbytes, unsigned char** object,
 				uint32_t *len);
 uint16_t ptp_getpartialobject_to_handler (PTPParams* params, uint32_t handle, uint32_t offset,
-                        	uint32_t maxbytes, PTPDataHandler *handler);
+				uint32_t maxbytes, PTPDataHandler *handler);
 
 uint16_t ptp_getthumb		(PTPParams *params, uint32_t handle,
 				unsigned char** object, unsigned int *len);
@@ -4103,12 +4103,12 @@ uint16_t ptp_generic_getdevicepropdesc (PTPParams *params, uint32_t propcode,
 uint16_t ptp_getdevicepropvalue	(PTPParams* params, uint32_t propcode,
 				PTPPropertyValue* value, uint16_t datatype);
 uint16_t ptp_setdevicepropvalue (PTPParams* params, uint32_t propcode,
-                        	PTPPropertyValue* value, uint16_t datatype);
+				PTPPropertyValue* value, uint16_t datatype);
 uint16_t ptp_generic_setdevicepropvalue (PTPParams* params, uint32_t propcode,
-                        	PTPPropertyValue* value, uint16_t datatype);
+				PTPPropertyValue* value, uint16_t datatype);
 uint16_t ptp_getfilesystemmanifest (PTPParams* params, uint32_t storage,
-                        uint32_t objectformatcode, uint32_t associationOH,
-        		uint64_t *numoifs, PTPObjectFilesystemInfo **oifs);
+				uint32_t objectformatcode, uint32_t associationOH,
+				uint64_t *numoifs, PTPObjectFilesystemInfo **oifs);
 uint16_t ptp_getstreaminfo (PTPParams *params, uint32_t streamid, PTPStreamInfo *si);
 uint16_t ptp_getstream (PTPParams* params, unsigned char **data, unsigned int *size);
 
@@ -4436,7 +4436,7 @@ uint16_t ptp_canon_eos_getstorageinfo (PTPParams* params, uint32_t p1, unsigned 
 uint16_t ptp_canon_eos_getpartialobject (PTPParams* params, uint32_t oid, uint32_t off, uint32_t xsize, unsigned char**data);
 uint16_t ptp_canon_eos_getpartialobjectex (PTPParams* params, uint32_t oid, uint32_t off, uint32_t xsize, unsigned char**data);
 uint16_t ptp_canon_eos_getobjectinfoex (PTPParams* params, uint32_t storageid, uint32_t objectid, uint32_t unk,
-        PTPCANONFolderEntry **entries, unsigned int *nrofentries);
+	PTPCANONFolderEntry **entries, unsigned int *nrofentries);
 uint16_t ptp_canon_eos_setdevicepropvalueex (PTPParams* params, unsigned char* data, unsigned int size);
 #define ptp_canon_eos_setremotemode(params,p1) ptp_generic_no_data(params,PTP_OC_CANON_EOS_SetRemoteMode,1,p1)
 #define ptp_canon_eos_seteventmode(params,p1) ptp_generic_no_data(params,PTP_OC_CANON_EOS_SetEventMode,1,p1)
@@ -4460,7 +4460,7 @@ uint16_t ptp_canon_eos_905f (PTPParams* params, uint32_t);
 uint16_t ptp_canon_eos_getdevicepropdesc (PTPParams* params, uint16_t propcode,
 				PTPDevicePropDesc *devicepropertydesc);
 uint16_t ptp_canon_eos_setdevicepropvalue (PTPParams* params, uint16_t propcode,
-                        	PTPPropertyValue* value, uint16_t datatype);
+				PTPPropertyValue* value, uint16_t datatype);
 uint16_t ptp_nikon_get_vendorpropcodes (PTPParams* params, uint16_t **props, unsigned int *size);
 uint16_t ptp_nikon_curve_download (PTPParams* params,
 				unsigned char **data, unsigned int *size);
@@ -4481,13 +4481,13 @@ uint16_t ptp_sony_getdevicepropdesc (PTPParams* params, uint16_t propcode,
 uint16_t ptp_sony_getalldevicepropdesc (PTPParams* params);
 uint16_t ptp_sony_qx_getalldevicepropdesc (PTPParams* params);
 uint16_t ptp_sony_setdevicecontrolvaluea (PTPParams* params, uint16_t propcode,
-                        	PTPPropertyValue* value, uint16_t datatype);
+				PTPPropertyValue* value, uint16_t datatype);
 uint16_t ptp_sony_qx_setdevicecontrolvaluea (PTPParams* params, uint16_t propcode,
-                        	PTPPropertyValue* value, uint16_t datatype);
+				PTPPropertyValue* value, uint16_t datatype);
 uint16_t ptp_sony_setdevicecontrolvalueb (PTPParams* params, uint16_t propcode,
-                        	PTPPropertyValue* value, uint16_t datatype);
+				PTPPropertyValue* value, uint16_t datatype);
 uint16_t ptp_sony_qx_setdevicecontrolvalueb (PTPParams* params, uint16_t propcode,
-                        	PTPPropertyValue* value, uint16_t datatype);
+				PTPPropertyValue* value, uint16_t datatype);
 uint16_t ptp_sony_9280 (PTPParams* params, uint32_t additional, uint32_t data1, uint32_t data2, uint32_t data3, uint32_t data4, uint8_t x, uint8_t y);
 uint16_t ptp_sony_9281 (PTPParams* params, uint32_t param1);
 /**
@@ -4817,7 +4817,7 @@ const char* ptp_get_event_code_name(PTPParams* params, uint16_t event_code);
 
 int
 ptp_render_property_value(PTPParams* params, uint16_t dpc,
-                          PTPDevicePropDesc *dpd, unsigned int length, char *out);
+				PTPDevicePropDesc *dpd, unsigned int length, char *out);
 int ptp_render_ofc(PTPParams* params, uint16_t ofc, int spaceleft, char *txt);
 int ptp_render_mtp_propname(uint16_t propid, int spaceleft, char *txt);
 MTPProperties *ptp_get_new_object_prop_entry(MTPProperties **props, int *nrofprops);
@@ -4858,11 +4858,11 @@ typedef struct tagptp_chdk_videosettings {
 
 /* the following happens to match what is used in CHDK, but is not part of the protocol */
 typedef struct {
-    unsigned size;
-    unsigned script_id; /* id of script message is to/from  */
-    unsigned type;
-    unsigned subtype;
-    char data[];
+	unsigned size;
+	unsigned script_id; /* id of script message is to/from  */
+	unsigned type;
+	unsigned subtype;
+	char data[];
 } ptp_chdk_script_msg;
 
 /*


### PR DESCRIPTION
The code (at least in this part of the project) is effectively formated using tabs with a tab-size of 8 as a means for indentation. Since I last worked on this project almost 10 years ago there have been a few places where spaces were introduced. Some obviously with an indent size of 8 in mind, others with an indent size of 4.

This commit tries its best to make the use of tabs consistent again, at least for indenting lines. The "intra line" indentation (white space after the first non-white-space character) is still a bit of a mess.

Note: this a white-space only change.