### PR TITLE
fix white-space and indentation inconsistencies in ...

### DIFF
--- a/examples/autodetect.c
+++ b/examples/autodetect.c
@@ -17,7 +17,7 @@ static CameraAbilitiesList	*abilities = NULL;
 int
 sample_autodetect (CameraList *list, GPContext *context) {
 	gp_list_reset (list);
-        return gp_camera_autodetect (list, context);
+	return gp_camera_autodetect (list, context);
 }
 
 /*
@@ -41,11 +41,11 @@ sample_open_camera (Camera ** camera, const char *model, const char *port, GPCon
 	}
 
 	/* First lookup the model / driver */
-        m = gp_abilities_list_lookup_model (abilities, model);
+	m = gp_abilities_list_lookup_model (abilities, model);
 	if (m < GP_OK) return ret;
-        ret = gp_abilities_list_get_abilities (abilities, m, &a);
+	ret = gp_abilities_list_get_abilities (abilities, m, &a);
 	if (ret < GP_OK) return ret;
-        ret = gp_camera_set_abilities (*camera, a);
+	ret = gp_camera_set_abilities (*camera, a);
 	if (ret < GP_OK) return ret;
 
 	if (!portinfolist) {
@@ -59,25 +59,25 @@ sample_open_camera (Camera ** camera, const char *model, const char *port, GPCon
 	}
 
 	/* Then associate the camera with the specified port */
-        p = gp_port_info_list_lookup_path (portinfolist, port);
-        switch (p) {
-        case GP_ERROR_UNKNOWN_PORT:
-                fprintf (stderr, "The port you specified "
-                        "('%s') can not be found. Please "
-                        "specify one of the ports found by "
-                        "'gphoto2 --list-ports' and make "
-                        "sure the spelling is correct "
-                        "(i.e. with prefix 'serial:' or 'usb:').",
-                                port);
-                break;
-        default:
-                break;
-        }
-        if (p < GP_OK) return p;
+	p = gp_port_info_list_lookup_path (portinfolist, port);
+	switch (p) {
+	case GP_ERROR_UNKNOWN_PORT:
+		fprintf (stderr, "The port you specified "
+			"('%s') can not be found. Please "
+			"specify one of the ports found by "
+			"'gphoto2 --list-ports' and make "
+			"sure the spelling is correct "
+			"(i.e. with prefix 'serial:' or 'usb:').",
+				port);
+		break;
+	default:
+		break;
+	}
+	if (p < GP_OK) return p;
 
-        ret = gp_port_info_list_get_info (portinfolist, p, &pi);
-        if (ret < GP_OK) return ret;
-        ret = gp_camera_set_port_info (*camera, pi);
-        if (ret < GP_OK) return ret;
+	ret = gp_port_info_list_get_info (portinfolist, p, &pi);
+	if (ret < GP_OK) return ret;
+	ret = gp_camera_set_port_info (*camera, pi);
+	if (ret < GP_OK) return ret;
 	return GP_OK;
 }

--- a/examples/best-iso.c
+++ b/examples/best-iso.c
@@ -24,23 +24,23 @@
 static int aperture;
 static float shutterspeed;
 
