### PR TITLE
Update CI to FreeBSD 13.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ task:
   name: FreeBSD
   freebsd_instance:
     matrix:
-      image_family: freebsd-13-2
+      image_family: freebsd-13-3
       # image_family: freebsd-12-2
       # image_family: freebsd-11-4
 


### PR DESCRIPTION
FreeBSD 13.2 reached end-of-life (EOL) as of July 1st, 2024.