### PR TITLE
introduce helper function aprintf(fmt, ...)

### DIFF
--- a/camlibs/canon/usb.c
+++ b/camlibs/canon/usb.c
@@ -955,8 +955,7 @@ canon_usb_wait_for_event (Camera *camera, int timeout,
 		if (path->folder[0] != '/') {
 			free (path);
 			*eventtype = GP_EVENT_UNKNOWN;
-			*eventdata = malloc(strlen("Failed to get added filename?")+1);
-			strcpy (*eventdata, "Failed to get added filename?");
+			*eventdata = aprintf("Failed to get added filename?");
 		}
 		free ( camera->pl->directory_state );
 		camera->pl->directory_state = final_state;
@@ -965,8 +964,7 @@ canon_usb_wait_for_event (Camera *camera, int timeout,
 	}
 	default:
 		*eventtype = GP_EVENT_UNKNOWN;
-		*eventdata = malloc(strlen("Unknown CANON event 0x01 0x02 0x03 0x04 0x05")+1);
-		sprintf (*eventdata,"Unknown CANON event 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x",buf2[0],buf2[1],buf2[2],buf2[3],buf2[4]);
+		*eventdata = aprintf("Unknown CANON event 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x",buf2[0],buf2[1],buf2[2],buf2[3],buf2[4]);
 		return GP_OK;
 	}
 	return GP_OK;

