### PR TITLE
More code cosmetic

### DIFF
--- a/camlibs/ptp2/chdk.c
+++ b/camlibs/ptp2/chdk.c
@@ -41,7 +41,6 @@
 #include "ptp.h"
 #include "ptp-bugs.h"
 #include "ptp-private.h"
-#include "ptp-pack.c"
 
 /* CHDK support */
 

--- a/camlibs/ptp2/chdk.c
+++ b/camlibs/ptp2/chdk.c
@@ -1256,8 +1256,7 @@ static void yuv_live_to_ppm (unsigned char *p_yuv,
 ) {
 	const unsigned char  *p_row = p_yuv;
 	const unsigned char  *p;
-	unsigned int	      row, x;
-	unsigned int	      row_inc;
+	int		      row, x, row_inc;
 	int		      pshift, xshift, skip;
 	char		      ppm_header[32];
 	uint8_t		      rgb[6];

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -44,7 +44,6 @@
 #include "ptp.h"
 #include "ptp-bugs.h"
 #include "ptp-private.h"
-#include "ptp-pack.c"
 
 #ifdef __GNUC__
 # define __unused__ __attribute__((unused))
@@ -424,7 +423,7 @@ skip:
 			GP_LOG_D ("deviceprop: %04x", x.DevicePropertiesSupported[i]);
 		for (i=0;i<x.unk_len;i++)
 			GP_LOG_D ("unk: %04x", x.unk[i]);
-		ptp_free_EOS_DI (&x);
+		ptp_canon_eos_free_deviceinfo (&x);
 	}
 
 	/* The new EOS occasionally returned an empty event set ... likely because we are too fast. try again some times. */
@@ -438,7 +437,7 @@ skip:
 
 	CR (camera_canon_eos_update_capture_target( camera, context, -1 ));
 
-	ptp_free_DI (&params->deviceinfo);
+	ptp_free_deviceinfo (&params->deviceinfo);
 	C_PTP (ptp_getdeviceinfo(params, &params->deviceinfo));
 	CR (fixup_cached_deviceinfo (camera, &params->deviceinfo));
 	C_PTP (ptp_canon_eos_getstorageids(params, &sids));

--- a/camlibs/ptp2/fujiptpip.c
+++ b/camlibs/ptp2/fujiptpip.c
@@ -74,14 +74,10 @@
 
 #include "ptp.h"
 #include "ptp-private.h"
+#include "ptp-bugs.h"
 
 #define PTPIP_VERSION_MAJOR 0x0001
 #define PTPIP_VERSION_MINOR 0x0000
-
-#include "ptp.h"
-#include "ptp-bugs.h"
-
-#include "ptp-pack.c"
 
 #define fujiptpip_len		0
 #define fujiptpip_type		4	/* not always present */

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -45,7 +45,6 @@
 #include "ptp.h"
 #include "ptp-bugs.h"
 #include "ptp-private.h"
-#include "ptp-pack.c"
 #include "olympus-wrap.h"
 
 #ifdef HAVE_LIBWS232
@@ -311,7 +310,7 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 
 
 		print_debug_deviceinfo (params, &newdi);
-		ptp_free_DI (di);
+		ptp_free_deviceinfo (di);
 		memcpy (di, &newdi, sizeof(newdi));
 		return GP_OK;
 	}
@@ -393,7 +392,7 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 			for (unsigned i=0;i<x.DevicePropertiesSupported_len;i++)
 				di->DevicePropertiesSupported[di->DevicePropertiesSupported_len + i] = x.DevicePropertiesSupported[i];
 			di->DevicePropertiesSupported_len += x.DevicePropertiesSupported_len;
-			ptp_free_EOS_DI (&x);
+			ptp_canon_eos_free_deviceinfo (&x);
 		}
 
 		LOG_ON_PTP_E (ptp_check_eos_events(params));
