### PR TITLE
minimal .editorconfig file to prevent reintroduction of spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.{c,h,sh,am}]
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = tab


### PR DESCRIPTION
The main goal here is convince editors to use tabs for indentation. Details can be found on https://editorconfig.org/.