--- a/camlibs/kodak/dc3200/library.c
+++ b/camlibs/kodak/dc3200/library.c
@@ -225,22 +225,13 @@ int dc3200_get_data(Camera *camera, unsigned char **data, unsigned long *data_le
 
 	if(folder) {
 		if(filename) {
-			file = malloc(strlen(folder) + strlen(filename) + 2);
-			if(!file)
-				return GP_ERROR;
-
 			/* concatenate the folder + filename */
-			strcpy(file, folder);
-			/* append the filename */
-			if(folder[strlen(folder)-1] != '\\')
-				strcat(file, "\\");
-			strcat(file, filename);
-
+			file = aprintf("%s%s%s", folder, folder[strlen(folder)-1] != '\\' ? "\\" : "", filename);
 		} else {
 			file = strdup(folder);
-			if(!file)
-				return GP_ERROR;
 		}
+		if(!file)
+			return GP_ERROR;
 	} else {
 		return GP_ERROR;
 	}

--- a/camlibs/ptp2/chdk.c
+++ b/camlibs/ptp2/chdk.c
@@ -182,9 +182,7 @@ chdk_list_func (CameraFilesystem *fs, const char *folder, CameraList *list,
 	if (strlen(folder)>2 && (xfolder[strlen(xfolder)-1] == '/'))
 		xfolder[strlen(xfolder)-1] = '\0';
 
-	C_MEM (lua = malloc(strlen(luascript)+strlen(xfolder)+1));
-
-	sprintf(lua,luascript,xfolder);
+	lua = aprintf(luascript, xfolder);
 	free(xfolder);
 
 	ret = chdk_generic_script_run (params, lua, &table, &retint, context);
@@ -327,8 +325,7 @@ chdk_get_info_func (CameraFilesystem *fs, const char *folder, const char *filena
 	const char 		*luascript = "\nreturn os.stat('A%s/%s')";
 	char 			*lua = NULL;
 
-	C_MEM (lua = malloc(strlen(luascript)+strlen(folder)+strlen(filename)+1));
-	sprintf(lua,luascript,folder,filename);
+	lua = aprintf(luascript, folder, filename);
 	ret = chdk_generic_script_run (params, lua, &table, &retint, context);
 	free (lua);
 	if (table) {
@@ -361,8 +358,7 @@ chdk_delete_file_func (CameraFilesystem *fs, const char *folder,
 	const char 		*luascript = "\nreturn os.remove('A%s/%s')";
 	char 			*lua = NULL;
 
-	C_MEM (lua = malloc(strlen(luascript)+strlen(folder)+strlen(filename)+1));
-	sprintf(lua,luascript,folder,filename);
+	lua = aprintf(luascript, folder, filename);
 	ret = chdk_generic_script_run (params, lua, NULL, NULL, context);
 	free (lua);
 	return ret;

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -6770,8 +6770,7 @@ camera_wait_for_event (Camera *camera, int timeout,
 					*eventtype = GP_EVENT_UNKNOWN;
 					if (PTP_DPC_CANON_EOS_FocusInfoEx == entry.u.propid) {
 						if (PTP_RC_OK == ptp_canon_eos_getdevicepropdesc (params, PTP_DPC_CANON_EOS_FocusInfoEx, &dpd)) {
-							C_MEM (*eventdata = malloc(strlen("FocusInfo ")+strlen(dpd.CurrentValue.str)+1));
-							sprintf (*eventdata, "FocusInfo %s", dpd.CurrentValue.str);
+							*eventdata = aprintf("FocusInfo %s", dpd.CurrentValue.str);
 							ptp_free_devicepropdesc (&dpd);
 							return GP_OK;
 						}
@@ -6782,13 +6781,11 @@ camera_wait_for_event (Camera *camera, int timeout,
 					dpd.DevicePropertyCode = entry.u.propid;
 					ret = camera_lookup_by_property(camera, &dpd, &name, &content, context);
 					if (ret == GP_OK) {
-						C_MEM (*eventdata = malloc(strlen("PTP Property 0123 changed, \"\" to \"\"")+strlen(name)+1+strlen(content?content:"")));
-						sprintf (*eventdata, "PTP Property %04x changed, \"%s\" to \"%s\"", entry.u.propid, name, content?content:"");
+						*eventdata = aprintf("PTP Property %04x changed, \"%s\" to \"%s\"", entry.u.propid, name, content?content:"");
 						free (name);
 						free (content);
 					} else {
-						C_MEM (*eventdata = malloc(strlen("PTP Property 0123 changed")+1));
-						sprintf (*eventdata, "PTP Property %04x changed", entry.u.propid);
+						*eventdata = aprintf("PTP Property %04x changed", entry.u.propid);
 					}
 					ptp_free_devicepropdesc (&dpd);
 					return GP_OK;
@@ -6800,19 +6797,16 @@ camera_wait_for_event (Camera *camera, int timeout,
 						*eventdata = NULL;
 					} else {
 						*eventtype = GP_EVENT_UNKNOWN;
-						C_MEM (*eventdata = malloc(strlen("Camera Status 123456789012345")+1));
-						sprintf (*eventdata, "Camera Status %d", entry.u.status);
+						*eventdata = aprintf("Camera Status %d", entry.u.status);
 					}
 					return GP_OK;
 				case PTP_CANON_EOS_CHANGES_TYPE_FOCUSINFO:
 					*eventtype = GP_EVENT_UNKNOWN;
-					C_MEM (*eventdata = malloc(strlen("Focus Info ") + strlen(entry.u.info)+1));
-					sprintf (*eventdata, "Focus Info %s", entry.u.info);
+					*eventdata = aprintf("Focus Info %s", entry.u.info);
 					return GP_OK;
 				case PTP_CANON_EOS_CHANGES_TYPE_FOCUSMASK:
 					*eventtype = GP_EVENT_UNKNOWN;
-					C_MEM (*eventdata = malloc(strlen("Focus Mask ") + strlen(entry.u.info)+1));
-					sprintf (*eventdata, "Focus Mask %s", entry.u.info);
+					*eventdata = aprintf("Focus Mask %s", entry.u.info);
 					return GP_OK;
 				case PTP_CANON_EOS_CHANGES_TYPE_UNKNOWN:
 					/* only return if interesting stuff happened */
@@ -6827,8 +6821,7 @@ camera_wait_for_event (Camera *camera, int timeout,
 					ptp_remove_object_from_cache(params, entry.u.object.oid);
 					gp_filesystem_reset (camera->fs);
 					*eventtype = GP_EVENT_UNKNOWN;
-					C_MEM (*eventdata = malloc(strlen("Object Removed")+1));
-					sprintf (*eventdata, "ObjectRemoved");
+					*eventdata = aprintf("ObjectRemoved");
 					return GP_OK;
 				default:
 					GP_LOG_D ("Unhandled EOS event 0x%04x", entry.type);
@@ -7305,21 +7298,18 @@ sonyout:
 
 					ret = camera_lookup_by_property(camera, &dpd, &name, &content, context);
 					if (ret == GP_OK) {
-						C_MEM (*eventdata = malloc(strlen("PTP Property 0123 changed, \"\" to \"\"")+strlen(name)+1+strlen(content?content:"")));
-						sprintf (*eventdata, "PTP Property %04x changed, \"%s\" to \"%s\"", event.Param1 & 0xffff, name, content?content:"");
+						*eventdata = aprintf("PTP Property %04x changed, \"%s\" to \"%s\"", event.Param1 & 0xffff, name, content?content:"");
 						free (name);
 						free (content);
 					} else {
-						C_MEM (*eventdata = malloc(strlen("PTP Property 0123 changed")+1));
-						sprintf (*eventdata, "PTP Property %04x changed", event.Param1 & 0xffff);
+						*eventdata = aprintf("PTP Property %04x changed", event.Param1 & 0xffff);
 					}
 					ptp_free_devicepropdesc (&dpd);
 					return GP_OK;
 				}
 				default:
 					*eventtype = GP_EVENT_UNKNOWN;
-					C_MEM (*eventdata = malloc(strlen("PTP Event 0123, Param1 01234567")+1));
-					sprintf (*eventdata, "PTP Event %04x, Param1 %08x", event.Code, event.Param1);
+					*eventdata = aprintf("PTP Event %04x, Param1 %08x", event.Code, event.Param1);
 					return GP_OK;
 				}
 			}
@@ -7425,8 +7415,7 @@ handleregular:
 	}
 	case PTP_EC_DeviceInfoChanged:
 		*eventtype = GP_EVENT_UNKNOWN;
-		C_MEM (*eventdata = malloc(strlen("PTP Deviceinfo changed")+1));
-		sprintf (*eventdata, "PTP Deviceinfo changed");
+		*eventdata = aprintf("PTP Deviceinfo changed");
 		C_PTP_REP (ptp_getdeviceinfo (params, &params->deviceinfo));
 		CR (fixup_cached_deviceinfo (camera, &params->deviceinfo));
 		print_debug_deviceinfo(params, &params->deviceinfo);
@@ -7443,8 +7432,7 @@ handleregular:
 		 * (reported via email)
 		 */
 		if (ret == PTP_RC_DevicePropNotSupported) {
-			C_MEM (*eventdata = malloc(strlen("PTP Property 01234567 changed")+1));
-			sprintf (*eventdata, "PTP Property %08x changed", event.Param1);
+			*eventdata = aprintf("PTP Property %08x changed", event.Param1);
 			break;
 		}
 		if (ret != PTP_RC_OK)
@@ -7452,13 +7440,11 @@ handleregular:
 
 		ret = camera_lookup_by_property(camera, &dpd, &name, &content, context);
 		if (ret == GP_OK) {
-			C_MEM (*eventdata = malloc(strlen("PTP Property 01234567 changed, \"\" to \"\"")+strlen(name)+1+strlen(content?content:"")));
-			sprintf (*eventdata, "PTP Property %08x changed, \"%s\" to \"%s\"", event.Param1, name, content?content:"");
+			*eventdata = aprintf("PTP Property %08x changed, \"%s\" to \"%s\"", event.Param1, name, content?content:"");
 			free (name);
 			free (content);
 		} else {
-			C_MEM (*eventdata = malloc(strlen("PTP Property 01234567 changed")+1));
-			sprintf (*eventdata, "PTP Property %08x changed", event.Param1);
+			*eventdata = aprintf("PTP Property %08x changed", event.Param1);
 		}
 		ptp_free_devicepropdesc (&dpd);
 		break;
@@ -7507,25 +7493,21 @@ handleregular:
 		ptp_remove_object_from_cache(params, event.Param1);
 		gp_filesystem_reset (camera->fs);
 		*eventtype = GP_EVENT_UNKNOWN;
-		C_MEM (*eventdata = malloc(strlen("PTP ObjectRemoved, Param1 01234567")+1));
-		sprintf (*eventdata, "PTP ObjectRemoved, Param1 %08x", event.Param1);
+		*eventdata = aprintf("PTP ObjectRemoved, Param1 %08x", event.Param1);
 		break;
 	case PTP_EC_StoreAdded:
 		gp_filesystem_reset (camera->fs);
 		*eventtype = GP_EVENT_UNKNOWN;
-		C_MEM (*eventdata = malloc(strlen("PTP StoreAdded, Param1 01234567")+1));
-		sprintf (*eventdata, "PTP StoreAdded, Param1 %08x", event.Param1);
+		*eventdata = aprintf("PTP StoreAdded, Param1 %08x", event.Param1);
 		break;
 	case PTP_EC_StoreRemoved:
 		gp_filesystem_reset (camera->fs);
 		*eventtype = GP_EVENT_UNKNOWN;
-		C_MEM (*eventdata = malloc(strlen("PTP StoreRemoved, Param1 01234567")+1));
-		sprintf (*eventdata, "PTP StoreRemoved, Param1 %08x", event.Param1);
+		*eventdata = aprintf("PTP StoreRemoved, Param1 %08x", event.Param1);
 		break;
 	default:
 		*eventtype = GP_EVENT_UNKNOWN;
-		C_MEM (*eventdata = malloc(strlen("PTP Event 0123, Param1 01234567")+1));
-		sprintf (*eventdata, "PTP Event %04x, Param1 %08x", event.Code, event.Param1);
+		*eventdata = aprintf("PTP Event %04x, Param1 %08x", event.Code, event.Param1);
 		break;
 	}
 	return GP_OK;

--- a/camlibs/ricoh/g3.c
+++ b/camlibs/ricoh/g3.c
@@ -190,7 +190,7 @@ g3_ftp_command_and_reply(GPPort *port, char *cmd, char **reply) {
 	unsigned int len;
 	char *realcmd, *s;
 
-	realcmd = malloc(strlen(cmd)+2+1);strcpy(realcmd, cmd);strcat(realcmd, "\r\n");
+	realcmd = aprintf("%s\r\n", cmd);
 
 	gp_log(GP_LOG_DEBUG, "g3" , "sending %s", cmd);
 	ret = g3_channel_write(port, 1, realcmd, strlen(realcmd));
@@ -326,8 +326,7 @@ g3_cwd_command( GPPort *port, const char *folder) {
 	char *cmd, *reply = NULL;
 	int ret;
 
-	cmd = malloc(strlen("CWD ") + strlen(folder) + 2 + 1);
-	sprintf(cmd,"CWD %s", folder);
+	cmd = aprintf("CWD %s", folder);
 	ret = g3_ftp_command_and_reply(port, cmd, &reply);
 	free(cmd);
 	if (ret < GP_OK) {
@@ -365,8 +364,7 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
 			msg = _("Downloading image...");
 		if (strstr(filename,"wav") || strstr(filename,"WAV"))
 			msg = _("Downloading audio...");
-		cmd = malloc(strlen("RETR ") + strlen(filename) + 2 + 1);
-		sprintf(cmd,"RETR %s", filename);
+		cmd = aprintf("RETR %s", filename);
 		ret = g3_ftp_command_and_reply(camera->port, cmd, &buf);
 		free(cmd);
 		if (ret < GP_OK) goto out;
@@ -386,8 +384,7 @@ get_file_func (CameraFilesystem *fs, const char *folder, const char *filename,
                         ret = GP_ERROR_FILE_NOT_FOUND;
 			goto out;
 		}
-		cmd = malloc(strlen("-SRET ") + strlen(filename) + 2 + 1);
-		sprintf(cmd,"-SRET %s", filename);
+		cmd = aprintf("-SRET %s", filename);
 		ret = g3_ftp_command_and_reply(camera->port, cmd, &buf);
 		free(cmd);
 		if (ret < GP_OK) goto out;
@@ -446,8 +443,7 @@ put_file_func (CameraFilesystem *fs, const char *folder, const char *fn, CameraF
 	ret = gp_file_get_data_and_size (file, &imgdata, &size);
 	if (ret < GP_OK) goto out;
 
-	cmd = malloc(strlen("-STOR ") + 20 + strlen(fn) + 2 + 1);
-	sprintf(cmd,"-STOR %ld %s", size, fn);
+	cmd = aprintf("-STOR %ld %s", size, fn);
 	ret = g3_ftp_command_and_reply(camera->port, cmd, &buf);
 	free(cmd);
 	if (ret < GP_OK) goto out;
@@ -478,9 +474,7 @@ delete_file_func (CameraFilesystem *fs, const char *folder,
 	if (ret < GP_OK)
 		return ret;
 
-	cmd = malloc(strlen("DELE ")+strlen(filename)+1);
-	if (!cmd) return GP_ERROR_NO_MEMORY;
-	sprintf(cmd,"DELE %s",filename);
+	cmd = aprintf("DELE %s", filename);
 	ret = g3_ftp_command_and_reply(camera->port, cmd, &reply);
 	if (ret < GP_OK)
 		goto out;
@@ -651,9 +645,7 @@ get_info_func (CameraFilesystem *fs, const char *folder, const char *filename,
 	if (!strcmp(filename+9,"MTA") || !strcmp(filename+9,"mta"))
 		strcpy(info->file.type,"text/plain");
 
-	cmd = malloc(strlen("-FDAT ")+strlen(folder)+1+strlen(filename)+1);
-	if (!cmd) return GP_ERROR_NO_MEMORY;
-	sprintf(cmd, "-FDAT %s/%s", folder,filename);
+	cmd = aprintf("-FDAT %s/%s", folder,filename);
 	ret = g3_ftp_command_and_reply(camera->port, cmd, &reply);
 	if (ret < GP_OK) goto out;
 	if (sscanf(reply, "200 date=%d:%d:%d %d:%d:%d",

--- a/camlibs/topfield/puppy.c
+++ b/camlibs/topfield/puppy.c
@@ -188,22 +188,13 @@ get_path (Camera *camera, const char *folder, const char *filename) {
 	char	*xfolder, *xfilename;
 
 	xfolder = strdup_to_latin1 (folder);
-	if (!xfolder)
-		return NULL;
 	xfilename = _convert_for_device (camera, filename);
-	if (!xfilename) {
-		free (xfolder);
+	if (!xfolder || !xfilename)
 		return NULL;
-	}
-	path = malloc(strlen(xfolder)+1+strlen(xfilename)+1);
-	if (!path) {
-		free (xfolder);
-		return NULL;
-	}
-	strcpy (path, xfolder);
-	strcat (path, "/");
+
+	path = aprintf("%s/%s", xfolder, xfilename);
 	backslash (path);
-	strcat (path, xfilename);
+
 	free (xfolder);
 	free (xfilename);
 	return path;

--- a/examples/sample-afl.c
+++ b/examples/sample-afl.c
@@ -47,11 +47,7 @@ recursive_directory(Camera *camera, const char *folder, GPContext *context, int 
 
 		if (!strlen(newfolder)) continue;
 
-		buf = malloc (strlen(folder) + 1 + strlen(newfolder) + 1);
-		strcpy(buf, folder);
-		if (strcmp(folder,"/"))		/* avoid double / */
-			strcat(buf, "/");
-		strcat(buf, newfolder);
+		buf = aprintf("%s%s%s", folder, strcmp(folder, "/") ? "/" : "", newfolder);
 
 		fprintf(stderr,"newfolder=%s\n", newfolder);
 

--- a/examples/sample-libfuzz.c
+++ b/examples/sample-libfuzz.c
@@ -72,11 +72,7 @@ recursive_directory(Camera *camera, const char *folder, GPContext *context, int 
 
 		if (!strlen(newfolder)) continue;
 
-		buf = (char*)malloc (strlen(folder) + 1 + strlen(newfolder) + 1);
-		strcpy(buf, folder);
-		if (strcmp(folder,"/"))		/* avoid double / */
-			strcat(buf, "/");
-		strcat(buf, newfolder);
+		buf = aprintf("%s%s%s", folder, strcmp(folder, "/") ? "/" : "", newfolder);
 
 		//fprintf(stderr,"newfolder=%s\n", newfolder);
 

--- a/libgphoto2/gphoto2-filesys.c
+++ b/libgphoto2/gphoto2-filesys.c
@@ -1465,10 +1465,7 @@ recursive_folder_scan (
 		char *xfolder;
 		ret = recursive_folder_scan (f, lookforfile, &xfolder);
 		if (ret == GP_OK) {
-			C_MEM ((*foldername) = malloc (strlen (folder->name) + 1 + strlen (xfolder) + 1));
-			strcpy ((*foldername),folder->name);
-			strcat ((*foldername),"/");
-			strcat ((*foldername),xfolder);
+			*foldername = aprintf("%s/%s", folder->name, xfolder);
 			free (xfolder);
 			return GP_OK;
 		}

--- a/libgphoto2_port/disk/disk.c
+++ b/libgphoto2_port/disk/disk.c
@@ -132,15 +132,13 @@ gp_port_library_list (GPPortInfoList *list)
 				if (-1 == stat(path, &stbuf))
 					continue;
 			}
-			s = malloc (strlen(_("Media '%s'"))+strlen(mntent->mnt_fsname)+1);
-			sprintf (s, _("Media '%s'"), mntent->mnt_fsname);
+			s = aprintf (_("Media '%s'"), mntent->mnt_fsname);
 			gp_port_info_new (&info);
 			gp_port_info_set_type (info, GP_PORT_DISK);
 			gp_port_info_set_name (info, s);
 			free (s);
 
-			s = malloc (strlen("disk:")+strlen(mntent->mnt_dir)+1);
-			sprintf (s, "disk:%s", mntent->mnt_dir);
+			s = aprintf ("disk:%s", mntent->mnt_dir);
 			gp_port_info_set_path (info, s);
 			if (gp_port_info_list_lookup_path (list, s) >= GP_OK) {
 				free (s);
@@ -213,13 +211,11 @@ gp_port_library_list (GPPortInfoList *list)
 			}
 			gp_port_info_new (&info);
 			gp_port_info_set_type (info, GP_PORT_DISK);
-			s = malloc (strlen(_("Media '%s'"))+strlen(mntent->mnt_fsname)+1);
-			sprintf (s, _("Media '%s'"),  mntent->mnt_fsname);
+			s = aprintf (_("Media '%s'"),  mntent->mnt_fsname);
 			gp_port_info_set_name (info, s);
 			free (s);
 
-			s = malloc (strlen("disk:")+strlen(mntent->mnt_dir)+1);
-			sprintf (s, "disk:%s", mntent->mnt_dir);
+			s = aprintf ("disk:%s", mntent->mnt_dir);
 			gp_port_info_set_path (info, s);
 			if (gp_port_info_list_lookup_path (list, s) >= GP_OK) {
 				free (s);

--- a/libgphoto2_port/gphoto2/gphoto2-port-log.h
+++ b/libgphoto2_port/gphoto2/gphoto2-port-log.h
@@ -218,6 +218,19 @@ __attribute__((__format__(printf,4,5)))
   char*
   gpi_vsnprintf (const char* format, va_list args);
 
+static inline char*
+aprintf(const char *fmt, ...)
+{
+	va_list ap;
+	char* res;
+
+	va_start(ap, fmt);
+	res = gpi_vsnprintf(fmt, ap);
+	va_end(ap);
+
+	return res;
+}
+
 #define C_MEM(MEM) do {\
 	if ((MEM) == NULL) {\
 		GP_LOG_E ("Out of memory: '%s' failed.", #MEM);\

--- a/libgphoto2_port/serial/unix.c
+++ b/libgphoto2_port/serial/unix.c
@@ -305,13 +305,10 @@ gp_port_library_list (GPPortInfoList *list)
 
 		gp_port_info_new (&info);
 		gp_port_info_set_type (info, GP_PORT_SERIAL);
-		C_MEM (xname = malloc (strlen("serial:")+strlen(path)+1));
-		strcpy (xname, "serial:");
-		strcat (xname, path);
+		xname = aprintf("serial:%s", path);
 		gp_port_info_set_path (info, xname);
 		free (xname);
-		C_MEM (xname = malloc (100));
-		snprintf (xname, 100, _("Serial Port %i"), x);
+		xname = aprintf(_("Serial Port %i"), x);
 		gp_port_info_set_name (info, xname);
 		free (xname);
 		CHECK (gp_port_info_list_append (list, info));

--- a/libgphoto2_port/vusb/vcamera.c
+++ b/libgphoto2_port/vusb/vcamera.c
@@ -453,10 +453,7 @@ read_directories(const char *path, struct ptp_dirent *parent) {
 		cur = malloc(sizeof(struct ptp_dirent));
 		if (!cur) break;
 		cur->name = strdup(gp_system_filename(de));
-		cur->fsname = malloc(strlen(path)+1+strlen(gp_system_filename(de))+1);
-		strcpy(cur->fsname,path);
-		strcat(cur->fsname,"/");
-		strcat(cur->fsname,gp_system_filename(de));
+		cur->fsname = aprintf("%s/%s", path, gp_system_filename(de));
 		cur->id = ptp_objectid++;
 		cur->next = first_dirent;
 		cur->parent = parent;


### PR DESCRIPTION
This replaces the verbose and error prone pattern of calling
```
    str = malloc(strlen("some value is 12345678")+1);
    sprintf(str, "some value is %d", val)
```
with
```
    str = aprintf(some value is %d", val);
```

This is similar to the GNU function asprintf() but returns the pointer instead of assigning it to the first parameter. It uses the existing gpi_vsnprintf(fmt, va_list) function.