@@ -7998,7 +7997,7 @@ camera_summary (Camera* camera, CameraText* summary, GPContext *context)
 		APPEND_TXT ("\n");
 		ptp_free_devicepropdesc (&dpd);
 	}
-	ptp_free_DI (&pdi);
+	ptp_free_deviceinfo (&pdi);
 	return (GP_OK);
 #undef SPACE_LEFT
 #undef APPEND_TXT

--- a/camlibs/ptp2/olympus-wrap.c
+++ b/camlibs/ptp2/olympus-wrap.c
@@ -37,6 +37,7 @@
 #include "ptp.h"
 #include "ptp-private.h"
 #include "olympus-wrap.h"
+#include "ptp-pack.c"     /* only for ptp_pack_OI */
 
 #include <gphoto2/gphoto2-library.h>
 #include <gphoto2/gphoto2-setting.h>

--- a/camlibs/ptp2/olympus-wrap.c
+++ b/camlibs/ptp2/olympus-wrap.c
@@ -36,7 +36,6 @@
 
 #include "ptp.h"
 #include "ptp-private.h"
-#include "ptp-pack.c"
 #include "olympus-wrap.h"
 
 #include <gphoto2/gphoto2-library.h>

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -41,110 +41,6 @@
 # define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
-static inline uint16_t
-htod16p (PTPParams *params, uint16_t var)
-{
-	return ((params->byteorder==PTP_DL_LE)?htole16(var):htobe16(var));
-}
-
-static inline uint32_t
-htod32p (PTPParams *params, uint32_t var)
-{
-	return ((params->byteorder==PTP_DL_LE)?htole32(var):htobe32(var));
-}
-
-static inline void
-htod16ap (PTPParams *params, unsigned char *a, uint16_t val)
-{
-	if (params->byteorder==PTP_DL_LE)
-		htole16a(a,val);
-	else
-		htobe16a(a,val);
-}
-
-static inline void
-htod32ap (PTPParams *params, unsigned char *a, uint32_t val)
-{
-	if (params->byteorder==PTP_DL_LE)
-		htole32a(a,val);
-	else
-		htobe32a(a,val);
-}
-
-static inline void
-htod64ap (PTPParams *params, unsigned char *a, uint64_t val)
-{
-	if (params->byteorder==PTP_DL_LE)
-		htole64a(a,val);
-	else
-		htobe64a(a,val);
-}
-
-static inline uint16_t
-dtoh16p (PTPParams *params, uint16_t var)
-{
-	return ((params->byteorder==PTP_DL_LE)?le16toh(var):be16toh(var));
-}
-
-static inline uint32_t
-dtoh32p (PTPParams *params, uint32_t var)
-{
-	return ((params->byteorder==PTP_DL_LE)?le32toh(var):be32toh(var));
-}
-
-static inline uint64_t
-dtoh64p (PTPParams *params, uint64_t var)
-{
-	return ((params->byteorder==PTP_DL_LE)?le64toh(var):be64toh(var));
-}
-
-static inline uint16_t
-dtoh16ap (PTPParams *params, const unsigned char *a)
-{
-	return ((params->byteorder==PTP_DL_LE)?le16atoh(a):be16atoh(a));
-}
-
-static inline uint32_t
-dtoh32ap (PTPParams *params, const unsigned char *a)
-{
-	return ((params->byteorder==PTP_DL_LE)?le32atoh(a):be32atoh(a));
-}
-
-static inline uint64_t
-dtoh64ap (PTPParams *params, const unsigned char *a)
-{
-	return ((params->byteorder==PTP_DL_LE)?le64atoh(a):be64atoh(a));
-}
-
-#define htod8a(a,x)	*(uint8_t*)(a) = x
-#define htod16a(a,x)	htod16ap(params,a,x)
-#define htod32a(a,x)	htod32ap(params,a,x)
-#define htod64a(a,x)	htod64ap(params,a,x)
-#define htod16(x)	htod16p(params,x)
-#define htod32(x)	htod32p(params,x)
-#define htod64(x)	htod64p(params,x)
-
-#define dtoh8a(x)	(*(uint8_t*)(x))
-#define dtoh16a(a)	dtoh16ap(params,a)
-#define dtoh32a(a)	dtoh32ap(params,a)
-#define dtoh64a(a)	dtoh64ap(params,a)
-#define dtoh16(x)	dtoh16p(params,x)
-#define dtoh32(x)	dtoh32p(params,x)
-#define dtoh64(x)	dtoh64p(params,x)
-
-static inline uint32_t _post_inc(uint32_t* o, int n)
-{
-	uint32_t res = *o;
-	*o += n;
-	return res;
-}
-
-#define dtoh8o(a, o)	dtoh8a ((a) + _post_inc(&o, sizeof(uint8_t)))
-#define dtoh16o(a, o)	dtoh16a((a) + _post_inc(&o, sizeof(uint16_t)))
-#define dtoh32o(a, o)	dtoh32a((a) + _post_inc(&o, sizeof(uint32_t)))
-#define dtoh64o(a, o)	dtoh64a((a) + _post_inc(&o, sizeof(uint64_t)))
-
-
 /*
  * PTP strings ... if the size field is:
  * size 0  : "empty string" ... we interpret that as string with just \0 terminator, return 1
@@ -433,21 +329,6 @@ ptp_unpack_DI (PTPParams *params, const unsigned char* data, PTPDeviceInfo *di, 
 	return 1;
 }
 
-inline static void
-ptp_free_DI (PTPDeviceInfo *di) {
-	free (di->SerialNumber);
-	free (di->DeviceVersion);
-	free (di->Model);
-	free (di->Manufacturer);
-	free (di->ImageFormats);
-	free (di->CaptureFormats);
-	free (di->VendorExtensionDesc);
-	free (di->OperationsSupported);
-	free (di->EventsSupported);
-	free (di->DevicePropertiesSupported);
-	memset(di, 0, sizeof(*di));
-}
-
 /* EOS Device Info unpack */
 static inline int
 ptp_unpack_EOS_DI (PTPParams *params, const unsigned char* data, PTPCanonEOSDeviceInfo *di, unsigned int datalen)
