### PR TITLE
Enable silent build rules by default

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ task:
     - pkg install -y autoconf automake libtool gettext-tools gettext-runtime pkgconf libltdl libexif libgd libxml2 curl
   configure_script:
     - autoreconf -ivf
-    - ./configure --disable-silent-rules --with-camlibs=everything || { tail -300 config.log; false; }
+    - ./configure --with-camlibs=everything || { tail -300 config.log; false; }
   compile_script:
     - make
   test_script:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,7 +13,6 @@ on:
 env:
   LC_ALL: C
   COMMON_CONFIGURE_FLAGS: >-
-    --disable-silent-rules
     --enable-vusb
     --with-camlibs=everything
     SLEEP=no

--- a/Makefile.am
+++ b/Makefile.am
@@ -116,9 +116,15 @@ update-po:
 
 @GP_GETTEXT_SETUP_MK@
 
-# Dummy target to force Automake to make the all target depend on it
+# We need *some* `all-local` target (dummy or real) to force Automake
+# to make the `all` target depend on it.  In this case, print build
+# flags for debugging purposes.
 all-local:
-	@:
+	@test -z "$(CFLAGS)"   || printf "  %s %-8s %s\n" env CFLAGS   "$(CFLAGS)"
+	@test -z "$(CPPFLAGS)" || printf "  %s %-8s %s\n" env CPPFLAGS "$(CPPFLAGS)"
+	@test -z "$(LDADD)"    || printf "  %s %-8s %s\n" env LDADD    "$(LDADD)"
+	@test -z "$(LIBADD)"   || printf "  %s %-8s %s\n" env LIBADD   "$(LIBADD)"
+	@test -z "$(LDFLAGS)"  || printf "  %s %-8s %s\n" env LDFLAGS  "$(LDFLAGS)"
 
 # Dummy target to force Automake to make the distclean target depend on it
 distclean-local:

--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,7 @@ ports/serial:
 
 all:
 * IOLIBS and CAMLIBS now runtime configurable
+* Builds use silent rules by default now
 
 
 translations:

--- a/camlibs/Makefile.am
+++ b/camlibs/Makefile.am
@@ -156,6 +156,19 @@ include tp6801/Makefile-files
 
 
 ########################################################################
+# Print build flags for camlibs
+
+CLEANFILES  += camlib-buildflags.stamp
+noinst_DATA += camlib-buildflags.stamp
+camlib-buildflags.stamp: $(camlib_LTLIBRARIES)
+	@test -z "$(camlib_cflags)"   || printf "  %s %-8s %s\n" cam CFLAGS   "$(camlib_cflags)"
+	@test -z "$(camlib_cppflags)" || printf "  %s %-8s %s\n" cam CPPFLAGS "$(camlib_cppflags)"
+	@test -z "$(camlib_libadd)"   || printf "  %s %-8s %s\n" cam LIBADD   "$(camlib_libadd)"
+	@test -z "$(camlib_ldflags)"  || printf "  %s %-8s %s\n" cam LDFLAGS  "$(camlib_ldflags)"
+	@date > $@
+
+
+########################################################################
 # Print list of GP_CAMLIB() definitions suitable for adding to
 # configure.ac
 print-camlibs: Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ dnl   libtool  2014-10-27 2.4.3
 dnl   libtool  2011-10-18 2.4.2
 
 
-AM_SILENT_RULES([no])
+AM_SILENT_RULES([yes])
 
 
 dnl Flag all GP_ strings in result as error unless specifically allowed.

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -25,8 +25,8 @@ LOCAL_CLEAN =
 # FIXME: Depend on source files.
 DOXYGEN_STAMPS += $(HTML_APIDOC_DIR).stamp
 $(HTML_APIDOC_DIR).stamp: Doxyfile
-	doxygen Doxyfile
-	echo > $@
+	$(AM_V_GEN)doxygen $$($(AM_V_P) || printf "%s" "-q") Doxyfile
+	@: > $@
 
 $(HTML_APIDOC_DIR).tar.gz: $(HTML_APIDOC_DIR).stamp
 	(cd $(DOXYGEN_OUTPUT_DIR) && $(AMTAR) chof - $(HTML_APIDOC_DIR) | GZIP=--best gzip -c) > $@

