### PR TITLE
ptp2: condense EOS OLCInfo related debug output

### DIFF
--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -172,6 +172,20 @@ ptp_error (PTPParams *params, const char *format, ...)
 	va_end (args);
 }
 
+/* Helper function to quickly render some bytes into a static string
+ * buffer for immediate copying/snprintf-ing. Parameter fmt is the
+ * format string used for each byte, e.g. "%02x ". */
+const char*
+ptp_bytes2str(const uint8_t* data, int data_size, const char* fmt)
+{
+	static char line[16 * 3 + 1];
+	int pos = 0;
+	for (int i = 0; i < data_size && pos < (int)sizeof(line); ++i) {
+		pos += snprintf(line + pos, sizeof(line) - pos, fmt, data[i]);
+	}
+	return line;
+}
+
 /* Pack / unpack functions */
 
 #include "ptp-pack.c"

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -4823,6 +4823,7 @@ void ptp_free_object		(PTPObject *oi);
 const char *ptp_strerror	(uint16_t ret, uint16_t vendor);
 void ptp_debug			(PTPParams *params, const char *format, ...);
 void ptp_error			(PTPParams *params, const char *format, ...);
+const char* ptp_bytes2str(const uint8_t* data, int data_size, const char* fmt);
 
 
 const char* ptp_get_property_description(PTPParams* params, uint32_t dpc);


### PR DESCRIPTION
A full logging excerpt now looks like this
```
event 237: EOS event OLCInfoChanged (size 81, version 0x0b, mask 0x1fff)
    0x00: 49 00 00 00 ff 1f 00 00 01 00 01 01 a0 10 00 a0
    0x10: 01 01 50 20 2c 01 01 00 00 04 01 01 71 00 00 00
    0x20: 00 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00
    0x30: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
    0x40: 00 00 00 00 00 00 00 00 00
event 237: olcmask 0x0001, 2 bytes: 01 00
event 238: olcmask 0x0002, 6 bytes: 01 01 a0 10 00 a0
event 239: olcmask 0x0004, 5 bytes: 01 01 50 20 2c
event 240: olcmask 0x0008, 4 bytes: 01 01 00 00
event 241: olcmask 0x0010, 4 bytes: 04 01 01 71
event 242: olcmask 0x0020, 6 bytes: 00 00 00 00 00 00
event 243: olcmask 0x0040, 8 bytes: 01 00 00 00 00 00 00 00
event 244: olcmask 0x0080, 4 bytes: 00 00 00 00
event 245: olcmask 0x0100, 6 bytes: 00 00 00 00 00 00
event 246: olcmask 0x0200, 5 bytes: 00 00 00 00 00
event 247: olcmask 0x0400, 5 bytes: 00 00 00 00 00
event 248: olcmask 0x0800, 9 bytes: 00 00 00 00 00 00 00 00 00
event 249: mask 0x1000 entry truncated (1 bytes), olcsizes table (8 bytes) wrong?
event 249: olcmask 0x1000, 1 bytes: 00
```

This allows for easy grepping of the log file. See comments for gained insight into olcmask 0x0010 entries. The user visible strings info strings of the UNKNOWN events have changed as well, e.g.:
```
UNKNOWN OLCInfo event 0x0010, 4 bytes: 04 02 06 2f
```
It also introduces a convenient ptp_bytes2str() function to render some bytes into a string for immediate printing/copying.