@@ -461,14 +342,6 @@ ptp_unpack_EOS_DI (PTPParams *params, const unsigned char* data, PTPCanonEOSDevi
 	ptp_unpack_uint32_t_array(params, data, &offset, datalen, &di->unk, &di->unk_len);
 
 	return offset >= 16;
-}
-
-static inline void
-ptp_free_EOS_DI (PTPCanonEOSDeviceInfo *di)
-{
-	free (di->EventsSupported);
-	free (di->DevicePropertiesSupported);
-	free (di->unk);
 }
 
 /* ObjectHandles array pack/unpack */

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -1711,8 +1711,6 @@ _lookup_or_allocate_canon_prop(PTPParams *params, uint16_t proptype)
 	else
 		params->canon_props = malloc(sizeof(params->canon_props[0]));
 	params->canon_props[j].proptype = proptype;
-	params->canon_props[j].size = 0;
-	params->canon_props[j].data = NULL;
 	memset (&params->canon_props[j].dpd,0,sizeof(params->canon_props[j].dpd));
 	params->canon_props[j].dpd.DevicePropertyCode = proptype;
 	params->canon_props[j].dpd.GetSet = 1;
@@ -1962,22 +1960,12 @@ ptp_unpack_CANON_changes (PTPParams *params, const unsigned char* data, unsigned
 			for (j=0;j<params->nrofcanon_props;j++)
 				if (params->canon_props[j].proptype == proptype)
 					break;
-			if (j<params->nrofcanon_props) {
-				if (	(params->canon_props[j].size != size) ||
-					(memcmp(params->canon_props[j].data,xdata,xsize))) {
-					params->canon_props[j].data = realloc(params->canon_props[j].data,xsize);
-					params->canon_props[j].size = size;
-					memcpy (params->canon_props[j].data,xdata,xsize);
-				}
-			} else {
+			if (j == params->nrofcanon_props) {
 				if (j)
 					params->canon_props = realloc(params->canon_props, sizeof(params->canon_props[0])*(j+1));
 				else
 					params->canon_props = malloc(sizeof(params->canon_props[0]));
 				params->canon_props[j].proptype = proptype;
-				params->canon_props[j].size = size;
-				params->canon_props[j].data = malloc(xsize);
-				memcpy(params->canon_props[j].data, xdata, xsize);
 				memset (&params->canon_props[j].dpd,0,sizeof(params->canon_props[j].dpd));
 				params->canon_props[j].dpd.GetSet = 1;
 				params->canon_props[j].dpd.FormFlag = PTP_DPFF_None;

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -1266,7 +1266,7 @@ ptp_unpack_OPL (PTPParams *params, const unsigned char* data, MTPProperties **pp
 #define PTP_ec_Param3		20
 
 static inline void
-ptp_unpack_EC (PTPParams *params, const unsigned char* data, PTPContainer *ec, unsigned int len)
+ptp_unpack_canon_event (PTPParams *params, const unsigned char* data, PTPContainer *ec, unsigned int len)
 {
 	unsigned int	length;
 	int	type;
@@ -1728,7 +1728,7 @@ _lookup_or_allocate_canon_prop(PTPParams *params, uint16_t proptype)
 	} while (0)
 
 static inline int
-ptp_unpack_CANON_changes (PTPParams *params, const unsigned char* data, unsigned int datasize, PTPCanon_changes_entry **pce)
+ptp_unpack_EOS_events (PTPParams *params, const unsigned char* data, unsigned int datasize, PTPCanon_changes_entry **pce)
 {
 	int	i = 0, entries = 0;
 	const unsigned char *curdata = data;

--- a/camlibs/ptp2/ptp-private.h
+++ b/camlibs/ptp2/ptp-private.h
@@ -142,7 +142,7 @@ have_eos_prop(PTPParams *params, uint16_t vendor, uint16_t prop) {
 	if ((params->deviceinfo.VendorExtensionID != PTP_VENDOR_CANON) || (vendor != PTP_VENDOR_CANON))
 		return 0;
 	for (i=0;i<params->nrofcanon_props;i++)
-		if (params->canon_props[i].proptype == prop)
+		if (params->canon_props[i].dpd.DevicePropertyCode == prop)
 			return 1;
 	return 0;
 }

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -3237,7 +3237,7 @@ ptp_canon_checkevent (PTPParams* params, PTPContainer* event, int* isevent)
 	*isevent=0;
 	CHECK_PTP_RC(ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size));
 	if (data && size) { /* check if we had a successful call with data */
-		ptp_unpack_EC(params, data, event, size);
+		ptp_unpack_canon_event(params, data, event, size);
 		*isevent=1;
 		free(data);
 	}
@@ -3877,7 +3877,7 @@ ptp_canon_eos_getevent (PTPParams* params, PTPCanon_changes_entry **entries, int
 	*nrofentries = 0;
 	*entries = NULL;
 	CHECK_PTP_RC(ptp_transaction(params, &ptp, PTP_DP_GETDATA, 0, &data, &size));
-	*nrofentries = ptp_unpack_CANON_changes(params,data,size,entries);
+	*nrofentries = ptp_unpack_EOS_events(params,data,size,entries);
 	free (data);
 	return PTP_RC_OK;
 }

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -3257,27 +3257,22 @@ ptp_add_event_queue (PTPContainer **events, unsigned int *nrevents, PTPContainer
 	(*nrevents)++;
 	return PTP_RC_OK;
 }
-uint16_t
-ptp_add_event (PTPParams *params, PTPContainer *evt)
-{
-	return ptp_add_event_queue (&params->events, &params->nrofevents, evt);
-/*
-	params->events = realloc(params->events, sizeof(PTPContainer)*(params->nrofevents+1));
-	memcpy (&params->events[params->nrofevents],evt,1*sizeof(PTPContainer));
-	params->nrofevents += 1;
 
-	return PTP_RC_OK;
-*/
+uint16_t
+ptp_add_event (PTPParams *params, PTPContainer *event)
+{
+	return ptp_add_events (params, event, 1);
 }
 
 uint16_t
-ptp_add_events (PTPParams *params, PTPContainer *evt, unsigned int nrevents)
+ptp_add_events (PTPParams *params, PTPContainer *events, unsigned int count)
 {
-	unsigned int i;
+	params->events = realloc(params->events, sizeof(PTPContainer)*(count+params->nrofevents));
+	if (!params->events)
+		return PTP_RC_GeneralError;
 
-	for (i=0;i<nrevents;i++) {
-		CHECK_PTP_RC (ptp_add_event_queue (&params->events, &params->nrofevents, &evt[i]));
-	}
+	memcpy (&params->events[params->nrofevents], events, count*sizeof(PTPContainer));
+	params->nrofevents += count;
 	return PTP_RC_OK;
 }
 

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -2117,7 +2117,6 @@ ptp_free_params (PTPParams *params)
 	free (params->storageids.Storage);
 	free (params->events);
 	for (i=0;i<params->nrofcanon_props;i++) {
-		free (params->canon_props[i].data);
 		ptp_free_devicepropdesc (&params->canon_props[i].dpd);
 	}
 	free (params->canon_props);

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -3832,29 +3832,6 @@ ptp_get_one_event_by_type(PTPParams *params, uint16_t code, PTPContainer *event)
 }
 
 /**
- * ptp_have_event:
- *
- * Check if one specific event has appeared in the queue, without draining it.
- *
- * params:	PTPParams*	in: params
- * 		code		in: event code
- *
- * Return values: 1 if removed, 0 if not.
- */
-int
-ptp_have_event(PTPParams *params, uint16_t code)
-{
-	unsigned int i;
-
-	if (!params->nrofevents)
-		return 0;
-	for (i=0;i<params->nrofevents;i++)
-		if (params->events[i].Code == code)
-			return 1;
-	return 0;
-}
-
-/**
  * ptp_canon_eos_getevent:
  *
  * This retrieves configuration status/updates/changes

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -565,6 +565,15 @@ ptp_canon_eos_getdeviceinfo (PTPParams* params, PTPCanonEOSDeviceInfo*di)
 	return ret;
 }
 
+void ptp_canon_eos_free_deviceinfo (PTPCanonEOSDeviceInfo *di)
+{
+	if (!di) return;
+	free (di->EventsSupported);
+	free (di->DevicePropertiesSupported);
+	free (di->unk);
+	memset(di, 0, sizeof(*di));
+}
+
 uint16_t
 ptp_getstreaminfo (PTPParams *params, uint32_t streamid, PTPStreamInfo *si)
 {
@@ -2118,7 +2127,7 @@ ptp_free_params (PTPParams *params)
 		ptp_free_devicepropdesc (&params->deviceproperties[i].desc);
 	free (params->deviceproperties);
 
-	ptp_free_DI (&params->deviceinfo);
+	ptp_free_deviceinfo (&params->deviceinfo);
 }
 
 /**
@@ -6012,6 +6021,23 @@ ptp_property_issupported(PTPParams* params, uint16_t property)
 		if (params->deviceinfo.DevicePropertiesSupported[i]==property)
 			return 1;
 	return 0;
+}
+
+void
+ptp_free_deviceinfo (PTPDeviceInfo *di)
+{
+	if (!di) return;
+	free (di->SerialNumber);
+	free (di->DeviceVersion);
+	free (di->Model);
+	free (di->Manufacturer);
+	free (di->ImageFormats);
+	free (di->CaptureFormats);
+	free (di->VendorExtensionDesc);
+	free (di->OperationsSupported);
+	free (di->EventsSupported);
+	free (di->DevicePropertiesSupported);
+	memset(di, 0, sizeof(*di));
 }
 
 void

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -4139,8 +4139,8 @@ uint16_t ptp_getstream (PTPParams* params, unsigned char **data, unsigned int *s
 uint16_t ptp_check_event (PTPParams *params);
 uint16_t ptp_check_event_queue (PTPParams *params);
 uint16_t ptp_wait_event (PTPParams *params);
-uint16_t ptp_add_event (PTPParams *params, PTPContainer *evt);
-uint16_t ptp_add_events (PTPParams *params, PTPContainer *evt, unsigned int nrevents);
+uint16_t ptp_add_event (PTPParams *params, PTPContainer *event);
+uint16_t ptp_add_events (PTPParams *params, PTPContainer *event, unsigned int count);
 uint16_t ptp_add_event_queue (PTPContainer **events, unsigned int *nrevents, PTPContainer *evt);
 int ptp_get_one_event (PTPParams *params, PTPContainer *evt);
 int ptp_get_one_event_by_type(PTPParams *params, uint16_t code, PTPContainer *event);

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1870,9 +1870,6 @@ struct _PTPCanon_changes_entry {
 typedef struct _PTPCanon_changes_entry PTPCanon_changes_entry;
 
 typedef struct _PTPCanon_Property {
-	uint32_t		proptype;
-
-	/* fill out for queries */
 	PTPDevicePropDesc	dpd;
 } PTPCanon_Property;
 

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -3788,7 +3788,6 @@ typedef struct _PTPObject PTPObject;
 struct _PTPDeviceProperty {
 	time_t			timestamp;
 	PTPDevicePropDesc	desc;
-	PTPPropertyValue	value;
 };
 typedef struct _PTPDeviceProperty PTPDeviceProperty;
 

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1870,9 +1870,7 @@ struct _PTPCanon_changes_entry {
 typedef struct _PTPCanon_changes_entry PTPCanon_changes_entry;
 
 typedef struct _PTPCanon_Property {
-	uint32_t		size;
 	uint32_t		proptype;
-	unsigned char		*data;
 
 	/* fill out for queries */
 	PTPDevicePropDesc	dpd;

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -4142,7 +4142,6 @@ uint16_t ptp_wait_event (PTPParams *params);
 uint16_t ptp_add_event (PTPParams *params, PTPContainer *evt);
 uint16_t ptp_add_events (PTPParams *params, PTPContainer *evt, unsigned int nrevents);
 uint16_t ptp_add_event_queue (PTPContainer **events, unsigned int *nrevents, PTPContainer *evt);
-int ptp_have_event(PTPParams *params, uint16_t code);
 int ptp_get_one_event (PTPParams *params, PTPContainer *evt);
 int ptp_get_one_event_by_type(PTPParams *params, uint16_t code, PTPContainer *event);
 uint16_t ptp_check_eos_events (PTPParams *params);

--- a/camlibs/ptp2/ptpip.c
+++ b/camlibs/ptp2/ptpip.c
@@ -63,14 +63,10 @@
 
 #include "ptp.h"
 #include "ptp-private.h"
+#include "ptp-bugs.h"
 
 #define PTPIP_VERSION_MAJOR 0x0001
 #define PTPIP_VERSION_MINOR 0x0000
-
-#include "ptp.h"
-#include "ptp-bugs.h"
-
-#include "ptp-pack.c"
 
 #define ptpip_len		0
 #define ptpip_type		4

--- a/camlibs/ptp2/usb.c
+++ b/camlibs/ptp2/usb.c
@@ -64,10 +64,6 @@
 /* 100 is not enough for various cameras types. 150 seems to work better */
 #define PTP2_FAST_TIMEOUT       150
 
-/* Pack / unpack functions */
-
-#include "ptp-pack.c"
-
 /* send / receive functions */
 
 uint16_t


### PR DESCRIPTION
This is basically code cosmetic that prepares the removal of `params->canon_props` member and accompanying EOS specific handler functions.