--- a/libgphoto2/Makefile.am
+++ b/libgphoto2/Makefile.am
@@ -1,4 +1,6 @@
+CLEANFILES =
 EXTRA_DIST =
+noinst_DATA =
 
 
 # included by all *.c files containing translated string literals as
@@ -91,3 +93,13 @@ libgphoto2_la_SOURCES      += gphoto2-setting.c
 libgphoto2_la_SOURCES      += gphoto2-widget.c
 
 libgphoto2_la_DEPENDENCIES += $(top_srcdir)/gphoto2/gphoto2-version.h
+
+
+CLEANFILES  += libgphoto2-buildflags.stamp
+noinst_DATA += libgphoto2-buildflags.stamp
+libgphoto2-buildflags.stamp: libgphoto2.la
+	@test -z "$(libgphoto2_la_CFLAGS)"   || printf "  %s %-8s %s\n" lg2 CFLAGS   "$(libgphoto2_la_CFLAGS)"
+	@test -z "$(libgphoto2_la_CPPFLAGS)" || printf "  %s %-8s %s\n" lg2 CPPFLAGS "$(libgphoto2_la_CPPFLAGS)"
+	@test -z "$(libgphoto2_la_LIBADD)"   || printf "  %s %-8s %s\n" lg2 LIBADD   "$(libgphoto2_la_LIBADD)"
+	@test -z "$(libgphoto2_la_LDFLAGS)"  || printf "  %s %-8s %s\n" lg2 LDFLAGS  "$(libgphoto2_la_LDFLAGS)"
+	@date > $@

--- a/libgphoto2_port/Makefile.am
+++ b/libgphoto2_port/Makefile.am
@@ -105,3 +105,13 @@ nobase_include_HEADERS =	\
 
 EXTRA_DIST += gphoto2/gphoto2-port-library.h
 EXTRA_DIST += gphoto2/gphoto2-port-locking.h
+
+
+CLEANFILES  += iolib-buildflags.stamp
+noinst_DATA += iolib-buildflags.stamp
+iolib-buildflags.stamp: $(iolib_LTLIBRARIES)
+	@test -z "$(iolib_cflags)"   || printf "  %s %-8s %s\n" iol CFLAGS   "$(iolib_cflags)"
+	@test -z "$(iolib_cppflags)" || printf "  %s %-8s %s\n" iol CPPFLAGS "$(iolib_cppflags)"
+	@test -z "$(iolib_libadd)"   || printf "  %s %-8s %s\n" iol LIBADD   "$(iolib_libadd)"
+	@test -z "$(iolib_ldflags)"  || printf "  %s %-8s %s\n" iol LDFLAGS  "$(iolib_ldflags)"
+	@date > $@

--- a/libgphoto2_port/configure.ac
+++ b/libgphoto2_port/configure.ac
@@ -20,7 +20,7 @@ AM_INIT_AUTOMAKE([
 ])
 
 
-AM_SILENT_RULES([no])
+AM_SILENT_RULES([yes])
 
 
 AC_LANG([C])

--- a/libgphoto2_port/gphoto-m4/gp-gettext-setup.m4
+++ b/libgphoto2_port/gphoto-m4/gp-gettext-setup.m4
@@ -57,21 +57,20 @@ dnl if the consistency check has been successful, and have "make all" abort
 dnl     Error: Inconsistent values for GETTEXT_PACKAGE_LIBGPHOTO2 and po/Makevars DOMAIN.
 dnl if the consistency check has failed.
 dnl
+m4_pattern_allow([AM_V_P])dnl
 cat >>${GP_GETTEXT_SETUP_MK} <<EOF
-	@set -ex; \\
+	@set -e; \\
 	MAKEVARS_FILE="\$\$(test -f '$3/Makevars' || echo '\$(srcdir)/')$3/Makevars"; \\
 	MAKEVARS_DOMAIN="\$\$(\$(SED) -n 's/^DOMAIN \\{0,\\}= \\{0,\\}//p' "\$\$MAKEVARS_FILE")"; \\
 	MAKE_TIME_DOMAIN="\$($1)"; \\
