### PR TITLE
fix memory leaks related to PTPCanon_changes_entry.u.info

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -6120,7 +6120,7 @@ camera_trigger_canon_eos_capture (Camera *camera, GPContext *context)
 				ptp_check_eos_events (params);
 				while (ptp_get_one_eos_event (params, &entry)) {
 					GP_LOG_D ("entry type %04x", entry.type);
-					if (entry.type == PTP_CANON_EOS_CHANGES_TYPE_UNKNOWN && sscanf (entry.u.info, "Button %d", &button)) {
+					if (entry.type == PTP_CANON_EOS_CHANGES_TYPE_UNKNOWN && sscanf (entry.u.info, "Button %d", &button) == 1) {
 						GP_LOG_D ("Button %d", button);
 						switch (button) {
 							/* Indicates a successful Half-Press(?) on M2, where it

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1833,7 +1833,7 @@ struct _PTPCanon_changes_entry {
 	enum _PTPCanon_changes_types	type;
 	union {
 		struct _PTPCanon_New_Object	object;	/* TYPE_OBJECTINFO */
-		char				*info;
+		char				info[84]; /* 84 is minimum sizeof(object) and sufficient for current use cases */
 		uint16_t			propid;
 		int				status;
 	} u;


### PR DESCRIPTION
Unpacking canon EOS event data uses heap memory stored in `char *info` for different types of information (mostly PTP_CANON_EOS_CHANGES_TYPE_UNKNOWN but also PTP_CANON_EOS_CHANGES_TYPE_FOCUS*). This memory needs to be freed on every call-sight of ptp_get_one_eos_event, which it wasn't and it needs to do so for every type using it, but if at all, it only freed it for PTP_CANON_EOS_CHANGES_TYPE_UNKNOWN data.

This patch replaces `char *info` with `char info[84]` and introduces a macro called PTP_CANON_SET_INFO() for setting that data. 84 is used, because the union is at least that large anyway because of the `object` member and 84 is sufficient for all current use cases. The macro makes sure there is no buffer overflow in the future.

This change does away with the error prone task of freeing the `info` memory after every ptp_get_one_eos_event() call.