-static void errordumper(GPLogLevel level, const char *domain, const char *str,
-                 void *data) {
-  fprintf(stdout, "%s\n", str);
+static void errordumper(GPLogLevel level, const char *domain, const char *str, void *data)
+{
+	fprintf(stdout, "%s\n", str);
 }
 
 static void
 ctx_error_func (GPContext *context, const char *str, void *data)
 {
-        fprintf  (stderr, "\n*** Contexterror ***              \n%s\n",str);
-        fflush   (stderr);
+	fprintf  (stderr, "\n*** Contexterror ***              \n%s\n",str);
+	fflush   (stderr);
 }
 
 static void
 ctx_status_func (GPContext *context, const char *str, void *data)
 {
-        fprintf  (stderr, "%s\n", str);
-        fflush   (stderr);
+	fprintf  (stderr, "%s\n", str);
+	fflush   (stderr);
 }
 
 static
@@ -51,16 +51,16 @@ GPContext* sample_create_context() {
 	context = gp_context_new();
 
 	/* All the parts below are optional! */
-        gp_context_set_error_func (context, ctx_error_func, NULL);
-        gp_context_set_status_func (context, ctx_status_func, NULL);
+	gp_context_set_error_func (context, ctx_error_func, NULL);
+	gp_context_set_status_func (context, ctx_status_func, NULL);
 
 	/* also:
 	gp_context_set_cancel_func    (p->context, ctx_cancel_func,  p);
-        gp_context_set_message_func   (p->context, ctx_message_func, p);
-        if (isatty (STDOUT_FILENO))
-                gp_context_set_progress_funcs (p->context,
-                        ctx_progress_start_func, ctx_progress_update_func,
-                        ctx_progress_stop_func, p);
+	gp_context_set_message_func   (p->context, ctx_message_func, p);
+	if (isatty (STDOUT_FILENO))
+		gp_context_set_progress_funcs (p->context,
+			ctx_progress_start_func, ctx_progress_update_func,
+			ctx_progress_stop_func, p);
 	 */
 	return context;
 }
@@ -115,9 +115,9 @@ get_config_value_string (Camera *camera, const char *key, char **str, GPContext 
 		goto out;
 	}
 	switch (type) {
-        case GP_WIDGET_MENU:
-        case GP_WIDGET_RADIO:
-        case GP_WIDGET_TEXT:
+	case GP_WIDGET_MENU:
+	case GP_WIDGET_RADIO:
+	case GP_WIDGET_TEXT:
 		break;
 	default:
 		fprintf (stderr, "widget has bad type %d\n", type);
@@ -174,9 +174,9 @@ set_config_value_string (Camera *camera, const char *key, const char *val, GPCon
 		goto out;
 	}
 	switch (type) {
-        case GP_WIDGET_MENU:
-        case GP_WIDGET_RADIO:
-        case GP_WIDGET_TEXT:
+	case GP_WIDGET_MENU:
+	case GP_WIDGET_RADIO:
+	case GP_WIDGET_TEXT:
 		/* This is the actual set call. Note that we keep
 		 * ownership of the string and have to free it if necessary.
 		 */
@@ -186,7 +186,7 @@ set_config_value_string (Camera *camera, const char *key, const char *val, GPCon
 			goto out;
 		}
 		break;
-        case GP_WIDGET_TOGGLE: {
+	case GP_WIDGET_TOGGLE: {
 		int ival;
 
 		sscanf(val,"%d",&ival);
@@ -321,9 +321,9 @@ main(int argc, char **argv) {
 	int	retval, iso, tries;
 	char	buf[20];
 	GPContext *context = sample_create_context();
-        /*int	fd;*/
-        CameraFile *file;
-        /*CameraFilePath camera_file_path;*/
+	/*int	fd;*/
+	CameraFile *file;
+	/*CameraFilePath camera_file_path;*/
 
 	gp_log_add_func(GP_LOG_ERROR, errordumper, NULL);
 	gp_camera_new(&camera);
@@ -404,31 +404,31 @@ main(int argc, char **argv) {
 
 #if 0
 
-        printf("Capturing.\n");
+	printf("Capturing.\n");
 
-        retval = gp_camera_capture(camera, GP_CAPTURE_IMAGE, &camera_file_path, context);
-        if (retval != GP_OK) {
+	retval = gp_camera_capture(camera, GP_CAPTURE_IMAGE, &camera_file_path, context);
+	if (retval != GP_OK) {
 		printf("  capture failed: %d\n", retval);
 		exit(1);
 	}
 
-        printf("Pathname on the camera: %s/%s\n", camera_file_path.folder, camera_file_path.name);
+	printf("Pathname on the camera: %s/%s\n", camera_file_path.folder, camera_file_path.name);
 
-        fd = open("capture.jpg", O_CREAT | O_WRONLY | O_BINARY, 0644);
+	fd = open("capture.jpg", O_CREAT | O_WRONLY | O_BINARY, 0644);
 
-        retval = gp_file_new_from_fd(&file, fd);
-        if (retval != GP_OK) printf("  gp_file_new failed: %d\n", retval);
+	retval = gp_file_new_from_fd(&file, fd);
+	if (retval != GP_OK) printf("  gp_file_new failed: %d\n", retval);
 
-        retval = gp_camera_file_get(camera, camera_file_path.folder, camera_file_path.name,
-                     GP_FILE_TYPE_NORMAL, file, context);
-        if (retval != GP_OK) printf("  file_get failed: %d\n", retval);
+	retval = gp_camera_file_get(camera, camera_file_path.folder, camera_file_path.name,
+		     GP_FILE_TYPE_NORMAL, file, context);
+	if (retval != GP_OK) printf("  file_get failed: %d\n", retval);
 
-        printf("Deleting downloaded image.\n");
-        retval = gp_camera_file_delete(camera, camera_file_path.folder, camera_file_path.name,
-                        context);
-        if (retval != GP_OK) printf("  Retval: %d\n", retval);
+	printf("Deleting downloaded image.\n");
+	retval = gp_camera_file_delete(camera, camera_file_path.folder, camera_file_path.name,
+			context);
+	if (retval != GP_OK) printf("  Retval: %d\n", retval);
 
-        gp_file_free(file);
+	gp_file_free(file);
 
 #endif
 #if 1

--- a/examples/config.c
+++ b/examples/config.c
@@ -62,9 +62,9 @@ get_config_value_string (Camera *camera, const char *key, char **str, GPContext 
 		goto out;
 	}
 	switch (type) {
-        case GP_WIDGET_MENU:
-        case GP_WIDGET_RADIO:
-        case GP_WIDGET_TEXT:
+	case GP_WIDGET_MENU:
+	case GP_WIDGET_RADIO:
+	case GP_WIDGET_TEXT:
 		break;
 	default:
 		fprintf (stderr, "widget has bad type %d\n", type);
@@ -121,9 +121,9 @@ set_config_value_string (Camera *camera, const char *key, const char *val, GPCon
 		goto out;
 	}
 	switch (type) {
-        case GP_WIDGET_MENU:
-        case GP_WIDGET_RADIO:
-        case GP_WIDGET_TEXT:
+	case GP_WIDGET_MENU:
+	case GP_WIDGET_RADIO:
+	case GP_WIDGET_TEXT:
 		break;
 	default:
 		fprintf (stderr, "widget has bad type %d\n", type);
@@ -178,7 +178,7 @@ canon_enable_capture (Camera *camera, int onoff, GPContext *context) {
 		goto out;
 	}
 	switch (type) {
-        case GP_WIDGET_TOGGLE:
+	case GP_WIDGET_TOGGLE:
 		break;
 	default:
 		fprintf (stderr, "widget has bad type %d\n", type);

--- a/examples/context.c
+++ b/examples/context.c
@@ -4,15 +4,15 @@
 static void
 ctx_error_func (GPContext *context, const char *str, void *data)
 {
-        fprintf  (stderr, "\n*** Contexterror ***              \n%s\n",str);
-        fflush   (stderr);
+	fprintf  (stderr, "\n*** Contexterror ***              \n%s\n",str);
+	fflush   (stderr);
 }
 
 static void
 ctx_status_func (GPContext *context, const char *str, void *data)
 {
-        fprintf  (stderr, "%s\n", str);
-        fflush   (stderr);
+	fprintf  (stderr, "%s\n", str);
+	fflush   (stderr);
 }
 
 GPContext* sample_create_context() {
@@ -22,16 +22,16 @@ GPContext* sample_create_context() {
 	context = gp_context_new();
 
 	/* All the parts below are optional! */
-        gp_context_set_error_func (context, ctx_error_func, NULL);
-        gp_context_set_status_func (context, ctx_status_func, NULL);
+	gp_context_set_error_func (context, ctx_error_func, NULL);
+	gp_context_set_status_func (context, ctx_status_func, NULL);
 
 	/* also:
 	gp_context_set_cancel_func    (p->context, ctx_cancel_func,  p);
-        gp_context_set_message_func   (p->context, ctx_message_func, p);
-        if (isatty (STDOUT_FILENO))
-                gp_context_set_progress_funcs (p->context,
-                        ctx_progress_start_func, ctx_progress_update_func,
-                        ctx_progress_stop_func, p);
+	gp_context_set_message_func   (p->context, ctx_message_func, p);
+	if (isatty (STDOUT_FILENO))
+		gp_context_set_progress_funcs (p->context,
+			ctx_progress_start_func, ctx_progress_update_func,
+			ctx_progress_stop_func, p);
 	 */
 	return context;
 }

--- a/examples/focus.c
+++ b/examples/focus.c
@@ -45,7 +45,7 @@ camera_eosviewfinder(Camera *camera, GPContext *context, int onoff) {
 		goto out;
 	}
 	switch (type) {
-        case GP_WIDGET_TOGGLE:
+	case GP_WIDGET_TOGGLE:
 		break;
 	default:
 		fprintf (stderr, "widget has bad type %d\n", type);
@@ -99,7 +99,7 @@ camera_auto_focus(Camera *camera, GPContext *context, int onoff) {
 		goto out;
 	}
 	switch (type) {
-        case GP_WIDGET_TOGGLE:
+	case GP_WIDGET_TOGGLE:
 		break;
 	default:
 		fprintf (stderr, "widget has bad type %d\n", type);
@@ -161,7 +161,7 @@ camera_manual_focus (Camera *camera, int xx, GPContext *context) {
 		goto out;
 	}
 	switch (type) {
-        case GP_WIDGET_RADIO: {
+	case GP_WIDGET_RADIO: {
 		int choices = gp_widget_count_choices (child);
 
 		ret = gp_widget_get_value (child, &mval);
@@ -184,7 +184,7 @@ camera_manual_focus (Camera *camera, int xx, GPContext *context) {
 		}
 		break;
 	}
-        case GP_WIDGET_RANGE:
+	case GP_WIDGET_RANGE:
 		ret = gp_widget_get_value (child, &rval);
 		if (ret < GP_OK) {
 			fprintf (stderr, "could not get widget value: %d\n", ret);

--- a/examples/foo.c
+++ b/examples/foo.c
@@ -1,6 +1,6 @@
 /*
 
-  My Preview  Trying to capture preview images with libgphoto2
+	My Preview  Trying to capture preview images with libgphoto2
 
 */
 
@@ -22,42 +22,42 @@ Camera  *canon;
 GPContext *canoncontext;
 
 void get_one(void) {  // capture 1 preview image
-  CameraFile *file;
-  char jpgname[] = "test2.jpg";
-  int rslt;
-  rslt  = gp_file_new(&file);
-  if (rslt) {
-    printf("Error creating new CameraFile %i\n",rslt);
-    exit(1);
-  }
-  // skipping focus for now but do it here
-  // skipping zoom also
-  rslt = gp_camera_capture_preview(canon, file, canoncontext);
-  if (rslt) {
-    printf("error capturing preview %i\n",rslt);
-    exit(1);
-  }
-  rslt = gp_file_save(file, jpgname);
-  if (rslt) {
-    printf("Error saving file (in gp_file_save) %i\n",rslt);
-    exit(1);
-  }
+	CameraFile *file;
+	char jpgname[] = "test2.jpg";
+	int rslt;
+	rslt  = gp_file_new(&file);
+	if (rslt) {
+		printf("Error creating new CameraFile %i\n",rslt);
+		exit(1);
+	}
+	// skipping focus for now but do it here
+	// skipping zoom also
+	rslt = gp_camera_capture_preview(canon, file, canoncontext);
+	if (rslt) {
+		printf("error capturing preview %i\n",rslt);
+		exit(1);
+	}
+	rslt = gp_file_save(file, jpgname);
+	if (rslt) {
+		printf("Error saving file (in gp_file_save) %i\n",rslt);
+		exit(1);
+	}
 }
 
 int main(void) {
-  int rslt;
-  // skip this for now
+	int rslt;
+	// skip this for now
 //  gp_log_add_func(GP_LOG_ERROR, errordumper, NULL);
-  gp_camera_new(&canon);
-  canoncontext =  sample_create_context();
-  printf("Camera init.  Takes about 10 seconds.\n");
-  rslt = gp_camera_init(canon, canoncontext);
-  if (rslt) {
-    printf("Error initializing camera %i\n",rslt);
-    exit(1);
-  }
-  //canon_enable_capture(canon, TRUE, canoncontext);  // in config.c
-  get_one();
-  gp_camera_exit(canon, canoncontext);
-  return 0;
+	gp_camera_new(&canon);
+	canoncontext =  sample_create_context();
+	printf("Camera init.  Takes about 10 seconds.\n");
+	rslt = gp_camera_init(canon, canoncontext);
+	if (rslt) {
+		printf("Error initializing camera %i\n",rslt);
+		exit(1);
+	}
+	//canon_enable_capture(canon, TRUE, canoncontext);  // in config.c
+	get_one();
+	gp_camera_exit(canon, canoncontext);
+	return 0;
 }

--- a/examples/lunkwill-canon-capture.c
+++ b/examples/lunkwill-canon-capture.c
@@ -22,12 +22,11 @@
 
 #include "samples.h"
 
-static void errordumper(GPLogLevel level, const char *domain, const char *str,
-                 void *data) {
-  struct timeval tv;
+static void errordumper(GPLogLevel level, const char *domain, const char *str, void *data) {
+	struct timeval tv;
 
-  gettimeofday (&tv, NULL);
-  fprintf(stdout, "%d.%d: %s\n", (int)tv.tv_sec, (int)tv.tv_usec, str);
+	gettimeofday (&tv, NULL);
+	fprintf(stdout, "%d.%d: %s\n", (int)tv.tv_sec, (int)tv.tv_usec, str);
 }
 
 /* This seems to have no effect on where images go

--- a/examples/preview.c
+++ b/examples/preview.c
@@ -21,9 +21,9 @@
 
 #include "samples.h"
 
-static void errordumper(GPLogLevel level, const char *domain, const char *str,
-                 void *data) {
-  printf("%s (data %p)\n", str,data);
+static void errordumper(GPLogLevel level, const char *domain, const char *str, void *data)
+{
+	printf("%s (data %p)\n", str,data);
 }
 
 /* This seems to have no effect on where images go
@@ -186,7 +186,7 @@ main(int argc, char **argv) {
 		gp_file_unref(file);
 	/*
 		sprintf(output_file, "image-%03d.jpg", i);
-	        capture_to_file(canon, canoncontext, output_file);
+		capture_to_file(canon, canoncontext, output_file);
 	*/
 	}
 	retval = camera_eosviewfinder(canon,canoncontext,0);

--- a/examples/sample-afl.c
+++ b/examples/sample-afl.c
@@ -10,8 +10,8 @@
  *
  */
 
-static void errordumper(GPLogLevel level, const char *domain, const char *str,
-                 void *data) {
+static void errordumper(GPLogLevel level, const char *domain, const char *str, void *data)
+{
 	/* Do not log ... but let it appear here so we discover debug paths */
 	fprintf(stderr, "%s:%s\n", domain, str);
 }
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
 	CameraAbilitiesList      *abilities = NULL;
 
 
-        gp_log_add_func(GP_LOG_DEBUG, errordumper, NULL);
+	gp_log_add_func(GP_LOG_DEBUG, errordumper, NULL);
 
 	context = sample_create_context (); /* see context.c */
 
@@ -162,9 +162,9 @@ int main(int argc, char **argv) {
 	ret = gp_port_info_list_lookup_path (gpinfolist, buf);
 	if (ret < GP_OK) return ret;
 
-        /* Detect all the cameras that can be autodetected... */
-        ret = gp_list_new (&list);
-        if (ret < GP_OK) return 1;
+	/* Detect all the cameras that can be autodetected... */
+	ret = gp_list_new (&list);
+	if (ret < GP_OK) return 1;
 
 	/* Load all the camera drivers we have... */
 	ret = gp_abilities_list_new (&abilities);
@@ -185,7 +185,7 @@ int main(int argc, char **argv) {
 	fprintf(stderr, "name is %s\n", name);
 
 	ret = sample_open_camera (&camera, name, buf, context);
-        if (ret < GP_OK) {
+	if (ret < GP_OK) {
 		fprintf(stderr,"camera %s at %s not found.\n", name, buf);
 		gp_list_free (list);
 		goto out;

--- a/gphoto2/gphoto2-abilities-list.h
+++ b/gphoto2/gphoto2-abilities-list.h
@@ -50,8 +50,8 @@ typedef enum {
  * and MTP Audio Players.
  */
 typedef enum {
-        GP_DEVICE_STILL_CAMERA          = 0,	 /**< Traditional still camera */
-        GP_DEVICE_AUDIO_PLAYER          = 1 << 0 /**< Audio player */
+	GP_DEVICE_STILL_CAMERA          = 0,	 /**< Traditional still camera */
+	GP_DEVICE_AUDIO_PLAYER          = 1 << 0 /**< Audio player */
 } GphotoDeviceType;
 
 /**
@@ -59,36 +59,36 @@ typedef enum {
  * Some drivers might support additional dynamic capabilities (like the PTP driver).
  */
 typedef enum {
-        GP_OPERATION_NONE       	= 0,	  /**< No remote control operation supported. */
-        GP_OPERATION_CAPTURE_IMAGE      = 1 << 0, /**< Capturing images supported. */
-        GP_OPERATION_CAPTURE_VIDEO      = 1 << 1, /**< Capturing videos supported. */
-        GP_OPERATION_CAPTURE_AUDIO      = 1 << 2, /**< Capturing audio supported. */
-        GP_OPERATION_CAPTURE_PREVIEW    = 1 << 3, /**< Capturing image previews supported. */
-        GP_OPERATION_CONFIG             = 1 << 4, /**< Camera and Driver configuration supported. */
-        GP_OPERATION_TRIGGER_CAPTURE    = 1 << 5  /**< Camera can trigger capture and wait for events. */
+	GP_OPERATION_NONE               = 0,      /**< No remote control operation supported. */
+	GP_OPERATION_CAPTURE_IMAGE      = 1 << 0, /**< Capturing images supported. */
+	GP_OPERATION_CAPTURE_VIDEO      = 1 << 1, /**< Capturing videos supported. */
+	GP_OPERATION_CAPTURE_AUDIO      = 1 << 2, /**< Capturing audio supported. */
+	GP_OPERATION_CAPTURE_PREVIEW    = 1 << 3, /**< Capturing image previews supported. */
+	GP_OPERATION_CONFIG             = 1 << 4, /**< Camera and Driver configuration supported. */
+	GP_OPERATION_TRIGGER_CAPTURE    = 1 << 5  /**< Camera can trigger capture and wait for events. */
 } CameraOperation;
 
 /**
  * A bitmask of image related operations of the device.
  */
 typedef enum {
-        GP_FILE_OPERATION_NONE          = 0,      /**< No special file operations, just download. */
-        GP_FILE_OPERATION_DELETE        = 1 << 1, /**< Deletion of files is possible. */
-        GP_FILE_OPERATION_PREVIEW       = 1 << 3, /**< Previewing viewfinder content is possible. */
-        GP_FILE_OPERATION_RAW           = 1 << 4, /**< Raw retrieval is possible (used by non-JPEG cameras) */
-        GP_FILE_OPERATION_AUDIO         = 1 << 5, /**< Audio retrieval is possible. */
-        GP_FILE_OPERATION_EXIF          = 1 << 6  /**< EXIF retrieval is possible. */
+	GP_FILE_OPERATION_NONE          = 0,      /**< No special file operations, just download. */
+	GP_FILE_OPERATION_DELETE        = 1 << 1, /**< Deletion of files is possible. */
+	GP_FILE_OPERATION_PREVIEW       = 1 << 3, /**< Previewing viewfinder content is possible. */
+	GP_FILE_OPERATION_RAW           = 1 << 4, /**< Raw retrieval is possible (used by non-JPEG cameras) */
+	GP_FILE_OPERATION_AUDIO         = 1 << 5, /**< Audio retrieval is possible. */
+	GP_FILE_OPERATION_EXIF          = 1 << 6  /**< EXIF retrieval is possible. */
 } CameraFileOperation;
 
 /**
  * A bitmask of filesystem related operations of the device.
  */
 typedef enum {
-        GP_FOLDER_OPERATION_NONE        = 0,	  /**< No special filesystem operation. */
-        GP_FOLDER_OPERATION_DELETE_ALL  = 1 << 0, /**< Deletion of all files on the device. */
-        GP_FOLDER_OPERATION_PUT_FILE    = 1 << 1, /**< Upload of files to the device possible. */
-        GP_FOLDER_OPERATION_MAKE_DIR    = 1 << 2, /**< Making directories on the device possible. */
-        GP_FOLDER_OPERATION_REMOVE_DIR  = 1 << 3  /**< Removing directories from the device possible. */
+	GP_FOLDER_OPERATION_NONE        = 0,      /**< No special filesystem operation. */
+	GP_FOLDER_OPERATION_DELETE_ALL  = 1 << 0, /**< Deletion of all files on the device. */
+	GP_FOLDER_OPERATION_PUT_FILE    = 1 << 1, /**< Upload of files to the device possible. */
+	GP_FOLDER_OPERATION_MAKE_DIR    = 1 << 2, /**< Making directories on the device possible. */
+	GP_FOLDER_OPERATION_REMOVE_DIR  = 1 << 3  /**< Removing directories from the device possible. */
 } CameraFolderOperation;
 
 #ifdef _GPHOTO2_INTERNAL_CODE
@@ -118,39 +118,39 @@ typedef enum {
  * camlibs, but the status regarding use by frontends is questionable.
  */
 typedef struct {
-        char model [128];			/**< \brief name of camera model */
-        CameraDriverStatus status;		/**< \brief driver quality */
+	char model [128];			/**< \brief name of camera model */
+	CameraDriverStatus status;		/**< \brief driver quality */
 
 	/** \brief Supported port types. */
 	GPPortType port;
 	/** \brief Supported serial port speeds (terminated with a value of 0). */
-        int speed [64];
+	int speed [64];
 
-        /* Supported operations */
-        CameraOperation       operations;	/**< \brief Camera operation funcs */
-        CameraFileOperation   file_operations;  /**< \brief Camera file op funcs */
-        CameraFolderOperation folder_operations;/**< \brief Camera folder op funcs */
+	/* Supported operations */
+	CameraOperation       operations;	/**< \brief Camera operation funcs */
+	CameraFileOperation   file_operations;  /**< \brief Camera file op funcs */
+	CameraFolderOperation folder_operations;/**< \brief Camera folder op funcs */
 
 	int usb_vendor;		/**< \brief USB Vendor D */
 	int usb_product;	/**< \brief USB Product ID */
-	int usb_class;          /**< \brief USB device class */
+	int usb_class;		/**< \brief USB device class */
 	int usb_subclass;	/**< \brief USB device subclass */
 	int usb_protocol;	/**< \brief USB device protocol */
 
-        /* For core use */
-        char library [1024];	/**< \brief (Internal) library filename */
-        char id [1024];		/**< \brief (Internal) camera ID name */
+	/* For core use */
+	char library [1024];	/**< \brief (Internal) library filename */
+	char id [1024];		/**< \brief (Internal) camera ID name */
 
 	GphotoDeviceType 	device_type;	/**< \brief Device type. */
 	/** Reserved space to use in the future w/out changing the
 	 * struct size */
-        int reserved2;		/**< reserved space \internal */
-        int reserved3;		/**< reserved space \internal */
-        int reserved4;		/**< reserved space \internal */
-        int reserved5;		/**< reserved space \internal */
-        int reserved6;		/**< reserved space \internal */
-        int reserved7;		/**< reserved space \internal */
-        int reserved8;		/**< reserved space \internal */
+	int reserved2;		/**< reserved space \internal */
+	int reserved3;		/**< reserved space \internal */
+	int reserved4;		/**< reserved space \internal */
+	int reserved5;		/**< reserved space \internal */
+	int reserved6;		/**< reserved space \internal */
+	int reserved7;		/**< reserved space \internal */
+	int reserved8;		/**< reserved space \internal */
 } CameraAbilities;
 
 

--- a/gphoto2/gphoto2-camera.h
+++ b/gphoto2/gphoto2-camera.h
@@ -405,8 +405,8 @@ int gp_camera_trigger_capture 	 (Camera *camera, GPContext *context);
 int gp_camera_capture_preview 	 (Camera *camera, CameraFile *file,
 				  GPContext *context);
 int gp_camera_wait_for_event     (Camera *camera, int timeout,
-		                  CameraEventType *eventtype, void **eventdata,
-			          GPContext *context);
+				  CameraEventType *eventtype, void **eventdata,
+				  GPContext *context);
 
 int gp_camera_get_storageinfo    (Camera *camera, CameraStorageInformation**,
 				   int *, GPContext *context);
@@ -437,20 +437,20 @@ int gp_camera_folder_remove_dir   (Camera *camera, const char *folder,
 /** \name Operations on files
  * @{
  */
-int gp_camera_file_get_info 	(Camera *camera, const char *folder,
+int gp_camera_file_get_info	(Camera *camera, const char *folder,
 				 const char *file, CameraFileInfo *info,
 				 GPContext *context);
-int gp_camera_file_set_info 	(Camera *camera, const char *folder,
+int gp_camera_file_set_info	(Camera *camera, const char *folder,
 				 const char *file, CameraFileInfo info,
 				 GPContext *context);
 int gp_camera_file_get		(Camera *camera, const char *folder,
 				 const char *file, CameraFileType type,
 				 CameraFile *camera_file, GPContext *context);
 int gp_camera_file_read		(Camera *camera, const char *folder, const char *file,
-		    		 CameraFileType type,
-		    		 uint64_t offset, char *buf, uint64_t *size,
-		    		 GPContext *context);
-int gp_camera_file_delete     	(Camera *camera, const char *folder,
+				 CameraFileType type,
+				 uint64_t offset, char *buf, uint64_t *size,
+				 GPContext *context);
+int gp_camera_file_delete	(Camera *camera, const char *folder,
 				 const char *file, GPContext *context);
 /**@}*/
 
@@ -468,9 +468,9 @@ typedef unsigned int (* CameraTimeoutStartFunc) (Camera *camera,
 typedef void         (* CameraTimeoutStopFunc)  (Camera *camera,
 						 unsigned int id, void *data);
 void         gp_camera_set_timeout_funcs (Camera *camera,
-				          CameraTimeoutStartFunc start_func,
-				          CameraTimeoutStopFunc  stop_func,
-				          void *data);
+					  CameraTimeoutStartFunc start_func,
+					  CameraTimeoutStopFunc  stop_func,
+					  void *data);
 int          gp_camera_start_timeout     (Camera *camera, unsigned int timeout,
 					  CameraTimeoutFunc func);
 void         gp_camera_stop_timeout      (Camera *camera, unsigned int id);

--- a/gphoto2/gphoto2-context.h
+++ b/gphoto2/gphoto2-context.h
@@ -80,7 +80,7 @@ typedef void         (* GPContextProgressStopFunc)   (GPContext *context,
 
 /* Setting those functions (frontends) */
 void gp_context_set_idle_func      (GPContext *context,
-			            GPContextIdleFunc func,     void *data);
+				    GPContextIdleFunc func,     void *data);
 void gp_context_set_progress_funcs (GPContext *context,
 				    GPContextProgressStartFunc  start_func,
 				    GPContextProgressUpdateFunc update_func,

--- a/gphoto2/gphoto2-filesys.h
+++ b/gphoto2/gphoto2-filesys.h
@@ -238,7 +238,7 @@ int gp_filesystem_free	 (CameraFilesystem *fs);
 
 /* Manual editing */
 int gp_filesystem_append           (CameraFilesystem *fs, const char *folder,
-			            const char *filename, GPContext *context);
+				    const char *filename, GPContext *context);
 int gp_filesystem_set_info_noop    (CameraFilesystem *fs,
 				    const char *folder, const char *filename,
 				    CameraFileInfo info, GPContext *context);
@@ -257,10 +257,10 @@ int gp_filesystem_reset            (CameraFilesystem *fs);
 int gp_filesystem_count	       (CameraFilesystem *fs, const char *folder,
 				GPContext *context);
 int gp_filesystem_name         (CameraFilesystem *fs, const char *folder,
-			        int filenumber, const char **filename,
+				int filenumber, const char **filename,
 				GPContext *context);
 int gp_filesystem_get_folder   (CameraFilesystem *fs, const char *filename,
-			        char **folder, GPContext *context);
+				char **folder, GPContext *context);
 int gp_filesystem_number       (CameraFilesystem *fs, const char *folder,
 				const char *filename, GPContext *context);
 

--- a/gphoto2/gphoto2-widget.h
+++ b/gphoto2/gphoto2-widget.h
@@ -70,16 +70,16 @@ typedef enum {									/* Value (get/set):	*/
  */
 typedef int (* CameraWidgetCallback) (Camera *, CameraWidget *, GPContext *);
 
-int 	gp_widget_new 	(CameraWidgetType type, const char *label,
-		         CameraWidget **widget);
-int    	gp_widget_free 	(CameraWidget *widget);
-int     gp_widget_ref   (CameraWidget *widget);
-int     gp_widget_unref (CameraWidget *widget);
+int 	gp_widget_new	(CameraWidgetType type, const char *label,
+			 CameraWidget **widget);
+int	gp_widget_free 	(CameraWidget *widget);
+int	gp_widget_ref   (CameraWidget *widget);
+int	gp_widget_unref (CameraWidget *widget);
 
 int	gp_widget_append	(CameraWidget *widget, CameraWidget *child);
-int 	gp_widget_prepend	(CameraWidget *widget, CameraWidget *child);
+int	gp_widget_prepend	(CameraWidget *widget, CameraWidget *child);
 
-int 	gp_widget_count_children     (CameraWidget *widget);
+int	gp_widget_count_children     (CameraWidget *widget);
 int	gp_widget_get_child	     (CameraWidget *widget, int child_number,
 				      CameraWidget **child);
 
@@ -90,21 +90,21 @@ int	gp_widget_get_child_by_label (CameraWidget *widget,
 int	gp_widget_get_child_by_id    (CameraWidget *widget, int id,
 				      CameraWidget **child);
 int	gp_widget_get_child_by_name  (CameraWidget *widget,
-                                      const char *name,
+				      const char *name,
 				      CameraWidget **child);
 int	gp_widget_get_root           (CameraWidget *widget,
-                                      CameraWidget **root);
-int     gp_widget_get_parent         (CameraWidget *widget,
+				      CameraWidget **root);
+int	gp_widget_get_parent         (CameraWidget *widget,
 				      CameraWidget **parent);
 
-int	gp_widget_set_value     (CameraWidget *widget, const void *value);
-int	gp_widget_get_value     (CameraWidget *widget, void *value);
+int	gp_widget_set_value	(CameraWidget *widget, const void *value);
+int	gp_widget_get_value	(CameraWidget *widget, void *value);
 
-int     gp_widget_set_name      (CameraWidget *widget, const char  *name);
-int     gp_widget_get_name      (CameraWidget *widget, const char **name);
+int	gp_widget_set_name	(CameraWidget *widget, const char  *name);
+int	gp_widget_get_name	(CameraWidget *widget, const char **name);
 
-int	gp_widget_set_info      (CameraWidget *widget, const char  *info);
-int	gp_widget_get_info      (CameraWidget *widget, const char **info);
+int	gp_widget_set_info	(CameraWidget *widget, const char  *info);
+int	gp_widget_get_info	(CameraWidget *widget, const char **info);
 
 int	gp_widget_get_id	(CameraWidget *widget, int *id);
 int	gp_widget_get_type	(CameraWidget *widget, CameraWidgetType *type);
@@ -115,16 +115,16 @@ int	gp_widget_set_range	(CameraWidget *range,
 int	gp_widget_get_range	(CameraWidget *range,
 				 float *min, float *max, float *increment);
 
-int	gp_widget_add_choice     (CameraWidget *widget, const char *choice);
-int	gp_widget_count_choices  (CameraWidget *widget);
-int	gp_widget_get_choice     (CameraWidget *widget, int choice_number,
-                                  const char **choice);
+int	gp_widget_add_choice	(CameraWidget *widget, const char *choice);
+int	gp_widget_count_choices	(CameraWidget *widget);
+int	gp_widget_get_choice	(CameraWidget *widget, int choice_number,
+				 const char **choice);
 
-int	gp_widget_changed        (CameraWidget *widget);
-int     gp_widget_set_changed    (CameraWidget *widget, int changed);
+int	gp_widget_changed	(CameraWidget *widget);
+int	gp_widget_set_changed	(CameraWidget *widget, int changed);
 
-int     gp_widget_set_readonly   (CameraWidget *widget, int readonly);
-int     gp_widget_get_readonly   (CameraWidget *widget, int *readonly);
+int	gp_widget_set_readonly	(CameraWidget *widget, int readonly);
+int	gp_widget_get_readonly	(CameraWidget *widget, int *readonly);
 
 #ifdef __cplusplus
 }

--- a/libgphoto2/bayer.h
+++ b/libgphoto2/bayer.h
@@ -29,9 +29,9 @@
 
 
 int gp_bayer_expand (unsigned char *input, int w, int h, unsigned char *output,
-                     BayerTile tile);
+	BayerTile tile);
 int gp_bayer_decode (unsigned char *input, int w, int h, unsigned char *output,
-		     BayerTile tile);
+	BayerTile tile);
 int gp_bayer_interpolate (unsigned char *image, int w, int h, BayerTile tile);
 /*
  * The following two functions use an alternative procedure called Adaptive
@@ -43,7 +43,7 @@ int gp_bayer_interpolate (unsigned char *image, int w, int h, BayerTile tile);
  */
 
 int gp_ahd_decode (unsigned char *input, int w, int h, unsigned char *output,
-		     BayerTile tile);
+	BayerTile tile);
 int gp_ahd_interpolate (unsigned char *image, int w, int h, BayerTile tile);
 
 #endif /* !defined(LIBGPHOTO2_BAYER_H) */

--- a/libgphoto2/gphoto2-abilities-list.c
+++ b/libgphoto2/gphoto2-abilities-list.c
@@ -179,13 +179,13 @@ foreach_func (const char *filename, lt_ptr data)
 {
 	foreach_data_t *fd = data;
 	CameraList *list = fd->list;
-    char *prefix = getenv(CAMLIBDIR_PREFIX_ENV);
+	char *prefix = getenv(CAMLIBDIR_PREFIX_ENV);
 
 	GP_LOG_D ("Found '%s'.", filename);
-    if(prefix && !strstr(filename,prefix)) {
-        GP_LOG_D("Skipping camlib filename '%s' not matching %s.",filename,prefix);
-        return (0); 
-    }
+	if(prefix && !strstr(filename,prefix)) {
+		GP_LOG_D("Skipping camlib filename '%s' not matching %s.",filename,prefix);
+		return (0);
+	}
 	fd->result = gp_list_append (list, filename, NULL);
 
 	return ((fd->result == GP_OK)?0:1);

--- a/libgphoto2/gphoto2-camera.c
+++ b/libgphoto2/gphoto2-camera.c
@@ -308,16 +308,16 @@ gp_camera_new (Camera **camera)
 
 	C_PARAMS (camera);
 
-        C_MEM (*camera = calloc (1, sizeof (Camera)));
+	C_MEM (*camera = calloc (1, sizeof (Camera)));
 
-        (*camera)->functions = calloc (1, sizeof (CameraFunctions));
-        (*camera)->pc        = calloc (1, sizeof (CameraPrivateCore));
+	(*camera)->functions = calloc (1, sizeof (CameraFunctions));
+	(*camera)->pc        = calloc (1, sizeof (CameraPrivateCore));
 	if (!(*camera)->functions || !(*camera)->pc) {
 		result = GP_ERROR_NO_MEMORY;
 		goto error;
 	}
 
-        (*camera)->pc->ref_count = 1;
+	(*camera)->pc->ref_count = 1;
 
 	/* Create the filesystem */
 	result = gp_filesystem_new (&(*camera)->fs);
@@ -329,7 +329,7 @@ gp_camera_new (Camera **camera)
 	if (result < GP_OK)
 		goto error;
 
-        return(GP_OK);
+	return(GP_OK);
 
 error:
 	gp_camera_free (*camera);
@@ -628,11 +628,11 @@ gp_camera_autodetect (CameraList *list, GPContext *context)
 	if (ret < GP_OK) goto out;
 
 	/* ... and autodetect the currently attached cameras. */
-        ret = gp_abilities_list_detect (al, il, xlist, context);
+	ret = gp_abilities_list_detect (al, il, xlist, context);
 	if (ret < GP_OK) goto out;
 
 	/* Filter out the "usb:" entry */
-        ret = gp_list_count (xlist);
+	ret = gp_list_count (xlist);
 	if (ret < GP_OK) goto out;
 	for (i=0;i<ret;i++) {
 		const char *name, *value;
@@ -697,7 +697,7 @@ gp_camera_init (Camera *camera, GPContext *context)
 		char		*ppath;
 		GPPortType	ptype;
 		GPPortInfo	info;
-        	CameraList	*list;
+		CameraList	*list;
 
 		result = gp_list_new (&list);
 		if (result < GP_OK)
@@ -864,7 +864,7 @@ gp_camera_get_config (Camera *camera, CameraWidget **window, GPContext *context)
 		gp_context_error (context, _("This camera does "
 			"not provide any configuration options."));
 		CAMERA_UNUSED (camera, context);
-                return (GP_ERROR_NOT_SUPPORTED);
+		return (GP_ERROR_NOT_SUPPORTED);
 	}
 
 	CHECK_RESULT_OPEN_CLOSE (camera, camera->functions->get_config (
@@ -940,8 +940,8 @@ gp_camera_get_single_config (Camera *camera, const char *name, CameraWidget **wi
 	gp_widget_set_readonly (*widget, ro);
 
 	switch (type) {
-        case GP_WIDGET_MENU:
-        case GP_WIDGET_RADIO: {
+	case GP_WIDGET_MENU:
+	case GP_WIDGET_RADIO: {
 		char *value;
 		int i, nrofchoices;
 
@@ -956,35 +956,35 @@ gp_camera_get_single_config (Camera *camera, const char *name, CameraWidget **wi
 		gp_widget_set_value (*widget, value);
 		break;
 	}
-        case GP_WIDGET_TEXT: {
+	case GP_WIDGET_TEXT: {
 		char *value;
 
 		gp_widget_get_value (child, &value);
 		gp_widget_set_value (*widget, value);
 		break;
 	}
-        case GP_WIDGET_RANGE: {
+	case GP_WIDGET_RANGE: {
 		float value, rmin, rmax, rstep;
 
 		gp_widget_get_range (child, &rmin, &rmax, &rstep);
 		gp_widget_set_range (*widget, rmin, rmax, rstep);
 		gp_widget_get_value (child, &value);
 		gp_widget_set_value (*widget, &value);
-                break;
+		break;
 	}
-        case GP_WIDGET_TOGGLE:
-        case GP_WIDGET_DATE: {
+	case GP_WIDGET_TOGGLE:
+	case GP_WIDGET_DATE: {
 		int value;
 
 		gp_widget_get_value (child, &value);
 		gp_widget_set_value (*widget, &value);
-                break;
+		break;
 	}
-        case GP_WIDGET_BUTTON:
-        case GP_WIDGET_SECTION:
-        case GP_WIDGET_WINDOW:
-        default:
-                ret = GP_ERROR_BAD_PARAMETERS;
+	case GP_WIDGET_BUTTON:
+	case GP_WIDGET_SECTION:
+	case GP_WIDGET_WINDOW:
+	default:
+		ret = GP_ERROR_BAD_PARAMETERS;
 		break;
 	}
 out:
@@ -1014,20 +1014,20 @@ _get_widget_names (CameraWidget *widget, CameraList *list)
 
 	gp_widget_get_type (widget, &type);
 	switch (type) {
-        case GP_WIDGET_MENU:
-        case GP_WIDGET_RADIO:
-        case GP_WIDGET_TEXT:
-        case GP_WIDGET_RANGE:
-        case GP_WIDGET_TOGGLE:
-        case GP_WIDGET_DATE: {
+	case GP_WIDGET_MENU:
+	case GP_WIDGET_RADIO:
+	case GP_WIDGET_TEXT:
+	GP_WIDGET_RANGE:
+	case GP_WIDGET_TOGGLE:
+	case GP_WIDGET_DATE: {
 		const char *name;
 
 		gp_widget_get_name (widget, &name);
 		gp_list_append (list, name, NULL);
-                break;
+		break;
 	}
-        case GP_WIDGET_SECTION:
-        case GP_WIDGET_WINDOW: {
+	case GP_WIDGET_SECTION:
+	case GP_WIDGET_WINDOW: {
 		int i, nrofchildren;
 
 		nrofchildren = gp_widget_count_children (widget);
@@ -1039,8 +1039,8 @@ _get_widget_names (CameraWidget *widget, CameraList *list)
 		}
 		break;
 	}
-        case GP_WIDGET_BUTTON:
-        default:
+	case GP_WIDGET_BUTTON:
+	default:
 		break;
 	}
 
@@ -1108,7 +1108,7 @@ gp_camera_set_config (Camera *camera, CameraWidget *window, GPContext *context)
 		gp_context_error (context, _("This camera does "
 			"not support setting configuration options."));
 		CAMERA_UNUSED (camera, context);
-                return (GP_ERROR_NOT_SUPPORTED);
+		return (GP_ERROR_NOT_SUPPORTED);
 	}
 
 	CHECK_RESULT_OPEN_CLOSE (camera, camera->functions->set_config (camera,
@@ -1173,35 +1173,35 @@ gp_camera_set_single_config (Camera *camera, const char *name, CameraWidget *wid
 	gp_widget_get_type (child, &type);
 	ret = GP_OK;
 	switch (type) {
-        case GP_WIDGET_MENU:
-        case GP_WIDGET_RADIO:
-        case GP_WIDGET_TEXT: {
+	case GP_WIDGET_MENU:
+	case GP_WIDGET_RADIO:
+	case GP_WIDGET_TEXT: {
 		char *value;
 
 		gp_widget_get_value (widget, &value);
 		gp_widget_set_value (child, value);
 		break;
 	}
-        case GP_WIDGET_RANGE: {
+	case GP_WIDGET_RANGE: {
 		float value;
 
 		gp_widget_get_value (widget, &value);
 		gp_widget_set_value (child, &value);
-                break;
+		break;
 	}
-        case GP_WIDGET_TOGGLE:
-        case GP_WIDGET_DATE: {
+	case GP_WIDGET_TOGGLE:
+	case GP_WIDGET_DATE: {
 		int value;
 
 		gp_widget_get_value (widget, &value);
 		gp_widget_set_value (child, &value);
-                break;
+		break;
 	}
-        case GP_WIDGET_BUTTON:
-        case GP_WIDGET_SECTION:
-        case GP_WIDGET_WINDOW:
-        default:
-                ret = GP_ERROR_BAD_PARAMETERS;
+	case GP_WIDGET_BUTTON:
+	case GP_WIDGET_SECTION:
+	case GP_WIDGET_WINDOW:
+	default:
+		ret = GP_ERROR_BAD_PARAMETERS;
 		break;
 	}
 	gp_widget_set_changed (child, 1);
@@ -1237,7 +1237,7 @@ gp_camera_get_summary (Camera *camera, CameraText *summary, GPContext *context)
 		gp_context_error (context, _("This camera does "
 				  "not support summaries."));
 		CAMERA_UNUSED (camera, context);
-                return (GP_ERROR_NOT_SUPPORTED);
+		return (GP_ERROR_NOT_SUPPORTED);
 	}
 
 	CHECK_RESULT_OPEN_CLOSE (camera, camera->functions->summary (camera,
@@ -1268,7 +1268,7 @@ gp_camera_get_manual (Camera *camera, CameraText *manual, GPContext *context)
 		gp_context_error (context, _("This camera "
 			"does not provide a manual."));
 		CAMERA_UNUSED (camera, context);
-                return (GP_ERROR_NOT_SUPPORTED);
+		return (GP_ERROR_NOT_SUPPORTED);
 	}
 
 	CHECK_RESULT_OPEN_CLOSE (camera, camera->functions->manual (camera,
@@ -1300,7 +1300,7 @@ gp_camera_get_about (Camera *camera, CameraText *about, GPContext *context)
 		gp_context_error (context, _("This camera does "
 			"not provide information about the driver."));
 		CAMERA_UNUSED (camera, context);
-                return (GP_ERROR_NOT_SUPPORTED);
+		return (GP_ERROR_NOT_SUPPORTED);
 	}
 
 	CHECK_RESULT_OPEN_CLOSE (camera, camera->functions->about (camera,
@@ -1333,7 +1333,7 @@ gp_camera_capture (Camera *camera, CameraCaptureType type,
 	if (!camera->functions->capture) {
 		gp_context_error (context, _("This camera can not capture."));
 		CAMERA_UNUSED (camera, context);
-                return (GP_ERROR_NOT_SUPPORTED);
+		return (GP_ERROR_NOT_SUPPORTED);
 	}
 
 	CHECK_RESULT_OPEN_CLOSE (camera, camera->functions->capture (camera,
@@ -1363,7 +1363,7 @@ gp_camera_trigger_capture (Camera *camera, GPContext *context)
 	if (!camera->functions->trigger_capture) {
 		gp_context_error (context, _("This camera can not trigger capture."));
 		CAMERA_UNUSED (camera, context);
-                return (GP_ERROR_NOT_SUPPORTED);
+		return (GP_ERROR_NOT_SUPPORTED);
 	}
 	CHECK_RESULT_OPEN_CLOSE (camera, camera->functions->trigger_capture (camera,
 						context), context);
@@ -1397,7 +1397,7 @@ gp_camera_capture_preview (Camera *camera, CameraFile *file, GPContext *context)
 		gp_context_error (context, _("This camera can "
 			"not capture previews."));
 		CAMERA_UNUSED (camera, context);
-                return (GP_ERROR_NOT_SUPPORTED);
+		return (GP_ERROR_NOT_SUPPORTED);
 	}
 
 	CHECK_RESULT_OPEN_CLOSE (camera, camera->functions->capture_preview (
@@ -1436,7 +1436,7 @@ gp_camera_capture_preview (Camera *camera, CameraFile *file, GPContext *context)
  */
 int
 gp_camera_wait_for_event (Camera *camera, int timeout,
-		          CameraEventType *eventtype, void **eventdata,
+			  CameraEventType *eventtype, void **eventdata,
 			  GPContext *context)
 {
 	C_PARAMS (camera);
@@ -1444,7 +1444,7 @@ gp_camera_wait_for_event (Camera *camera, int timeout,
 
 	if (!camera->functions->wait_for_event) {
 		CAMERA_UNUSED (camera, context);
-                return (GP_ERROR_NOT_SUPPORTED);
+		return (GP_ERROR_NOT_SUPPORTED);
 	}
 	CHECK_RESULT_OPEN_CLOSE (camera, camera->functions->wait_for_event (
 					camera, timeout, eventtype, eventdata,
@@ -1478,7 +1478,7 @@ gp_camera_folder_list_files (Camera *camera, const char *folder,
 
 	CR (camera, gp_list_sort (list), context);
 	CAMERA_UNUSED (camera, context);
-        return (GP_OK);
+	return (GP_OK);
 }
 
 /**
@@ -1506,7 +1506,7 @@ gp_camera_folder_list_folders (Camera *camera, const char* folder,
 
 	CR (camera, gp_list_sort (list), context);
 	CAMERA_UNUSED (camera, context);
-        return (GP_OK);
+	return (GP_OK);
 }
 
 /**

--- a/libgphoto2/gphoto2-file.c
+++ b/libgphoto2/gphoto2-file.c
@@ -56,17 +56,17 @@
  * \internal
  */
 struct _CameraFile {
-        char		mime_type [64];
-        char		name [MAX_PATH];
-        int		ref_count;
-        time_t		mtime;
+	char		mime_type [64];
+	char		name [MAX_PATH];
+	int		ref_count;
+	time_t		mtime;
 
 	CameraFileAccessType	accesstype;
 
 	/* for GP_FILE_ACCESSTYPE_MEMORY files */
-        unsigned long	size;
-        unsigned char	*data;
-        unsigned long	offset;	/* read pointer */
+	unsigned long	size;
+	unsigned char	*data;
+	unsigned long	offset;	/* read pointer */
 
 	/* for GP_FILE_ACCESSTYPE_FD files */
 	int		fd;
@@ -242,7 +242,7 @@ gp_file_append (CameraFile *file, const char *data,
 		GP_LOG_E ("Unknown file access type %d", file->accesstype);
 		return GP_ERROR;
 	}
-        return (GP_OK);
+	return (GP_OK);
 }
 
 /**
@@ -300,7 +300,7 @@ gp_file_slurp (CameraFile *file, char *data,
 		GP_LOG_E ("Unknown file access type %d", file->accesstype);
 		return GP_ERROR;
 	}
-        return (GP_OK);
+	return (GP_OK);
 }
 
 
@@ -608,10 +608,10 @@ static const char *mime_table[] = {
 int
 gp_file_open (CameraFile *file, const char *filename)
 {
-        FILE *fp;
-        char *name, *dot;
-        long size, size_read;
-        int  i;
+	FILE *fp;
+	char *name, *dot;
+	long size, size_read;
+	int  i;
 	struct stat s;
 
 
@@ -619,12 +619,12 @@ gp_file_open (CameraFile *file, const char *filename)
 
 	CHECK_RESULT (gp_file_clean (file));
 
-        fp = fopen(filename, "r");
-        if (!fp)
+	fp = fopen(filename, "r");
+	if (!fp)
 		return (GP_ERROR);
 	fseek (fp, 0, SEEK_END);
-        size = ftell (fp);
-        rewind (fp);
+	size = ftell (fp);
+	rewind (fp);
 
 	switch (file->accesstype) {
 	case GP_FILE_ACCESSTYPE_MEMORY:
@@ -657,34 +657,35 @@ gp_file_open (CameraFile *file, const char *filename)
 		break;
 	}
 
-        name = strrchr (filename, '/');
-        if (name)
-                strncpy (file->name, name + 1, sizeof (file->name));
-           else
-                strncpy (file->name, filename, sizeof (file->name));
+	name = strrchr (filename, '/');
+	if (name)
+		strncpy (file->name, name + 1, sizeof (file->name));
+	else
+		strncpy (file->name, filename, sizeof (file->name));
 
-        /* MIME lookup */
-        dot = strrchr (filename, '.');
-        if (dot) {
-            for (i = 0; mime_table[i] ; i+=2)
-                if (!strcasecmp (mime_table[i], dot+1)) {
-                    strncpy (file->mime_type, mime_table[i+1], sizeof(file->mime_type));
-                    break;
-                }
-            if (!mime_table[i])
-                /*
-                 * We did not found the type in the lookup table,
-                 * so we use the file suffix as mime type.
-                 * Note: This should probably use GP_MIME_UNKNOWN instead
-                 * of returning a non-standard type.
-                 */
-                sprintf(file->mime_type, "image/%s", dot + 1);
-        } else
-            /*
-             * Damn, no filename suffix...
-             */
-            strncpy (file->mime_type, GP_MIME_UNKNOWN,
-		     sizeof (file->mime_type));
+	/* MIME lookup */
+	dot = strrchr (filename, '.');
+	if (dot) {
+		for (i = 0; mime_table[i] ; i+=2)
+			if (!strcasecmp (mime_table[i], dot+1)) {
+				strncpy (file->mime_type, mime_table[i+1], sizeof(file->mime_type));
+				break;
+			}
+		if (!mime_table[i])
+			/*
+			* We did not found the type in the lookup table,
+			* so we use the file suffix as mime type.
+			* Note: This should probably use GP_MIME_UNKNOWN instead
+			* of returning a non-standard type.
+			*/
+			sprintf(file->mime_type, "image/%s", dot + 1);
+	} else {
+		/*
+		* Damn, no filename suffix...
+		*/
+		strncpy (file->mime_type, GP_MIME_UNKNOWN,
+			sizeof (file->mime_type));
+	}
 
 	if (stat (filename, &s) != -1) {
 		file->mtime = s.st_mtime;
@@ -692,7 +693,7 @@ gp_file_open (CameraFile *file, const char *filename)
 		file->mtime = time (NULL);
 	}
 
-        return (GP_OK);
+	return (GP_OK);
 }
 
 
@@ -704,10 +705,10 @@ gp_file_open (CameraFile *file, const char *filename)
 int
 gp_file_clean (CameraFile *file)
 {
-        /*
+	/*
 	 * Frees a CameraFile's components, not the CameraFile itself.
 	 * This is used to prep a CameraFile struct to be filled.
-         */
+	 */
 
 	C_PARAMS (file);
 
@@ -722,7 +723,7 @@ gp_file_clean (CameraFile *file)
 	default:break;
 	}
 	strcpy (file->name, "");
-        return (GP_OK);
+	return (GP_OK);
 }
 
 /**
@@ -1035,7 +1036,7 @@ int
 gp_file_detect_mime_type (CameraFile *file)
 {
 	const char TIFF_SOI_MARKER[] = {(char) 0x49, (char) 0x49, (char) 0x2A,
-				        (char) 0x00, (char) 0x08, '\0' };
+					(char) 0x00, (char) 0x08, '\0' };
 	const char JPEG_SOI_MARKER[] = {(char) 0xFF, (char) 0xD8, '\0' };
 
 	C_PARAMS (file);
@@ -1116,7 +1117,7 @@ gp_file_adjust_name_for_mime_type (CameraFile *file)
 
 	GP_LOG_D ("Adjusting file name for mime type '%s'...", file->mime_type);
 	for (x = 0; table[x]; x += 2)
-                if (!strcmp (file->mime_type, table[x])) {
+		if (!strcmp (file->mime_type, table[x])) {
 
 			/* Search the current suffix and erase it */
 			suffix = strrchr (file->name, '.');

--- a/libgphoto2/gphoto2-filesys.c
+++ b/libgphoto2/gphoto2-filesys.c
@@ -430,7 +430,7 @@ lookup_folder_file (
 		CameraList	*list;
 		int		ret;
 		/*
-                 * The folder is dirty. List the files in it to make it clean.
+		 * The folder is dirty. List the files in it to make it clean.
 		 */
 		GP_LOG_D ("Folder %s is dirty. "
 			"Listing files in there to make folder clean...", folder);

--- a/libgphoto2/gphoto2-list.c
+++ b/libgphoto2/gphoto2-list.c
@@ -134,7 +134,7 @@ gp_list_free (CameraList *list)
 	 */
 	list->ref_count = 0;
 	free (list);
-        return (GP_OK);
+	return (GP_OK);
 }
 
 /**
@@ -190,16 +190,16 @@ gp_list_append (CameraList *list, const char *name, const char *value)
 	} else {
 		list->entry[list->used].value = NULL;
 	}
-        list->used++;
-        return (GP_OK);
+	list->used++;
+	return (GP_OK);
 }
 
 static int
 cmp_list (const void *a, const void *b) {
-        const struct _entry *ca = a;
-        const struct _entry *cb = b;
+	const struct _entry *ca = a;
+	const struct _entry *cb = b;
 
-        return strcmp (ca->name, cb->name);
+	return strcmp (ca->name, cb->name);
 }
 
 /**
@@ -230,7 +230,7 @@ gp_list_count (CameraList *list)
 {
 	C_PARAMS (list && list->ref_count);
 
-        return (list->used);
+	return (list->used);
 }
 
 /**

--- a/libgphoto2/gphoto2-setting.c
+++ b/libgphoto2/gphoto2-setting.c
@@ -74,22 +74,22 @@ static int load_settings (void);
 int
 gp_setting_get (char *id, char *key, char *value)
 {
-        int x;
+	int x;
 
 	C_PARAMS (id && key);
 
 	if (!glob_setting_count)
 		load_settings ();
 
-        for (x=0; x<glob_setting_count; x++) {
-                if ((strcmp(glob_setting[x].id, id)==0) &&
+	for (x=0; x<glob_setting_count; x++) {
+		if ((strcmp(glob_setting[x].id, id)==0) &&
 		    (strcmp(glob_setting[x].key, key)==0)) {
-                        strcpy(value, glob_setting[x].value);
-                        return (GP_OK);
-                }
-        }
-        strcpy(value, "");
-        return(GP_ERROR);
+			strcpy(value, glob_setting[x].value);
+			return (GP_OK);
+		}
+	}
+	strcpy(value, "");
+	return(GP_ERROR);
 }
 
 /**
@@ -106,7 +106,7 @@ gp_setting_get (char *id, char *key, char *value)
 int
 gp_setting_set (char *id, char *key, char *value)
 {
-        int x;
+	int x;
 
 	C_PARAMS (id && key);
 
@@ -115,20 +115,20 @@ gp_setting_set (char *id, char *key, char *value)
 
 	GP_LOG_D ("Setting key '%s' to value '%s' (%s)", key, value, id);
 
-        for (x=0; x<glob_setting_count; x++) {
-                if ((strcmp(glob_setting[x].id, id)==0) &&
+	for (x=0; x<glob_setting_count; x++) {
+		if ((strcmp(glob_setting[x].id, id)==0) &&
 		    (strcmp(glob_setting[x].key, key)==0)) {
-                        strcpy(glob_setting[x].value, value);
-                        save_settings ();
-                        return (GP_OK);
-                }
+			strcpy(glob_setting[x].value, value);
+			save_settings ();
+			return (GP_OK);
+		}
 	}
-        strcpy(glob_setting[glob_setting_count].id, id);
-        strcpy(glob_setting[glob_setting_count].key, key);
-        strcpy(glob_setting[glob_setting_count++].value, value);
-        save_settings ();
+	strcpy(glob_setting[glob_setting_count].id, id);
+	strcpy(glob_setting[glob_setting_count].key, key);
+	strcpy(glob_setting[glob_setting_count++].value, value);
+	save_settings ();
 
-        return (GP_OK);
+	return (GP_OK);
 }
 
 static int
@@ -208,16 +208,16 @@ load_settings (void)
 		if (!fgets(buf, 1023, f))
 			break;
 		if (strlen(buf)>2) {
-		     buf[strlen(buf)-1] = '\0';
-		     id = strtok(buf, "=");
-		     strcpy(glob_setting[glob_setting_count].id,id);
-		     key = strtok(NULL, "=");
-		     strcpy(glob_setting[glob_setting_count].key,key);
-		     value = strtok(NULL, "\0");
-		     if (value)
-			strcpy(glob_setting[glob_setting_count++].value, value);
-		       else
-			strcpy(glob_setting[glob_setting_count++].value, "");
+			buf[strlen(buf)-1] = '\0';
+			id = strtok(buf, "=");
+			strcpy(glob_setting[glob_setting_count].id,id);
+			key = strtok(NULL, "=");
+			strcpy(glob_setting[glob_setting_count].key,key);
+			value = strtok(NULL, "\0");
+			if (value)
+				strcpy(glob_setting[glob_setting_count++].value, value);
+			else
+				strcpy(glob_setting[glob_setting_count++].value, "");
 		}
 	}
 	fclose (f);

--- a/libgphoto2/gphoto2-widget.c
+++ b/libgphoto2/gphoto2-widget.c
@@ -105,16 +105,16 @@ gp_widget_new (CameraWidgetType type, const char *label,
 
 	/* set the value to nothing */
 	(*widget)->value_int    	= 0;
-        (*widget)->value_float  	= 0.0;
-        (*widget)->value_string 	= NULL;
+	(*widget)->value_float  	= 0.0;
+	(*widget)->value_string 	= NULL;
 
-        (*widget)->ref_count    	= 1;
+	(*widget)->ref_count    	= 1;
 	(*widget)->choice_count 	= 0;
 	(*widget)->choice 		= NULL;
 	(*widget)->readonly 		= 0;
 	(*widget)->id			= i++;
 
-        /* Clear all children pointers */
+	/* Clear all children pointers */
 	free ((*widget)->children);
 	(*widget)->children = NULL;
 	(*widget)->children_count = 0;
@@ -386,41 +386,41 @@ gp_widget_set_value (CameraWidget *widget, const void *value)
 {
 	C_PARAMS (widget && value);
 
-        switch (widget->type) {
+	switch (widget->type) {
 	case GP_WIDGET_BUTTON:
 		widget->callback = (CameraWidgetCallback) value;
 		return (GP_OK);
 	case GP_WIDGET_MENU:
 	case GP_WIDGET_RADIO:
-        case GP_WIDGET_TEXT:
+	case GP_WIDGET_TEXT:
 		GP_LOG_D ("Setting value of widget '%s' to '%s'...",
 			widget->label, (char*) value);
 		if (widget->value_string) {
-                	if (strcmp (widget->value_string, (char*) value))
-                    		widget->changed = 1;
-                	free (widget->value_string);
-        	} else
-        		widget->changed = 1;
-        	widget->value_string = strdup ((char*)value);
-        	return (GP_OK);
-        case GP_WIDGET_RANGE:
-            	if (widget->value_float != *((float*)value)) {
-                	widget->value_float  = *((float*)value);
-                	widget->changed = 1;
-            	}
-            	return (GP_OK);
+			if (strcmp (widget->value_string, (char*) value))
+				widget->changed = 1;
+			free (widget->value_string);
+		} else
+			widget->changed = 1;
+		widget->value_string = strdup ((char*)value);
+		return (GP_OK);
+	case GP_WIDGET_RANGE:
+		if (widget->value_float != *((float*)value)) {
+			widget->value_float  = *((float*)value);
+			widget->changed = 1;
+		}
+		return (GP_OK);
 	case GP_WIDGET_DATE:
-        case GP_WIDGET_TOGGLE:
-        	if (widget->value_int != *((int*)value)) {
-        		widget->value_int  = *((int*)value);
-        		widget->changed = 1;
-        	}
-	        return (GP_OK);
+	case GP_WIDGET_TOGGLE:
+		if (widget->value_int != *((int*)value)) {
+			widget->value_int  = *((int*)value);
+			widget->changed = 1;
+		}
+		return (GP_OK);
 	case GP_WIDGET_WINDOW:
 	case GP_WIDGET_SECTION:
-        default:
-        	return (GP_ERROR_BAD_PARAMETERS);
-        }
+	default:
+		return (GP_ERROR_BAD_PARAMETERS);
+	}
 }
 
 /**
@@ -436,27 +436,27 @@ gp_widget_get_value (CameraWidget *widget, void *value)
 {
 	C_PARAMS (widget && value);
 
-        switch (widget->type) {
+	switch (widget->type) {
 	case GP_WIDGET_BUTTON:
 		*(CameraWidgetCallback*)value = widget->callback;
 		return (GP_OK);
 	case GP_WIDGET_MENU:
 	case GP_WIDGET_RADIO:
-        case GP_WIDGET_TEXT:
-        	*((char**)value) = widget->value_string;
-        	return (GP_OK);
-        case GP_WIDGET_RANGE:
-        	*((float*)value) = widget->value_float;
-        	return (GP_OK);
-        case GP_WIDGET_TOGGLE:
+	case GP_WIDGET_TEXT:
+		*((char**)value) = widget->value_string;
+		return (GP_OK);
+	case GP_WIDGET_RANGE:
+		*((float*)value) = widget->value_float;
+		return (GP_OK);
+	case GP_WIDGET_TOGGLE:
 	case GP_WIDGET_DATE:
-            	*((int*)value) = widget->value_int;
-        	return (GP_OK);
+		*((int*)value) = widget->value_int;
+		return (GP_OK);
 	case GP_WIDGET_SECTION:
 	case GP_WIDGET_WINDOW:
-        default:
+	default:
 		return (GP_ERROR_BAD_PARAMETERS);
-        }
+	}
 }
 
 /**
@@ -473,8 +473,8 @@ gp_widget_append (CameraWidget *widget, CameraWidget *child)
 	C_PARAMS (widget && child);
 
 	/* Return if they can't have any children */
-        C_PARAMS ((widget->type == GP_WIDGET_WINDOW) ||
-                  (widget->type == GP_WIDGET_SECTION));
+	C_PARAMS ((widget->type == GP_WIDGET_WINDOW) ||
+		  (widget->type == GP_WIDGET_SECTION));
 
 	C_MEM (widget->children = realloc(widget->children, sizeof(CameraWidget*)*(widget->children_count+1)));
 	widget->children[widget->children_count] = child;
@@ -825,5 +825,5 @@ gp_widget_changed (CameraWidget *widget)
 {
 	C_PARAMS (widget);
 
-        return widget->changed;
+	return widget->changed;
 }

--- a/libgphoto2/jpeg.c
+++ b/libgphoto2/jpeg.c
@@ -31,11 +31,11 @@
 
 /* call example:nullpictureabort(picture,"Picture",0); */
 #define nullpointerabort(pointer,name,val) \
-    if (pointer==NULL) { printf(name " does not exist\n"); return val; }
+	if (pointer==NULL) { printf(name " does not exist\n"); return val; }
 
 /* call example:nullpictureabortvoid(picture,"Picture"); */
 #define nullpointerabortvoid(pointer,name) \
-    if (pointer==NULL) { printf(name " does not exist\n"); return; }
+	if (pointer==NULL) { printf(name " does not exist\n"); return; }
 
 #define CHECK_RESULT(result)       {int r = (result); if (r < 0) return (r);}
 
@@ -43,15 +43,15 @@
 #define countof(array) (sizeof(array) / sizeof((array)[0]))
 
 const jpegmarker JPEG_MARKERS[] = {
-    JPEG_START,             JPEG_COMMENT,           JPEG_APPO,
-    JPEG_QUANTIZATION,      JPEG_HUFFMAN,           JPEG_SOFC0,
-    JPEG_SSSEAHAL,          JPEG_EOI
+	JPEG_START,             JPEG_COMMENT,           JPEG_APPO,
+	JPEG_QUANTIZATION,      JPEG_HUFFMAN,           JPEG_SOFC0,
+	JPEG_SSSEAHAL,          JPEG_EOI
 };
 
 const char *JPEG_MARKERNAMES[] = {
-    "Start",                "Comment",              "APPO",
-    "Quantization table",   "Huffman table",        "SOFC0",
-    "SsSeAhAl",             "End of image"
+	"Start",                "Comment",              "APPO",
+	"Quantization table",   "Huffman table",        "SOFC0",
+	"SsSeAhAl",             "End of image"
 };
 
 chunk *gpi_jpeg_chunk_new(int length)
@@ -64,301 +64,297 @@ chunk *gpi_jpeg_chunk_new(int length)
 		return NULL;
 	}
 	mychunk->size=length;
-/*    printf("New chunk of size %i\n", mychunk->size); */
+/*	printf("New chunk of size %i\n", mychunk->size); */
 	mychunk->data = malloc(length);
 	return mychunk;
 }
 
 chunk *gpi_jpeg_chunk_new_filled(int length, char *data)
 {
-    chunk *mychunk;
-    printf("Entered gpi_jpeg_chunk_new_filled\n");
-    mychunk = gpi_jpeg_chunk_new(length);
-    if (!mychunk)
-	return NULL;
-    printf("Filling the chunk data via chunk_new_filled\n");
-    memcpy(mychunk->data, data, length);
-    return mychunk;
+	chunk *mychunk;
+	printf("Entered gpi_jpeg_chunk_new_filled\n");
+	mychunk = gpi_jpeg_chunk_new(length);
+	if (!mychunk)
+		return NULL;
+	printf("Filling the chunk data via chunk_new_filled\n");
+	memcpy(mychunk->data, data, length);
+	return mychunk;
 }
 
 void gpi_jpeg_chunk_destroy(chunk *mychunk)
 {
-    nullpointerabortvoid(mychunk, "Chunk");
-    mychunk->size=0;
-    free(mychunk->data);
-    free(mychunk);
+	nullpointerabortvoid(mychunk, "Chunk");
+	mychunk->size=0;
+	free(mychunk->data);
+	free(mychunk);
 }
 
 
 void gpi_jpeg_chunk_print(chunk *mychunk)
 {
-    int x;
-/*    printf("Size=%i\n", mychunk->size); */
-    nullpointerabortvoid(mychunk, "Chunk");
-    for (x=0; x<mychunk->size; x++)
-        printf("%hhX ", mychunk->data[x]);
-    printf("\n");
+	int x;
+/*	printf("Size=%i\n", mychunk->size); */
+	nullpointerabortvoid(mychunk, "Chunk");
+	for (x=0; x<mychunk->size; x++)
+		printf("%hhX ", mychunk->data[x]);
+	printf("\n");
 }
 
 char gpi_jpeg_findff(int *location, chunk *picture)
 {
-/* printf("Entered jpeg_findamarker!!!!!!\n"); */
-    nullpointerabort(picture, "Picture",0);
-    while(*location<picture->size)
-    {
-/*        printf("%hX ",picture->data[*location]); */
-        if (picture->data[*location]==0xff)
-        {
-/*        printf("return success!\n"); */
-        return 1;
-        }
-    (*location)++;
-    }
-/*    printf("return failure!\n"); */
-    return 0;
+/*	printf("Entered jpeg_findamarker!!!!!!\n"); */
+	nullpointerabort(picture, "Picture",0);
+	while(*location<picture->size)
+	{
+/*		printf("%hX ",picture->data[*location]); */
+		if (picture->data[*location]==0xff)
+		{
+/*		printf("return success!\n"); */
+			return 1;
+			}
+	(*location)++;
+	}
+/*	printf("return failure!\n"); */
+	return 0;
 }
 
 char gpi_jpeg_findactivemarker(char *id, int *location, chunk *picture)
 {
-/*    printf("Entered gpi_jpeg_findactivemarker!!!!!!!!\n"); */
-    nullpointerabort(picture, "Picture",0);
-    while(gpi_jpeg_findff(location, picture) && ((*location+1)<picture->size))
-        if (picture->data[*location+1]) {
-            *id=picture->data[*location+1];
-            return 1;
-        }
-    return 0;
+/*	printf("Entered gpi_jpeg_findactivemarker!!!!!!!!\n"); */
+	nullpointerabort(picture, "Picture",0);
+	while(gpi_jpeg_findff(location, picture) && ((*location+1)<picture->size))
+		if (picture->data[*location+1]) {
+			*id=picture->data[*location+1];
+			return 1;
+		}
+	return 0;
 }
 
 char *gpi_jpeg_markername(unsigned int c)
 {
-    unsigned int x;
-/*    printf("searching for marker %X in list\n",c); */
-/*    printf("%i\n", sizeof(markers)); */
-    for (x=0; x<countof(JPEG_MARKERS); x++)
-    {
-/*        printf("checking to see if it is marker %X\n", markers[x]); */
+	unsigned int x;
+/*	printf("searching for marker %X in list\n",c); */
+/*	printf("%i\n", sizeof(markers)); */
+	for (x=0; x<countof(JPEG_MARKERS); x++)
+	{
+/*		printf("checking to see if it is marker %X\n", markers[x]); */
 
-        if (c==JPEG_MARKERS[x])
-            return (char *)JPEG_MARKERNAMES[x];
-    }
-    return "Undefined marker";
+		if (c==JPEG_MARKERS[x])
+			return (char *)JPEG_MARKERNAMES[x];
+	}
+	return "Undefined marker";
 }
 
 jpeg *gpi_jpeg_new()
 {
-    jpeg *temp;
-    temp=malloc(sizeof(jpeg));
-    temp->count=0;
-    return temp;
+	jpeg *temp;
+	temp=malloc(sizeof(jpeg));
+	temp->count=0;
+	return temp;
 }
 
 void gpi_jpeg_destroy(jpeg *myjpeg)
 {
-    int count;
-    for (count=0; count<myjpeg->count; count++)
-        gpi_jpeg_chunk_destroy(myjpeg->marker[count]);
-    myjpeg->count=0;
-    free(myjpeg);
+	int count;
+	for (count=0; count<myjpeg->count; count++)
+		gpi_jpeg_chunk_destroy(myjpeg->marker[count]);
+	myjpeg->count=0;
+	free(myjpeg);
 }
 
 void gpi_jpeg_add_marker(jpeg *myjpeg, chunk *picture, int start, int end)
 {
-    int length;
-    nullpointerabortvoid(picture, "Picture");
-    length=(int)(end-start+1);
-/*  printf("Add marker #%i starting from %i and ending at %i for a length of %i\n", myjpeg->count, start, end, length); */
-    myjpeg->marker[myjpeg->count] = gpi_jpeg_chunk_new(length);
-    if (!myjpeg->marker[myjpeg->count])
+	int length;
+	nullpointerabortvoid(picture, "Picture");
+	length=(int)(end-start+1);
+/*	printf("Add marker #%i starting from %i and ending at %i for a length of %i\n", myjpeg->count, start, end, length); */
+	myjpeg->marker[myjpeg->count] = gpi_jpeg_chunk_new(length);
+	if (!myjpeg->marker[myjpeg->count])
 	return;
-/*  printf("Read length is: %i\n", myjpeg->marker[myjpeg->count].size); */
-    memcpy(myjpeg->marker[myjpeg->count]->data, picture->data+start, length);
-    gpi_jpeg_chunk_print(myjpeg->marker[myjpeg->count]);
-    myjpeg->count++;
+/*	printf("Read length is: %i\n", myjpeg->marker[myjpeg->count].size); */
+	memcpy(myjpeg->marker[myjpeg->count]->data, picture->data+start, length);
+	gpi_jpeg_chunk_print(myjpeg->marker[myjpeg->count]);
+	myjpeg->count++;
 }
 
 void gpi_jpeg_add_chunk(jpeg *myjpeg, chunk *source)
 { /* Warning! This points to the added chunk instead of deleting it! */
-    printf("Entered gpi_jpeg_add_chunk\n");
-    nullpointerabortvoid(source, "Chunk to add");
-    myjpeg->marker[myjpeg->count]=source;
-    myjpeg->count++;
+	printf("Entered gpi_jpeg_add_chunk\n");
+	nullpointerabortvoid(source, "Chunk to add");
+	myjpeg->marker[myjpeg->count]=source;
+	myjpeg->count++;
 }
 
 void gpi_jpeg_parse(jpeg *myjpeg, chunk *picture)
 {
-    int position=0;
-    int lastposition;
-    char id;
-    nullpointerabortvoid(picture,"Picture");
-    if (picture->data[0]!=0xff)
-        {
-            gpi_jpeg_findactivemarker(&id, &position, picture);
-            gpi_jpeg_add_marker(myjpeg,picture,0,position-1);
-            lastposition=position;
-            position++;
-        }
-        else
-        {
-        lastposition=position;
-        position+=2;
-        gpi_jpeg_findactivemarker(&id, &position, picture);
-        gpi_jpeg_add_marker(myjpeg,picture,0,position-1);
-        lastposition=position;
-        position+=2;
-        }
-    while (position<picture->size)
-        {
-            gpi_jpeg_findactivemarker(&id, &position, picture);
-            gpi_jpeg_add_marker(myjpeg,picture,lastposition,position-1);
-            lastposition=position;
-            position+=2;
-        }
-    position-=2;
-    if (position<picture->size)
-    gpi_jpeg_add_marker(myjpeg,picture,lastposition,picture->size-1);
+	int position=0;
+	int lastposition;
+	char id;
+	nullpointerabortvoid(picture,"Picture");
+	if (picture->data[0]!=0xff) {
+		gpi_jpeg_findactivemarker(&id, &position, picture);
+		gpi_jpeg_add_marker(myjpeg,picture,0,position-1);
+		lastposition=position;
+		position++;
+	} else {
+		lastposition=position;
+		position+=2;
+		gpi_jpeg_findactivemarker(&id, &position, picture);
+		gpi_jpeg_add_marker(myjpeg,picture,0,position-1);
+		lastposition=position;
+		position+=2;
+	}
+	while (position<picture->size) {
+		gpi_jpeg_findactivemarker(&id, &position, picture);
+		gpi_jpeg_add_marker(myjpeg,picture,lastposition,position-1);
+		lastposition=position;
+		position+=2;
+	}
+	position-=2;
+	if (position<picture->size)
+	gpi_jpeg_add_marker(myjpeg,picture,lastposition,picture->size-1);
 }
 
 void gpi_jpeg_print(jpeg *myjpeg)
 {
-    int c;
-    printf("There are %i markers\n", myjpeg->count);
-    for (c=0; c < myjpeg->count; c++)
-    {
-        printf("%s:\n",gpi_jpeg_markername(myjpeg->marker[c]->data[1]));
-        gpi_jpeg_chunk_print(myjpeg->marker[c]);
-    }
+	int c;
+	printf("There are %i markers\n", myjpeg->count);
+	for (c=0; c < myjpeg->count; c++)
+	{
+		printf("%s:\n",gpi_jpeg_markername(myjpeg->marker[c]->data[1]));
+		gpi_jpeg_chunk_print(myjpeg->marker[c]);
+	}
 }
 
 chunk *gpi_jpeg_make_start() /* also makes the JFIF marker */
 {
-    chunk *temp;
-    /* Start marker and
-       JFIF APPO Marker:Version 1.01, density 1x2 (the 00 01 00 02) */
-    temp = gpi_jpeg_chunk_new_filled(20,  "\xFF\xD8"
-        "\xFF\xE0\x00\x10\x4A\x46\x49\x46" "\x00\x01\x01\x00\x00\x01\x00\x02" "\x00\x00");
-    return temp;
+	chunk *temp;
+	/* Start marker and
+	JFIF APPO Marker:Version 1.01, density 1x2 (the 00 01 00 02) */
+	temp = gpi_jpeg_chunk_new_filled(20,  "\xFF\xD8"
+		"\xFF\xE0\x00\x10\x4A\x46\x49\x46" "\x00\x01\x01\x00\x00\x01\x00\x02" "\x00\x00");
+	return temp;
 }
 
 chunk *gpi_jpeg_make_SOFC (int width, int height, char vh1, char vh2, char vh3, char q1, char q2, char q3)
 {
-    chunk *target;
+	chunk *target;
 
-    char sofc_data[]={
-        0xFF, 0xC0, 0x00, 0x11,  0x08, 0x00, 0x80, 0x01,
-        0x40, 0x03, 0x01, 0x11,  0x00, 0x02, 0x21, 0x01,  0x03, 0x11, 0x00
-        };
-    target = gpi_jpeg_chunk_new(sizeof(sofc_data));
-    if (target==NULL) { printf("New SOFC failed allocation\n"); return target; }
-    memcpy(target->data, sofc_data, sizeof(sofc_data));
-    target->data[5] = (height&0xff00) >> 8;
-    target->data[6] = height&0xff;
-    target->data[7] = (width&0xff00) >> 8;
-    target->data[8] = width&0xff;
-    target->data[11]= vh1;
-    target->data[12]= q1;
-    target->data[14]= vh2;
-    target->data[15]= q2;
-    target->data[17]= vh3;
-    target->data[18]= q3;
-    return target;
+	char sofc_data[]={
+		0xFF, 0xC0, 0x00, 0x11,  0x08, 0x00, 0x80, 0x01,
+		0x40, 0x03, 0x01, 0x11,  0x00, 0x02, 0x21, 0x01,  0x03, 0x11, 0x00
+		};
+	target = gpi_jpeg_chunk_new(sizeof(sofc_data));
+	if (target==NULL) { printf("New SOFC failed allocation\n"); return target; }
+	memcpy(target->data, sofc_data, sizeof(sofc_data));
+	target->data[5] = (height&0xff00) >> 8;
+	target->data[6] = height&0xff;
+	target->data[7] = (width&0xff00) >> 8;
+	target->data[8] = width&0xff;
+	target->data[11]= vh1;
+	target->data[12]= q1;
+	target->data[14]= vh2;
+	target->data[15]= q2;
+	target->data[17]= vh3;
+	target->data[18]= q3;
+	return target;
 }
 
 chunk *gpi_jpeg_makeSsSeAhAl(int huffset1, int huffset2, int huffset3)
 {
-    chunk *target;
-    printf("About to call gpi_jpeg_chunk_new_filled\n");
-    target= gpi_jpeg_chunk_new_filled(14, "\xFF\xDA\x00\x0C\x03\x01\x00\x02"
-        "\x00\x03\x00\x00\x3F\x00");
-    if (!target) return NULL;
-    target->data[6] = huffset1;
-    target->data[8] = huffset2;
-    target->data[10] = huffset3;
-    return target;
+	chunk *target;
+	printf("About to call gpi_jpeg_chunk_new_filled\n");
+	target= gpi_jpeg_chunk_new_filled(14, "\xFF\xDA\x00\x0C\x03\x01\x00\x02"
+		"\x00\x03\x00\x00\x3F\x00");
+	if (!target) return NULL;
+	target->data[6] = huffset1;
+	target->data[8] = huffset2;
+	target->data[10] = huffset3;
+	return target;
 }
 
 void gpi_jpeg_print_quantization_table(jpeg_quantization_table *table)
 {
-    int x;
-    nullpointerabortvoid(table, "Quantization table");
-    for (x=0; x<64; x++)
-    {
-        if (x && ((x%8)==0))
-        {
-            printf("\n");
-        }
-        printf("%3i ", (*table)[x]);
-    }
-    printf("\n");
+	int x;
+	nullpointerabortvoid(table, "Quantization table");
+	for (x=0; x<64; x++)
+	{
+		if (x && ((x%8)==0))
+		{
+		printf("\n");
+		}
+		printf("%3i ", (*table)[x]);
+	}
+	printf("\n");
 }
 
 
 chunk *gpi_jpeg_make_quantization(const jpeg_quantization_table *table, char number)
 {
-    chunk *temp;
-    char x,y,z,c;
-    temp = gpi_jpeg_chunk_new(5+64);
-    if (!temp) return NULL;
-    memcpy(temp->data, "\xFF\xDB\x00\x43\x01", 5);
-    temp->data[4]=number;
-    for (c=z=0; z<8; z++)
-        if (z%2)
-            for (y=0,x=z; y<=z; x--,y++)
-                {
-                temp->data[5+c] = (*table)[x+y*8];
-                temp->data[5+63-c++] = (*table)[63-x-y*8];
-                }
-        else
-            for (x=0,y=z; x<=z; x++,y--)
-                {
-                temp->data[5+c] = (*table)[x+y*8];
-                temp->data[5+63-c++] = (*table)[63-x-y*8];
-                }
-    return temp;
+	chunk *temp;
+	char x,y,z,c;
+	temp = gpi_jpeg_chunk_new(5+64);
+	if (!temp) return NULL;
+	memcpy(temp->data, "\xFF\xDB\x00\x43\x01", 5);
+	temp->data[4]=number;
+	for (c=z=0; z<8; z++)
+		if (z%2)
+		for (y=0,x=z; y<=z; x--,y++)
+			{
+			temp->data[5+c] = (*table)[x+y*8];
+			temp->data[5+63-c++] = (*table)[63-x-y*8];
+			}
+		else
+		for (x=0,y=z; x<=z; x++,y--)
+			{
+			temp->data[5+c] = (*table)[x+y*8];
+			temp->data[5+63-c++] = (*table)[63-x-y*8];
+			}
+	return temp;
 }
 
 jpeg_quantization_table *gpi_jpeg_quantization2table(chunk *qmarker)
 {
-    char x,y,z,c;
-    jpeg_quantization_table *table;
-    table = (jpeg_quantization_table *)malloc(64);
-    for (c=z=0; z<8; z++)
-        if (z%2)
-            for (y=0,x=z; y<=z; x--,y++)
-                {
-                (*table)[63-x-y*8] = qmarker->data[5+63-c];
-                (*table)[x+y*8] = qmarker->data[5+c++];
-                }
-        else
-            for (x=0,y=z; x<=z; x++,y--)
-                {
-                (*table)[63-x-y*8] = qmarker->data[5+63-c];
-                (*table)[x+y*8] = qmarker->data[5+c++];
-                }
-    return table;
+	char x,y,z,c;
+	jpeg_quantization_table *table;
+	table = (jpeg_quantization_table *)malloc(64);
+	for (c=z=0; z<8; z++)
+		if (z%2)
+		for (y=0,x=z; y<=z; x--,y++)
+			{
+			(*table)[63-x-y*8] = qmarker->data[5+63-c];
+			(*table)[x+y*8] = qmarker->data[5+c++];
+			}
+		else
+		for (x=0,y=z; x<=z; x++,y--)
+			{
+			(*table)[63-x-y*8] = qmarker->data[5+63-c];
+			(*table)[x+y*8] = qmarker->data[5+c++];
+			}
+	return table;
 }
 
 
 jpeg *gpi_jpeg_header(int width, int height,
-    char vh1, char vh2, char vh3,
-    char q1, char q2, char q3,
-    const jpeg_quantization_table *quant1, const jpeg_quantization_table *quant2,
-    char huffset1, char huffset2, char huffset3,
-    chunk *huff1, chunk *huff2, chunk *huff3, chunk *huff4)
+	char vh1, char vh2, char vh3,
+	char q1, char q2, char q3,
+	const jpeg_quantization_table *quant1, const jpeg_quantization_table *quant2,
+	char huffset1, char huffset2, char huffset3,
+	chunk *huff1, chunk *huff2, chunk *huff3, chunk *huff4)
 {
-    jpeg *temp;
-    temp = gpi_jpeg_new();
-    gpi_jpeg_add_chunk(temp, gpi_jpeg_make_start());
-    gpi_jpeg_add_chunk(temp, gpi_jpeg_make_quantization(quant1, 0));
-    gpi_jpeg_add_chunk(temp, gpi_jpeg_make_quantization(quant2, 1));
-    gpi_jpeg_add_chunk(temp, gpi_jpeg_make_SOFC(width,height, vh1,vh2,vh3, q1,q2,q3));
-    gpi_jpeg_add_chunk(temp, huff1);
-    gpi_jpeg_add_chunk(temp, huff2);
-    gpi_jpeg_add_chunk(temp, huff3);
-    gpi_jpeg_add_chunk(temp, huff4);
-    printf("About to make and add the SsSeAhAl marker\n");
-    gpi_jpeg_add_chunk(temp, gpi_jpeg_makeSsSeAhAl(huffset1, huffset2, huffset3));
-    return temp;
+	jpeg *temp;
+	temp = gpi_jpeg_new();
+	gpi_jpeg_add_chunk(temp, gpi_jpeg_make_start());
+	gpi_jpeg_add_chunk(temp, gpi_jpeg_make_quantization(quant1, 0));
+	gpi_jpeg_add_chunk(temp, gpi_jpeg_make_quantization(quant2, 1));
+	gpi_jpeg_add_chunk(temp, gpi_jpeg_make_SOFC(width,height, vh1,vh2,vh3, q1,q2,q3));
+	gpi_jpeg_add_chunk(temp, huff1);
+	gpi_jpeg_add_chunk(temp, huff2);
+	gpi_jpeg_add_chunk(temp, huff3);
+	gpi_jpeg_add_chunk(temp, huff4);
+	printf("About to make and add the SsSeAhAl marker\n");
+	gpi_jpeg_add_chunk(temp, gpi_jpeg_makeSsSeAhAl(huffset1, huffset2, huffset3));
+	return temp;
 }
 
 /*#define TESTING_JPEG_C */
@@ -366,61 +362,61 @@ jpeg *gpi_jpeg_header(int width, int height,
 #ifndef TESTING_JPEG_C
 char gpi_jpeg_write(CameraFile *file, const char *filename, jpeg *myjpeg)
 {
-    int x;
-    CHECK_RESULT (gp_file_set_name (file, filename));
-    CHECK_RESULT (gp_file_set_mime_type(file, GP_MIME_JPEG));
-    for (x=0; x<myjpeg->count; x++)
-        CHECK_RESULT (gp_file_append(file, (char*)myjpeg->marker[x]->data, myjpeg->marker[x]->size));
-    return 1;
+	int x;
+	CHECK_RESULT (gp_file_set_name (file, filename));
+	CHECK_RESULT (gp_file_set_mime_type(file, GP_MIME_JPEG));
+	for (x=0; x<myjpeg->count; x++)
+		CHECK_RESULT (gp_file_append(file, (char*)myjpeg->marker[x]->data, myjpeg->marker[x]->size));
+	return 1;
 }
 #endif
 
 #ifdef TESTING_JPEG_C
 /* TEST CODE SECTION */
 char testdata[] ={
-    0xFF,0xD8, 0xFF,0xE0, 0xff,0xDB, 0xFF,0xC4, 0xFF,0xDA,
-    0xFF,0xC0, 0xff,0xff};
+	0xFF,0xD8, 0xFF,0xE0, 0xff,0xDB, 0xFF,0xC4, 0xFF,0xDA,
+	0xFF,0xC0, 0xff,0xff};
 
 jpeg_quantization_table mytable = {
-      2,  3,  4,  5,  6,  7,  8,  9,
-      3,  4,  5,  6,  7,  8,  9, 10,
-      4,  5,  6,  7,  8,  9, 10, 11,
-      5,  6,  7,  8,  9, 10, 11, 12,
-      6,  7,  8,  9, 10, 11, 12, 13,
-      7,  8,  9, 10, 11, 12, 13, 14,
-      8,  9, 10, 11, 12, 13, 14, 15,
-      9, 10, 11, 12, 13, 14, 15, 16};
+	2,  3,  4,  5,  6,  7,  8,  9,
+	3,  4,  5,  6,  7,  8,  9, 10,
+	4,  5,  6,  7,  8,  9, 10, 11,
+	5,  6,  7,  8,  9, 10, 11, 12,
+	6,  7,  8,  9, 10, 11, 12, 13,
+	7,  8,  9, 10, 11, 12, 13, 14,
+	8,  9, 10, 11, 12, 13, 14, 15,
+	9, 10, 11, 12, 13, 14, 15, 16};
 
 int main()
 {
-chunk *picture;
-jpeg *myjpeg;
-char id;
-int location=0,x;
-printf("Print the test quantization table\n");
-gpi_jpeg_print_quantization_table(&mytable);
-myjpeg = gpi_jpeg_new();
-picture = gpi_jpeg_chunk_new(sizeof(testdata));
-picture->data=testdata;
-picture->size=sizeof(testdata);
-printf("testdata size is %i\n",picture->size);
-gpi_jpeg_chunk_print(picture);
-printf("Call jpeg_parse!!!!!!!!!!!!!!!!!!!!!!!\n");
-gpi_jpeg_parse(myjpeg,picture);
+	chunk *picture;
+	jpeg *myjpeg;
+	char id;
+	int location=0,x;
+	printf("Print the test quantization table\n");
+	gpi_jpeg_print_quantization_table(&mytable);
+	myjpeg = gpi_jpeg_new();
+	picture = gpi_jpeg_chunk_new(sizeof(testdata));
+	picture->data=testdata;
+	picture->size=sizeof(testdata);
+	printf("testdata size is %i\n",picture->size);
+	gpi_jpeg_chunk_print(picture);
+	printf("Call jpeg_parse!!!!!!!!!!!!!!!!!!!!!!!\n");
+	gpi_jpeg_parse(myjpeg,picture);
 
-printf("\nPrint the jpeg table\n");
-gpi_jpeg_print(myjpeg);
-printf("\nCall gpi_jpeg_destroy\n");
-gpi_jpeg_destroy(myjpeg);
-/* You can't call gpi_jpeg_chunk_destroy because testdata is a constant.
- * Since picture->data points to it, it would segfault.
- */
-free(picture);
-printf("gpi_jpeg_chunk_new and gpi_jpeg_chunk_destroy tests\n");
-picture = gpi_jpeg_chunk_new(10);
-for (x=0; x<10; x++) picture->data[x]=x;
-for (x=0; x<10; x++) printf("%hX ",picture->data[x]);
-gpi_jpeg_chunk_destroy(picture);
-printf("\n");
+	printf("\nPrint the jpeg table\n");
+	gpi_jpeg_print(myjpeg);
+	printf("\nCall gpi_jpeg_destroy\n");
+	gpi_jpeg_destroy(myjpeg);
+	/* You can't call gpi_jpeg_chunk_destroy because testdata is a constant.
+	* Since picture->data points to it, it would segfault.
+	*/
+	free(picture);
+	printf("gpi_jpeg_chunk_new and gpi_jpeg_chunk_destroy tests\n");
+	picture = gpi_jpeg_chunk_new(10);
+	for (x=0; x<10; x++) picture->data[x]=x;
+	for (x=0; x<10; x++) printf("%hX ",picture->data[x]);
+	gpi_jpeg_chunk_destroy(picture);
+	printf("\n");
 }
 #endif

--- a/libgphoto2/jpeg.h
+++ b/libgphoto2/jpeg.h
@@ -27,21 +27,21 @@
 #include <gphoto2/gphoto2-file.h>
 
 typedef enum {
-    JPEG_START=0xD8,        JPEG_COMMENT=0xFE,      JPEG_APPO=0xE0,
-    JPEG_QUANTIZATION=0xDB, JPEG_HUFFMAN=0xC4,      JPEG_SOFC0=0xC0,
-    JPEG_SSSEAHAL=0xDA,     JPEG_EOI=0xD9
+	JPEG_START=0xD8,        JPEG_COMMENT=0xFE,      JPEG_APPO=0xE0,
+	JPEG_QUANTIZATION=0xDB, JPEG_HUFFMAN=0xC4,      JPEG_SOFC0=0xC0,
+	JPEG_SSSEAHAL=0xDA,     JPEG_EOI=0xD9
 } jpegmarker;
 
 typedef struct chunk{
-    int size;
-    unsigned char *data;
+	int size;
+	unsigned char *data;
 } chunk;
 
 typedef char jpeg_quantization_table[64];
 
 typedef struct jpeg {
-    int count;
-    struct chunk *marker[20]; /* I think this should be big enough */
+	int count;
+	struct chunk *marker[20]; /* I think this should be big enough */
 }jpeg;
 
 chunk *gpi_jpeg_chunk_new(int length);
@@ -71,11 +71,11 @@ chunk *gpi_jpeg_make_quantization(const jpeg_quantization_table * table, char nu
 jpeg_quantization_table *gpi_jpeg_quantization2table(chunk *qmarker);
 
 jpeg *gpi_jpeg_header(int width, int height,
-    char vh1, char vh2, char vh3,
-    char q1, char q2, char q3,
-    const jpeg_quantization_table *quant1, const jpeg_quantization_table *quant2,
-    char huffset1, char huffset2, char huffset3,
-    chunk *huff1, chunk *huff2, chunk *huff3, chunk *huff4);
+	char vh1, char vh2, char vh3,
+	char q1, char q2, char q3,
+	const jpeg_quantization_table *quant1, const jpeg_quantization_table *quant2,
+	char huffset1, char huffset2, char huffset3,
+	chunk *huff1, chunk *huff2, chunk *huff3, chunk *huff4);
 
 char gpi_jpeg_write(CameraFile *file, const char *name, jpeg *myjpeg);
 

--- a/libgphoto2_port/libgphoto2_port/gphoto2-port-info-list.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port-info-list.c
@@ -224,7 +224,7 @@ gp_port_info_list_append (GPPortInfoList *list, GPPortInfo info)
 	for (generic = i = 0; i < list->count; i++)
 		if (!strlen (list->info[i]->name))
 			generic++;
-        return (list->count - 1 - generic);
+	return (list->count - 1 - generic);
 }
 
 
@@ -238,13 +238,13 @@ foreach_func (const char *filename, lt_ptr data)
 	GPPortType type;
 	unsigned int j, old_size = list->count;
 	int result;
-    char *prefix = getenv(IOLIBDIR_PREFIX_ENV);
+	char *prefix = getenv(IOLIBDIR_PREFIX_ENV);
 
 	GP_LOG_D ("Called for filename '%s'.", filename );
-    if(prefix && !strstr(filename,prefix)) {
-        GP_LOG_D("Skipping filename '%s' not matching %s.",filename,prefix);
-        return (0); 
-    }
+	if(prefix && !strstr(filename,prefix)) {
+		GP_LOG_D("Skipping filename '%s' not matching %s.",filename,prefix);
+		return (0);
+	}
 
 	lh = lt_dlopenext (filename);
 	if (!lh) {
@@ -333,7 +333,7 @@ gp_port_info_list_load (GPPortInfoList *list)
 		GP_LOG_E ("No iolibs found in '%s'", iolibs);
 		return GP_ERROR_LIBRARY;
 	}
-        return (GP_OK);
+	return (GP_OK);
 }
 
 /**

--- a/libgphoto2_port/libgphoto2_port/gphoto2-port-locking.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port-locking.c
@@ -33,10 +33,10 @@ pthread_mutex_t gpi_libltdl_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void gpi_libltdl_lock(void)
 {
-  pthread_mutex_lock(&gpi_libltdl_mutex);
+	pthread_mutex_lock(&gpi_libltdl_mutex);
 }
 
 void gpi_libltdl_unlock(void)
 {
-  pthread_mutex_unlock(&gpi_libltdl_mutex);
+	pthread_mutex_unlock(&gpi_libltdl_mutex);
 }

--- a/libgphoto2_port/libgphoto2_port/gphoto2-port-log.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port-log.c
@@ -72,7 +72,7 @@ gpi_vsnprintf (const char* format, va_list args)
  * Use gp_log_add_func() and gp_log_remove_func() to access it.
  */
 typedef struct {
-	int id;			/**< Internal id */
+	int          id;	/**< Internal id */
 	GPLogLevel   level;	/**< Internal loglevel */
 	GPLogFunc    func;	/**< Internal function pointer to call */
 	void        *data;	/**< Private data supplied by caller */
@@ -177,17 +177,17 @@ gp_log_remove_func (int id)
  * HEXDUMP_BLOCK_DISTANCE and/or HEXDUMP_OFFSET_WIDTH.
  */
 #define HEXDUMP_COMPLETE_LINE {\
-        curline[HEXDUMP_OFFSET_WIDTH - 4] = hexchars[(index >> 12) & 0xf]; \
-        curline[HEXDUMP_OFFSET_WIDTH - 3] = hexchars[(index >>  8) & 0xf]; \
-        curline[HEXDUMP_OFFSET_WIDTH - 2] = hexchars[(index >>  4) & 0xf]; \
-        curline[HEXDUMP_OFFSET_WIDTH - 1] = '0'; \
-        curline[HEXDUMP_OFFSET_WIDTH + 0] = ' '; \
-        curline[HEXDUMP_OFFSET_WIDTH + 1] = ' '; \
-        curline[HEXDUMP_MIDDLE] = '-'; \
-        curline[HEXDUMP_INIT_Y-2] = ' '; \
-        curline[HEXDUMP_INIT_Y-1] = ' '; \
-        curline[HEXDUMP_LINE_WIDTH] = '\n'; \
-        curline = curline + (HEXDUMP_LINE_WIDTH + 1);}
+	curline[HEXDUMP_OFFSET_WIDTH - 4] = hexchars[(index >> 12) & 0xf]; \
+	curline[HEXDUMP_OFFSET_WIDTH - 3] = hexchars[(index >>  8) & 0xf]; \
+	curline[HEXDUMP_OFFSET_WIDTH - 2] = hexchars[(index >>  4) & 0xf]; \
+	curline[HEXDUMP_OFFSET_WIDTH - 1] = '0'; \
+	curline[HEXDUMP_OFFSET_WIDTH + 0] = ' '; \
+	curline[HEXDUMP_OFFSET_WIDTH + 1] = ' '; \
+	curline[HEXDUMP_MIDDLE] = '-'; \
+	curline[HEXDUMP_INIT_Y-2] = ' '; \
+	curline[HEXDUMP_INIT_Y-1] = ' '; \
+	curline[HEXDUMP_LINE_WIDTH] = '\n'; \
+	curline = curline + (HEXDUMP_LINE_WIDTH + 1);}
 
 /**
  * \brief Log data
@@ -244,35 +244,35 @@ gp_log_data (const char *domain, const char *data, unsigned int size, const char
 	}
 
 	for (index = 0; index < size; ++index) {
-                value = (unsigned char)data[index];
-                curline[x] = hexchars[value >> 4];
-                curline[x+1] = hexchars[value & 0xf];
-                curline[x+2] = ' ';
-                curline[y++] = ((value>=32)&&(value<127))?value:'.';
-                x += 3;
-                if ((index & 0xf) == 0xf) { /* end of line */
-                        x = HEXDUMP_INIT_X;
-                        y = HEXDUMP_INIT_Y;
-                        HEXDUMP_COMPLETE_LINE;
-                }
-        }
-        if ((index & 0xf) != 0) { /* not at end of line yet? */
-                /* if so, complete this line */
-                while (y < HEXDUMP_INIT_Y + 16) {
-                        curline[x+0] = ' ';
-                        curline[x+1] = ' ';
-                        curline[x+2] = ' ';
-                        curline[y++] = ' ';
-                        x += 3;
-                }
-                HEXDUMP_COMPLETE_LINE;
-        }
-        curline[0] = '\0';
+		value = (unsigned char)data[index];
+		curline[x] = hexchars[value >> 4];
+		curline[x+1] = hexchars[value & 0xf];
+		curline[x+2] = ' ';
+		curline[y++] = ((value>=32)&&(value<127))?value:'.';
+		x += 3;
+		if ((index & 0xf) == 0xf) { /* end of line */
+			x = HEXDUMP_INIT_X;
+			y = HEXDUMP_INIT_Y;
+			HEXDUMP_COMPLETE_LINE;
+		}
+	}
+	if ((index & 0xf) != 0) { /* not at end of line yet? */
+		/* if so, complete this line */
+		while (y < HEXDUMP_INIT_Y + 16) {
+			curline[x+0] = ' ';
+			curline[x+1] = ' ';
+			curline[x+2] = ' ';
+			curline[y++] = ' ';
+			x += 3;
+		}
+		HEXDUMP_COMPLETE_LINE;
+	}
+	curline[0] = '\0';
 
-        if (size == original_size)
-                gp_log (GP_LOG_DATA, domain, "%s (hexdump of %d bytes)\n%s", msg, size, result);
-        else
-                gp_log (GP_LOG_DATA, domain, "%s (hexdump of the first %d of %d bytes)\n%s", msg, size, original_size, result);
+	if (size == original_size)
+		gp_log (GP_LOG_DATA, domain, "%s (hexdump of %d bytes)\n%s", msg, size, result);
+	else
+		gp_log (GP_LOG_DATA, domain, "%s (hexdump of the first %d of %d bytes)\n%s", msg, size, original_size, result);
 
 exit:
 	free (msg);

--- a/libgphoto2_port/libgphoto2_port/gphoto2-port-portability.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port-portability.c
@@ -38,131 +38,131 @@
 
 void gp_port_win_convert_path (char *path) {
 
-        int x;
+	int x;
 
-        if (strchr(path, '\\'))
-                /* already converted */
-                return;
+	if (strchr(path, '\\'))
+		/* already converted */
+		return;
 
-        if (path[0] != '.') {
-                path[0] = path[1];
-                path[1] = ':';
-                path[2] = '\\';
-        }
+	if (path[0] != '.') {
+		path[0] = path[1];
+		path[1] = ':';
+		path[2] = '\\';
+	}
 
-        for (x=0; x<strlen(path); x++)
-                if (path[x] == '/')
-                        path[x] = '\\';
+	for (x=0; x<strlen(path); x++)
+		if (path[x] == '/')
+			path[x] = '\\';
 }
 
 int gp_system_mkdir (const char *dirname) {
 
-        if (_mkdir(dirname) < 0)
-                return (GP_ERROR);
-        return (GP_OK);
+	if (_mkdir(dirname) < 0)
+		return (GP_ERROR);
+	return (GP_OK);
 }
 
 int gp_system_rmdir (const char *dirname) {
 
-        if (_rmdir(dirname) < 0)
-                return (GP_ERROR);
-        return (GP_OK);
+	if (_rmdir(dirname) < 0)
+		return (GP_ERROR);
+	return (GP_OK);
 }
 
 
 gp_system_dir gp_system_opendir (const char *dirname) {
 
-        GPPORTWINDIR *d;
-        DWORD dr;
-        int x;
-        d = (GPPORTWINDIR*)malloc(sizeof(GPPORTWINDIR));
-        d->handle = INVALID_HANDLE_VALUE;
-        d->got_first = 0;
-        strcpy(d->dir, dirname);
-        d->drive_count = 0;
-        d->drive_index = 0;
+	GPPORTWINDIR *d;
+	DWORD dr;
+	int x;
+	d = (GPPORTWINDIR*)malloc(sizeof(GPPORTWINDIR));
+	d->handle = INVALID_HANDLE_VALUE;
+	d->got_first = 0;
+	strcpy(d->dir, dirname);
+	d->drive_count = 0;
+	d->drive_index = 0;
 
-        dr = GetLogicalDrives();
+	dr = GetLogicalDrives();
 
-        for (x=0; x<32; x++) {
-                if ((dr >> x) & 0x0001) {
-                        sprintf(d->drive[d->drive_count], "%c", 'A' + x);
-                        d->drive_count += 1;
-                }
-        }
+	for (x=0; x<32; x++) {
+		if ((dr >> x) & 0x0001) {
+			sprintf(d->drive[d->drive_count], "%c", 'A' + x);
+			d->drive_count += 1;
+		}
+	}
 
-        return (d);
+	return (d);
 }
 
 gp_system_dirent gp_system_readdir (gp_system_dir d) {
 
-        char dirn[1024];
+	char dirn[1024];
 
-        if (strcmp(d->dir, "/")==0) {
-                if (d->drive_index == d->drive_count)
-                        return (NULL);
-                strcpy(d->search.cFileName, d->drive[d->drive_index]);
-                d->drive_index += 1;
-                return (&(d->search));
-        }
-
-
-        /* Append the wildcard */
-
-        strcpy(dirn, d->dir);
-        gp_port_win_convert_path(dirn);
-
-        if (dirn[strlen(dirn)-1] != '\\')
-                strcat(dirn, "\\");
-        strcat(dirn, "*");
+	if (strcmp(d->dir, "/")==0) {
+		if (d->drive_index == d->drive_count)
+			return (NULL);
+		strcpy(d->search.cFileName, d->drive[d->drive_index]);
+		d->drive_index += 1;
+		return (&(d->search));
+	}
 
 
-        if (d->handle == INVALID_HANDLE_VALUE) {
-                d->handle = FindFirstFile(dirn, &(d->search));
-                if (d->handle == INVALID_HANDLE_VALUE)
-                        return NULL;
-        } else {
-                if (!FindNextFile(d->handle, &(d->search)))
-                        return NULL;
-        }
+	/* Append the wildcard */
 
-        return (&(d->search));
+	strcpy(dirn, d->dir);
+	gp_port_win_convert_path(dirn);
+
+	if (dirn[strlen(dirn)-1] != '\\')
+		strcat(dirn, "\\");
+	strcat(dirn, "*");
+
+
+	if (d->handle == INVALID_HANDLE_VALUE) {
+		d->handle = FindFirstFile(dirn, &(d->search));
+		if (d->handle == INVALID_HANDLE_VALUE)
+			return NULL;
+	} else {
+		if (!FindNextFile(d->handle, &(d->search)))
+			return NULL;
+	}
+
+	return (&(d->search));
 }
 
 const char *gp_system_filename (gp_system_dirent de) {
 
-        return (de->cFileName);
+	return (de->cFileName);
 }
 
 int gp_system_closedir (gp_system_dir d) {
-        FindClose(d->handle);
-        free(d);
-        return (1);
+	FindClose(d->handle);
+	free(d);
+	return (1);
 }
 
 int gp_system_is_file (const char *filename) {
 
-        struct stat st;
+	struct stat st;
 
-        gp_port_win_convert_path(filename);
+	gp_port_win_convert_path(filename);
 
-        if (stat(filename, &st)!=0)
-                return 0;
-        return (st.st_mode & _S_IFREG);
+	if (stat(filename, &st)!=0)
+		return 0;
+	return (st.st_mode & _S_IFREG);
 }
 
 int gp_system_is_dir (const char *dirname) {
 
-        struct stat st;
+	struct stat st;
 
-        if (strlen(dirname) <= 3)
-                return 1;
+	if (strlen(dirname) <= 3)
+		return 1;
 
-        gp_port_win_convert_path(dirname);
+	gp_port_win_convert_path(dirname);
 
-        if (stat(dirname, &st)!=0)
-                return 0;
-        return (st.st_mode & _S_IFDIR);
+	if (stat(dirname, &st)!=0)
+		return 0;
+	return (st.st_mode & _S_IFDIR);
 }
 
 
@@ -177,9 +177,9 @@ int gp_system_is_dir (const char *dirname) {
  * \return a gphoto error code
  */
 int gp_system_mkdir (const char *dirname) {
-        if (mkdir(dirname, 0777)<0)
-                return (GP_ERROR);
-        return (GP_OK);
+	if (mkdir(dirname, 0777)<0)
+		return (GP_ERROR);
+	return (GP_OK);
 }
 
 /**
@@ -208,7 +208,7 @@ int gp_system_rmdir (const char *dirname) {
  * \return a directory handle for use in gp_system_readdir() and gp_system_closedir()
  */
 gp_system_dir gp_system_opendir (const char *dirname) {
-        return (opendir(dirname));
+	return (opendir(dirname));
 }
 
 /**
@@ -222,7 +222,7 @@ gp_system_dir gp_system_opendir (const char *dirname) {
  * \return a new gp_system_dirent or NULL
  */
 gp_system_dirent gp_system_readdir (gp_system_dir d) {
-        return (readdir(d));
+	return (readdir(d));
 }
 
 /**
@@ -234,7 +234,7 @@ gp_system_dirent gp_system_readdir (gp_system_dir d) {
  * \return the filename of the directory entry
  */
 const char *gp_system_filename (gp_system_dirent de) {
-        return (de->d_name);
+	return (de->d_name);
 }
 
 /**
@@ -246,8 +246,8 @@ const char *gp_system_filename (gp_system_dirent de) {
  * \return a gphoto error code
  */
 int gp_system_closedir (gp_system_dir dir) {
-        closedir(dir);
-        return (GP_OK);
+	closedir(dir);
+	return (GP_OK);
 }
 
 /**
@@ -260,11 +260,11 @@ int gp_system_closedir (gp_system_dir dir) {
  * \return boolean flag whether passed filename is a file.
  */
 int gp_system_is_file (const char *filename) {
-        struct stat st;
+	struct stat st;
 
-        if (stat(filename, &st)!=0)
-                return 0;
-        return (!S_ISDIR(st.st_mode));
+	if (stat(filename, &st)!=0)
+		return 0;
+	return (!S_ISDIR(st.st_mode));
 }
 
 /**
@@ -277,10 +277,10 @@ int gp_system_is_file (const char *filename) {
  * \return boolean flag whether passed filename is a directory.
  */
 int gp_system_is_dir (const char *dirname) {
-        struct stat st;
+	struct stat st;
 
-        if (stat(dirname, &st)!=0)
-                return 0;
-        return (S_ISDIR(st.st_mode));
+	if (stat(dirname, &st)!=0)
+		return 0;
+	return (S_ISDIR(st.st_mode));
 }
 #endif

--- a/libgphoto2_port/libgphoto2_port/gphoto2-port.c
+++ b/libgphoto2_port/libgphoto2_port/gphoto2-port.c
@@ -84,7 +84,7 @@ gp_port_new (GPPort **port)
 {
 	C_PARAMS (port);
 
-        GP_LOG_D ("Creating new device...");
+	GP_LOG_D ("Creating new device...");
 
 	C_MEM (*port = calloc (1, sizeof (GPPort)));
 
@@ -94,7 +94,7 @@ gp_port_new (GPPort **port)
 		return (GP_ERROR_NO_MEMORY);
 	}
 
-        return (GP_OK);
+	return (GP_OK);
 }
 
 static int
@@ -301,7 +301,7 @@ gp_port_close (GPPort *port)
 	CHECK_INIT (port);
 
 	CHECK_SUPP (port, "close", port->pc->ops->close);
-        CHECK_RESULT (port->pc->ops->close(port));
+	CHECK_RESULT (port->pc->ops->close(port));
 
 	return (GP_OK);
 }
@@ -323,7 +323,7 @@ gp_port_reset (GPPort *port)
 	CHECK_INIT (port);
 
 	CHECK_SUPP (port, "reset", port->pc->ops->reset);
-        CHECK_RESULT (port->pc->ops->reset(port));
+	CHECK_RESULT (port->pc->ops->reset(port));
 
 	return (GP_OK);
 }
@@ -372,9 +372,9 @@ gp_port_free (GPPort *port)
 		port->pc = NULL;
 	}
 
-        free (port);
+	free (port);
 
-        return GP_OK;
+	return GP_OK;
 }
 
 /**
@@ -394,9 +394,9 @@ gp_port_write (GPPort *port, const char *data, int size)
 {
 	int retval;
 
-        gp_log (GP_LOG_DATA, __func__, "Writing %i = 0x%x bytes to port...", size, size);
+	gp_log (GP_LOG_DATA, __func__, "Writing %i = 0x%x bytes to port...", size, size);
 
- 	C_PARAMS (port && data);
+	C_PARAMS (port && data);
 	CHECK_INIT (port);
 
 	/* Check if we wrote all bytes */
@@ -427,7 +427,7 @@ gp_port_write (GPPort *port, const char *data, int size)
 int
 gp_port_read (GPPort *port, char *data, int size)
 {
-        int retval;
+	int retval;
 
 	gp_log (GP_LOG_DATA, __func__, "Reading %i = 0x%x bytes from port...", size, size);
 
@@ -463,7 +463,7 @@ gp_port_read (GPPort *port, char *data, int size)
 int
 gp_port_check_int (GPPort *port, char *data, int size)
 {
-        int retval;
+	int retval;
 
 	gp_log (GP_LOG_DATA, __func__, "Reading %i = 0x%x bytes from interrupt endpoint...", size, size);
 
@@ -496,9 +496,9 @@ gp_port_check_int (GPPort *port, char *data, int size)
 int
 gp_port_check_int_fast (GPPort *port, char *data, int size)
 {
-        int retval;
+	int retval;
 
-        gp_log (GP_LOG_DATA, __func__, "Reading %i = 0x%x bytes from interrupt endpoint...", size, size);
+	gp_log (GP_LOG_DATA, __func__, "Reading %i = 0x%x bytes from interrupt endpoint...", size, size);
 
 	C_PARAMS (port);
 	CHECK_INIT (port);
@@ -536,10 +536,10 @@ gp_port_set_timeout (GPPort *port, int timeout)
 {
 	C_PARAMS (port);
 
-        GP_LOG_D ("Setting port timeout to %i milliseconds.", timeout);
-        port->timeout = timeout;
+	GP_LOG_D ("Setting port timeout to %i milliseconds.", timeout);
+	port->timeout = timeout;
 
-        return GP_OK;
+	return GP_OK;
 }
 
 /** Deprecated */
@@ -571,9 +571,9 @@ gp_port_get_timeout (GPPort *port, int *timeout)
 	C_PARAMS (port);
 
 	GP_LOG_D ("Current port timeout is %i milliseconds.", port->timeout);
-        *timeout = port->timeout;
+	*timeout = port->timeout;
 
-        return GP_OK;
+	return GP_OK;
 }
 
 /**
@@ -595,16 +595,16 @@ gp_port_set_settings (GPPort *port, GPPortSettings settings)
 	C_PARAMS (port);
 	CHECK_INIT (port);
 
-        /*
+	/*
 	 * We copy the settings to settings_pending and call update on the
 	 * port.
 	 */
-        memcpy (&port->settings_pending, &settings,
+	memcpy (&port->settings_pending, &settings,
 		sizeof (port->settings_pending));
 	CHECK_SUPP (port, "update", port->pc->ops->update);
-        CHECK_RESULT (port->pc->ops->update (port));
+	CHECK_RESULT (port->pc->ops->update (port));
 
-        return (GP_OK);
+	return (GP_OK);
 }
 
 /** Deprecated */
@@ -634,9 +634,9 @@ gp_port_get_settings (GPPort *port, GPPortSettings *settings)
 {
 	C_PARAMS (port);
 
-        memcpy (settings, &(port->settings), sizeof (gp_port_settings));
+	memcpy (settings, &(port->settings), sizeof (gp_port_settings));
 
-        return GP_OK;
+	return GP_OK;
 }
 
 /**
@@ -657,7 +657,7 @@ gp_port_get_pin (GPPort *port, GPPin pin, GPLevel *level)
 	CHECK_INIT (port);
 
 	CHECK_SUPP (port, "get_pin", port->pc->ops->get_pin);
-        CHECK_RESULT (port->pc->ops->get_pin (port, pin, level));
+	CHECK_RESULT (port->pc->ops->get_pin (port, pin, level));
 
 	GP_LOG_D ("Level of pin %i: %i", pin, *level);
 
@@ -742,8 +742,8 @@ gp_port_send_break (GPPort *port, int duration)
 	C_PARAMS (port);
 	CHECK_INIT (port);
 
-        CHECK_SUPP (port, "send_break", port->pc->ops->send_break);
-        CHECK_RESULT (port->pc->ops->send_break (port, duration));
+	CHECK_SUPP (port, "send_break", port->pc->ops->send_break);
+	CHECK_RESULT (port->pc->ops->send_break (port, duration));
 
 	return (GP_OK);
 }
@@ -769,7 +769,7 @@ gp_port_flush (GPPort *port, int direction)
 	CHECK_SUPP (port, "flush", port->pc->ops->flush);
 	CHECK_RESULT (port->pc->ops->flush (port, direction));
 
-        return (GP_OK);
+	return (GP_OK);
 }
 
 
@@ -796,7 +796,7 @@ gp_port_usb_find_device (GPPort *port, int idvendor, int idproduct)
 	CHECK_SUPP (port, "find_device", port->pc->ops->find_device);
 	CHECK_RESULT (port->pc->ops->find_device (port, idvendor, idproduct));
 
-        return (GP_OK);
+	return (GP_OK);
 }
 
 /**
@@ -820,7 +820,7 @@ gp_port_usb_find_device_by_class (GPPort *port, int mainclass, int subclass, int
 	CHECK_SUPP (port, "find_device_by_class", port->pc->ops->find_device_by_class);
 	CHECK_RESULT (port->pc->ops->find_device_by_class (port, mainclass, subclass, protocol));
 
-        return (GP_OK);
+	return (GP_OK);
 }
 
 /**
@@ -842,9 +842,9 @@ gp_port_usb_clear_halt (GPPort *port, int ep)
 	CHECK_INIT (port);
 
 	CHECK_SUPP (port, "clear_halt", port->pc->ops->clear_halt);
-        CHECK_RESULT (port->pc->ops->clear_halt (port, ep));
+	CHECK_RESULT (port->pc->ops->clear_halt (port, ep));
 
-        return (GP_OK);
+	return (GP_OK);
 }
 
 /**
@@ -865,7 +865,7 @@ int
 gp_port_usb_msg_write (GPPort *port, int request, int value, int index,
 	char *bytes, int size)
 {
-        int retval;
+	int retval;
 
 	GP_LOG_DATA (bytes, size, "Writing message (request=0x%x value=0x%x index=0x%x size=%i=0x%x):",
 		     request, value, index, size, size);
@@ -874,10 +874,10 @@ gp_port_usb_msg_write (GPPort *port, int request, int value, int index,
 	CHECK_INIT (port);
 
 	CHECK_SUPP (port, "msg_write", port->pc->ops->msg_write);
-        retval = port->pc->ops->msg_write(port, request, value, index, bytes, size);
+	retval = port->pc->ops->msg_write(port, request, value, index, bytes, size);
 	CHECK_RESULT (retval);
 
-        return (retval);
+	return (retval);
 }
 
 /**
@@ -898,7 +898,7 @@ int
 gp_port_usb_msg_read (GPPort *port, int request, int value, int index,
 	char *bytes, int size)
 {
-        int retval;
+	int retval;
 
 	gp_log (GP_LOG_DATA, __func__, "Reading message (request=0x%x value=0x%x index=0x%x size=%i=0x%x)...",
 		request, value, index, size, size);
@@ -907,13 +907,13 @@ gp_port_usb_msg_read (GPPort *port, int request, int value, int index,
 	CHECK_INIT (port);
 
 	CHECK_SUPP (port, "msg_read", port->pc->ops->msg_read);
-        retval = port->pc->ops->msg_read (port, request, value, index, bytes, size);
+	retval = port->pc->ops->msg_read (port, request, value, index, bytes, size);
 	CHECK_RESULT (retval);
 
 	LOG_DATA (bytes, retval, size, "Read", "USB message (request=0x%x value=0x%x index=0x%x size=%i=0x%x)",
 		  request, value, index, size, size);
 
-        return (retval);
+	return (retval);
 }
 
 /*
@@ -938,7 +938,7 @@ int
 gp_port_usb_msg_interface_write (GPPort *port, int request,
 	int value, int index, char *bytes, int size)
 {
-        int retval;
+	int retval;
 
 	GP_LOG_DATA (bytes, size, "Writing message (request=0x%x value=0x%x index=0x%x size=%i=0x%x)...",
 		     request, value, index, size, size);
@@ -947,11 +947,11 @@ gp_port_usb_msg_interface_write (GPPort *port, int request,
 	CHECK_INIT (port);
 
 	CHECK_SUPP (port, "msg_build", port->pc->ops->msg_interface_write);
-        retval = port->pc->ops->msg_interface_write(port, request,
-        		value, index, bytes, size);
+	retval = port->pc->ops->msg_interface_write(port, request,
+			value, index, bytes, size);
 	CHECK_RESULT (retval);
 
-        return (retval);
+	return (retval);
 }
 
 
@@ -973,7 +973,7 @@ int
 gp_port_usb_msg_interface_read (GPPort *port, int request, int value, int index,
 	char *bytes, int size)
 {
-        int retval;
+	int retval;
 
 	gp_log (GP_LOG_DATA, __func__, "Reading message (request=0x%x value=0x%x index=0x%x size=%i=0x%x)...",
 		request, value, index, size, size);
@@ -982,14 +982,14 @@ gp_port_usb_msg_interface_read (GPPort *port, int request, int value, int index,
 	CHECK_INIT (port);
 
 	CHECK_SUPP (port, "msg_read", port->pc->ops->msg_interface_read);
-        retval = port->pc->ops->msg_interface_read (port, request,
-        		value, index, bytes, size);
+	retval = port->pc->ops->msg_interface_read (port, request,
+			value, index, bytes, size);
 	CHECK_RESULT (retval);
 
 	LOG_DATA (bytes, retval, size, "Read", "USB message (request=0x%x value=0x%x index=0x%x size=%i=0x%x)",
 		  request, value, index, size, size);
 
-        return (retval);
+	return (retval);
 }
 
 
@@ -1016,7 +1016,7 @@ int
 gp_port_usb_msg_class_write (GPPort *port, int request,
 	int value, int index, char *bytes, int size)
 {
-        int retval;
+	int retval;
 
 	GP_LOG_DATA (bytes, size, "Writing message (request=0x%x value=0x%x index=0x%x size=%i=0x%x):",
 		     request, value, index, size, size);
@@ -1025,11 +1025,11 @@ gp_port_usb_msg_class_write (GPPort *port, int request,
 	CHECK_INIT (port);
 
 	CHECK_SUPP (port, "msg_build", port->pc->ops->msg_class_write);
-        retval = port->pc->ops->msg_class_write(port, request,
-        		value, index, bytes, size);
+	retval = port->pc->ops->msg_class_write(port, request,
+			value, index, bytes, size);
 	CHECK_RESULT (retval);
 
-        return (retval);
+	return (retval);
 }
 
 
@@ -1051,7 +1051,7 @@ int
 gp_port_usb_msg_class_read (GPPort *port, int request, int value, int index,
 	char *bytes, int size)
 {
-        int retval;
+	int retval;
 
 	gp_log (GP_LOG_DATA, __func__, "Reading message (request=0x%x value=0x%x index=0x%x size=%i=0x%x)...",
 		request, value, index, size, size);
@@ -1060,14 +1060,14 @@ gp_port_usb_msg_class_read (GPPort *port, int request, int value, int index,
 	CHECK_INIT (port);
 
 	CHECK_SUPP (port, "msg_read", port->pc->ops->msg_class_read);
-        retval = port->pc->ops->msg_class_read (port, request,
-        		value, index, bytes, size);
+	retval = port->pc->ops->msg_class_read (port, request,
+			value, index, bytes, size);
 	CHECK_RESULT (retval);
 
 	LOG_DATA (bytes, retval, size, "Read", "USB message (request=0x%x value=0x%x index=0x%x size=%i=0x%x)",
 		  request, value, index, size, size);
 
-        return (retval);
+	return (retval);
 }
 
 /**


### PR DESCRIPTION
 * examples
 * gphoto2
 * libgphoto2
 * libgphoto2_port

The code (at least in this part of the project) is effectively formated using tabs with a tab-size of 8 as a means for indentation.

There have been a few places where spaces were introduced. Some obviously with an indent size of 8 in mind, others with an indent size of 4.

This commit tries its best to make the use of tabs consistent again, at least for indenting lines. The "intra line" indentation (white space after the first non-white-space character) is still a bit of a mess.