-	echo "  MAKEVARS_DOMAIN=\$\$MAKEVARS_DOMAIN"; \\
-	echo "  $1=\$($1)"; \\
 	if test "x\$\$MAKEVARS_DOMAIN" = "x\$($1)"; then \\
-	     echo "Good: Matching gettext domain values (\$($1))"; \\
+	     if \$(AM_V_P); then printf "  %-7s %s\n" CHECK "Good: Matching gettext domain values (\$($1))"; fi; \\
 	     true; \\
 	elif test "x\$\$USE_NLS" = xyes; then \\
-	     echo "Error: Mismatching gettext domain values (\$($1) vs \$\${MAKEVARS_DOMAIN})"; \\
+	     printf "  %-7s %s\n" CHECK "Error: Mismatching gettext domain values (\$($1) vs \$\${MAKEVARS_DOMAIN})"; \\
 	     false; \\
 	else \\
-	     echo "Warning: Mismatching gettext domain values (\$($1) vs \$\${MAKEVARS_DOMAIN})"; \\
+	     printf "  %-7s %s\n" CHECK "Warning: Mismatching gettext domain values (\$($1) vs \$\${MAKEVARS_DOMAIN})"; \\
 	     true; \\
 	fi
 EOF

--- a/libgphoto2_port/libgphoto2_port/Makefile.am
+++ b/libgphoto2_port/libgphoto2_port/Makefile.am
@@ -1,4 +1,6 @@
+CLEANFILES =
 EXTRA_DIST =
+noinst_DATA =
 
 
 # included by all *.c files containing translated string literals as
@@ -76,3 +78,13 @@ libgphoto2_port_la_SOURCES      += gphoto2-port-result.c
 libgphoto2_port_la_DEPENDENCIES += $(top_srcdir)/gphoto2/gphoto2-port-locking.h
 libgphoto2_port_la_DEPENDENCIES += $(top_srcdir)/gphoto2/gphoto2-port-version.h
 libgphoto2_port_la_DEPENDENCIES += $(top_srcdir)/gphoto2/gphoto2-port-library.h
+
+
+CLEANFILES  += libgphoto2_port-buildflags.stamp
+noinst_DATA += libgphoto2_port-buildflags.stamp
+libgphoto2_port-buildflags.stamp: libgphoto2_port.la
+	@test -z "$(libgphoto2_port_la_CFLAGS)"   || printf "  %s %-8s %s\n" lgp CFLAGS   "$(libgphoto2_port_la_CFLAGS)"
+	@test -z "$(libgphoto2_port_la_CPPFLAGS)" || printf "  %s %-8s %s\n" lgp CPPFLAGS "$(libgphoto2_port_la_CPPFLAGS)"
+	@test -z "$(libgphoto2_port_la_LIBADD)"   || printf "  %s %-8s %s\n" lgp LIBADD   "$(libgphoto2_port_la_LIBADD)"
+	@test -z "$(libgphoto2_port_la_LDFLAGS)"  || printf "  %s %-8s %s\n" lgp LDFLAGS  "$(libgphoto2_port_la_LDFLAGS)"
+	@date > $@


### PR DESCRIPTION
Enable silent build rules by default.

You can still use verbose build rules by using any of the following
methods:

  * run `configure` with the `--disable-silent-rules` argument
  * run `make` with the `V=1` argument

This hides the compiler command line which makes debugging users'
problems more difficult. To compensate for that, this prints the
build flags separately, but a lot less frequently:

For each part of the build (`libgphoto2_port.la`, iolibs,
`libgphoto2.la`, camlibs), if something of that part has been
rebuilt, prints the build flags (_CPPFLAGS, _CFLAGS, _LIBADD,
_LDFLAGS) once.

Always prints the environment variables CPPFLAGS CFLAGS LDADD
LIBADD LDFLAGS once, whether they are the defaults the configure
script sets or given on the `make` command line.

Not all make recipes have been converted to be completely silent,
but the majority (especially the Automake standard recipes) are
now silent.
