### PR TITLE
PTP symbol naming

### DIFF
--- a/camlibs/lumix/lumix.c
+++ b/camlibs/lumix/lumix.c
@@ -1510,7 +1510,7 @@ add_objectid_and_upload (Camera *camera, CameraFilePath *path, GPContext *contex
 	/*
 	info.file.width         = oi->ImagePixWidth;
 	info.file.height        = oi->ImagePixHeight;
-	info.file.size          = oi->ObjectCompressedSize;
+	info.file.size          = oi->ObjectSize;
 	info.file.mtime         = time(NULL);
 
 	info.preview.fields = GP_FILE_INFO_TYPE |
@@ -1519,7 +1519,7 @@ add_objectid_and_upload (Camera *camera, CameraFilePath *path, GPContext *contex
 	strcpy_mime (info.preview.type, params->deviceinfo.VendorExtensionID, oi->ThumbFormat);
 	info.preview.width      = oi->ThumbPixWidth;
 	info.preview.height     = oi->ThumbPixHeight;
-	info.preview.size       = oi->ThumbCompressedSize;
+	info.preview.size       = oi->ThumbSize;
 	*/
 
 	GP_LOG_D ("setting fileinfo in fs");

--- a/camlibs/ptp2/chdk.c
+++ b/camlibs/ptp2/chdk.c
@@ -992,7 +992,7 @@ chdk_get_onoff(CONFIG_GET_ARGS) {
 	gp_widget_set_name (*widget, menu->name);
 	if (GP_OK != gp_setting_get("ptp2","chdk", buf))
 		strcpy(buf,"off");
-	for (i=0;i<sizeof (chdkonoff)/sizeof (chdkonoff[i]);i++) {
+	for (i=0;i<ARRAYSIZE(chdkonoff);i++) {
 		gp_widget_add_choice (*widget, _(chdkonoff[i].label));
 		if (!strcmp (buf,chdkonoff[i].name))
 			gp_widget_set_value (*widget, _(chdkonoff[i].label));
@@ -1006,7 +1006,7 @@ chdk_put_onoff(CONFIG_PUT_ARGS) {
 	char		*val;
 
 	CR (gp_widget_get_value(widget, &val));
-	for (i=0;i<sizeof(chdkonoff)/sizeof(chdkonoff[i]);i++) {
+	for (i=0;i<ARRAYSIZE(chdkonoff);i++) {
 		if (!strcmp( val, _(chdkonoff[i].label))) {
 			gp_setting_set("ptp2","chdk",chdkonoff[i].name);
 			break;

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -334,7 +334,7 @@ camera_canon_eos_update_capture_target(Camera *camera, GPContext *context, int v
 		if (ct_val.u32 == PTP_CANON_EOS_CAPTUREDEST_HD) {
 			uint16_t	ret;
 #if 0
-			int		uilocked = params->uilocked;
+			int		eos_uilocked = params->eos_uilocked;
 
 			/* if we want to download the image from the device, we need to tell the camera
 			 * that we have enough space left. */
@@ -342,12 +342,12 @@ camera_canon_eos_update_capture_target(Camera *camera, GPContext *context, int v
 			ret = ptp_canon_eos_pchddcapacity(params, 0x7fffffff, 0x00001000, 0x00000001);
 			 */
 
-			if (!uilocked)
+			if (!eos_uilocked)
 				LOG_ON_PTP_E (ptp_canon_eos_setuilock (params));
 #endif
 			ret = ptp_canon_eos_pchddcapacity(params, 0x0fffffff, 0x00001000, 0x00000001);
 #if 0
-			if (!uilocked)
+			if (!eos_uilocked)
 				LOG_ON_PTP_E (ptp_canon_eos_resetuilock (params));
 #endif
 			/* not so bad if its just busy, would also fail later. */
@@ -584,9 +584,9 @@ camera_unprepare_canon_eos_capture(Camera *camera, GPContext *context) {
 	CR (camera_canon_eos_update_capture_target(camera, context, 1));
 
 	if (ptp_operation_issupported(&camera->pl->params, PTP_OC_CANON_EOS_ResetUILock)) {
-		if (params->uilocked) {
+		if (params->eos_uilocked) {
 			LOG_ON_PTP_E (ptp_canon_eos_resetuilock (params));
-			params->uilocked = 0;
+			params->eos_uilocked = 0;
 		}
 	}
 
@@ -10053,13 +10053,13 @@ _put_Canon_EOS_UILock(CONFIG_PUT_ARGS)
 	CR (gp_widget_get_value(widget, &val));
 
 	if (val) {
-		if (!params->uilocked)
+		if (!params->eos_uilocked)
 			C_PTP_REP (ptp_canon_eos_setuilock (params));
-		params->uilocked = 1;
+		params->eos_uilocked = 1;
 	} else {
-		if (params->uilocked)
+		if (params->eos_uilocked)
 			C_PTP_REP (ptp_canon_eos_resetuilock (params));
-		params->uilocked = 0;
+		params->eos_uilocked = 0;
 	}
 	return GP_OK;
 }

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -64,8 +64,8 @@ have_prop(Camera *camera, uint16_t vendor, uint32_t prop) {
 	if (	((prop & 0x7000) == 0x5000) ||
 		(NIKON_1(&camera->pl->params) && ((prop & 0xf000) == 0xf000))
 	) { /* properties */
-		for (i=0; i<camera->pl->params.deviceinfo.DevicePropertiesSupported_len; i++) {
-			if (prop != camera->pl->params.deviceinfo.DevicePropertiesSupported[i])
+		for (i=0; i<camera->pl->params.deviceinfo.DeviceProps_len; i++) {
+			if (prop != camera->pl->params.deviceinfo.DeviceProps[i])
 				continue;
 			if ((prop & 0xf000) == 0x5000) { /* generic property */
 				if (!vendor || (camera->pl->params.deviceinfo.VendorExtensionID==vendor))
@@ -76,9 +76,9 @@ have_prop(Camera *camera, uint16_t vendor, uint32_t prop) {
 		}
 	}
 	if ((prop & 0x7000) == 0x1000) { /* commands */
-		for (i=0; i<camera->pl->params.deviceinfo.OperationsSupported_len; i++) {
+		for (i=0; i<camera->pl->params.deviceinfo.Operations_len; i++) {
 
-			if (prop != camera->pl->params.deviceinfo.OperationsSupported[i])
+			if (prop != camera->pl->params.deviceinfo.Operations[i])
 				continue;
 			if ((prop & 0xf000) == 0x1000) /* generic property */
 				return 1;
@@ -417,10 +417,10 @@ skip:
 		unsigned int i;
 
 		C_PTP (ptp_canon_eos_getdeviceinfo (params, &x));
-		for (i=0;i<x.EventsSupported_len;i++)
-			GP_LOG_D ("event: %04x", x.EventsSupported[i]);
-		for (i=0;i<x.DevicePropertiesSupported_len;i++)
-			GP_LOG_D ("deviceprop: %04x", x.DevicePropertiesSupported[i]);
+		for (i=0;i<x.Events_len;i++)
+			GP_LOG_D ("event: %04x", x.Events[i]);
+		for (i=0;i<x.DeviceProps_len;i++)
+			GP_LOG_D ("deviceprop: %04x", x.DeviceProps[i]);
 		for (i=0;i<x.unk_len;i++)
 			GP_LOG_D ("unk: %04x", x.unk[i]);
 		ptp_canon_eos_free_deviceinfo (&x);
@@ -8860,8 +8860,8 @@ _put_Nikon_Movie(CONFIG_PUT_ARGS)
 
 		C_PTP_REP (ptp_nikon_stopmovie (params));
 
-		for (i=0;i<params->deviceinfo.EventsSupported_len;i++)
-			if (params->deviceinfo.EventsSupported[i] == PTP_EC_Nikon_MovieRecordComplete) {
+		for (i=0;i<params->deviceinfo.Events_len;i++)
+			if (params->deviceinfo.Events[i] == PTP_EC_Nikon_MovieRecordComplete) {
 				havec108 = 1;
 				break;
 			}
@@ -11785,7 +11785,7 @@ _get_config (Camera *camera, const char *confname, CameraWidget **outwidget, Cam
 		}
 	}
 
-	if (!params->deviceinfo.DevicePropertiesSupported_len) {
+	if (!params->deviceinfo.DeviceProps_len) {
 		free (setprops);
 		return GP_OK;
 	}
@@ -11797,8 +11797,8 @@ _get_config (Camera *camera, const char *confname, CameraWidget **outwidget, Cam
 		gp_widget_append (window, section);
 	}
 
-	for (i=0;i<params->deviceinfo.DevicePropertiesSupported_len;i++) {
-		uint16_t		propid = params->deviceinfo.DevicePropertiesSupported[i];
+	for (i=0;i<params->deviceinfo.DeviceProps_len;i++) {
+		uint16_t		propid = params->deviceinfo.DeviceProps[i];
 		char			buf[21], *label;
 		PTPDevicePropDesc	dpd;
 		CameraWidgetType	type;
@@ -12180,14 +12180,14 @@ _set_config (Camera *camera, const char *confname, CameraWidget *window, GPConte
 				return ret;
 		}
 	}
-	if (!params->deviceinfo.DevicePropertiesSupported_len)
+	if (!params->deviceinfo.DeviceProps_len)
 		return GP_OK;
 
 	if (mode == MODE_SET)
 		CR (gp_widget_get_child_by_label (subwindow, _("Other PTP Device Properties"), &section));
 	/* Generic property setter */
-	for (i=0;i<params->deviceinfo.DevicePropertiesSupported_len;i++) {
-		uint16_t		propid = params->deviceinfo.DevicePropertiesSupported[i];
+	for (i=0;i<params->deviceinfo.DeviceProps_len;i++) {
+		uint16_t		propid = params->deviceinfo.DeviceProps[i];
 		CameraWidgetType	type;
 		char			buf[20], *label, *xval;
 		PTPDevicePropDesc	dpd;

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -886,14 +886,14 @@ GENERIC_TABLE(i8, int8_t,  PTP_DTC_INT8)
 static int						\
 _get_##name(CONFIG_GET_ARGS) {				\
 	return _get_Genericu16Table(CONFIG_GET_NAMES,	\
-		tbl,sizeof(tbl)/sizeof(tbl[0])		\
+		tbl,ARRAYSIZE(tbl)		\
 	);						\
 }							\
 							\
 static int __unused__					\
 _put_##name(CONFIG_PUT_ARGS) {				\
 	return _put_Genericu16Table(CONFIG_PUT_NAMES,	\
-		tbl,sizeof(tbl)/sizeof(tbl[0])		\
+		tbl,ARRAYSIZE(tbl)		\
 	);						\
 }
 
@@ -901,14 +901,14 @@ _put_##name(CONFIG_PUT_ARGS) {				\
 static int						\
 _get_##name(CONFIG_GET_ARGS) {				\
 	return _get_Genericu32Table(CONFIG_GET_NAMES,	\
-		tbl,sizeof(tbl)/sizeof(tbl[0])		\
+		tbl,ARRAYSIZE(tbl)		\
 	);						\
 }							\
 							\
 static int __unused__					\
 _put_##name(CONFIG_PUT_ARGS) {				\
 	return _put_Genericu32Table(CONFIG_PUT_NAMES,	\
-		tbl,sizeof(tbl)/sizeof(tbl[0])		\
+		tbl,ARRAYSIZE(tbl)		\
 	);						\
 }
 
@@ -916,14 +916,14 @@ _put_##name(CONFIG_PUT_ARGS) {				\
 static int						\
 _get_##name(CONFIG_GET_ARGS) {				\
 	return _get_Generici16Table(CONFIG_GET_NAMES,	\
-		tbl,sizeof(tbl)/sizeof(tbl[0])		\
+		tbl,ARRAYSIZE(tbl)		\
 	);						\
 }							\
 							\
 static int __unused__					\
 _put_##name(CONFIG_PUT_ARGS) {				\
 	return _put_Generici16Table(CONFIG_PUT_NAMES,	\
-		tbl,sizeof(tbl)/sizeof(tbl[0])		\
+		tbl,ARRAYSIZE(tbl)		\
 	);						\
 }
 
@@ -931,14 +931,14 @@ _put_##name(CONFIG_PUT_ARGS) {				\
 static int						\
 _get_##name(CONFIG_GET_ARGS) {				\
 	return _get_Genericu8Table(CONFIG_GET_NAMES,	\
-		tbl,sizeof(tbl)/sizeof(tbl[0])		\
+		tbl,ARRAYSIZE(tbl)		\
 	);						\
 }							\
 							\
 static int __unused__					\
 _put_##name(CONFIG_PUT_ARGS) {				\
 	return _put_Genericu8Table(CONFIG_PUT_NAMES,	\
-		tbl,sizeof(tbl)/sizeof(tbl[0])		\
+		tbl,ARRAYSIZE(tbl)		\
 	);						\
 }
 
@@ -946,14 +946,14 @@ _put_##name(CONFIG_PUT_ARGS) {				\
 static int						\
 _get_##name(CONFIG_GET_ARGS) {				\
 	return _get_Generici8Table(CONFIG_GET_NAMES,	\
-		tbl,sizeof(tbl)/sizeof(tbl[0])		\
+		tbl,ARRAYSIZE(tbl)		\
 	);						\
 }							\
 							\
 static int __unused__					\
 _put_##name(CONFIG_PUT_ARGS) {				\
 	return _put_Generici8Table(CONFIG_PUT_NAMES,	\
-		tbl,sizeof(tbl)/sizeof(tbl[0])		\
+		tbl,ARRAYSIZE(tbl)		\
 	);						\
 }
 
@@ -3646,7 +3646,7 @@ _get_Sony_FNumber(CONFIG_GET_ARGS) {
 	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
 	gp_widget_set_name (*widget, menu->name);
 
-	for (i=0;i<sizeof(sony_fnumbers)/sizeof(sony_fnumbers[0]); i++) {
+	for (i=0;i<ARRAYSIZE(sony_fnumbers); i++) {
 		sprintf(buf,"f/%g",sony_fnumbers[i]/100.0);
 		gp_widget_add_choice (*widget,buf);
 		if (sony_fnumbers[i] == dpd->CurrentValue.u16) {
@@ -4482,7 +4482,7 @@ _get_Canon_CameraOrientation(CONFIG_GET_ARGS) {
 		return (GP_ERROR);
 	gp_widget_new (GP_WIDGET_TEXT, _(menu->label), widget);
 	gp_widget_set_name (*widget, menu->name);
-	for (i=0;i<sizeof(canon_orientation)/sizeof(canon_orientation[0]);i++) {
+	for (i=0;i<ARRAYSIZE(canon_orientation);i++) {
 		if (canon_orientation[i].value != dpd->CurrentValue.u16)
 			continue;
 		gp_widget_set_value (*widget, canon_orientation[i].label);
@@ -5108,7 +5108,7 @@ _get_SigmaFP_Aperture(CONFIG_GET_ARGS) {
 	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
 	gp_widget_set_name (*widget, menu->name);
 
-	for (i=0;i<sizeof(sigma_apertures)/sizeof(sigma_apertures[0]);i++) {
+	for (i=0;i<ARRAYSIZE(sigma_apertures);i++) {
 		gp_widget_add_choice (*widget, _(sigma_apertures[i].val));
 		if (aperture == sigma_apertures[i].numval) {
 			gp_widget_set_value (*widget, _(sigma_apertures[i].val));
@@ -5133,7 +5133,7 @@ _put_SigmaFP_Aperture(CONFIG_PUT_ARGS) {
 	gp_widget_get_value (widget, &value_str);
 	memset(datagrp1,0,sizeof(datagrp1));
 
-	for (i=0;i<sizeof(sigma_apertures)/sizeof(sigma_apertures[0]);i++) {
+	for (i=0;i<ARRAYSIZE(sigma_apertures);i++) {
 		if (!strcmp(value_str,_(sigma_apertures[i].val))) {
 			aperture = sigma_apertures[i].numval;
 			valfound = 1;
@@ -5254,7 +5254,7 @@ _get_SigmaFP_ShutterSpeed(CONFIG_GET_ARGS) {
 	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
 	gp_widget_set_name (*widget, menu->name);
 
-	for (i=0;i<sizeof(sigma_shutterspeeds)/sizeof(sigma_shutterspeeds[0]);i++) {
+	for (i=0;i<ARRAYSIZE(sigma_shutterspeeds);i++) {
 		gp_widget_add_choice (*widget, _(sigma_shutterspeeds[i].val));
 		if (shutterspeed == sigma_shutterspeeds[i].numval) {
 			gp_widget_set_value (*widget, _(sigma_shutterspeeds[i].val));
@@ -5279,7 +5279,7 @@ _put_SigmaFP_ShutterSpeed(CONFIG_PUT_ARGS) {
 	gp_widget_get_value (widget, &value_str);
 	memset(datagrp1,0,sizeof(datagrp1));
 
-	for (i=0;i<sizeof(sigma_shutterspeeds)/sizeof(sigma_shutterspeeds[0]);i++) {
+	for (i=0;i<ARRAYSIZE(sigma_shutterspeeds);i++) {
 		if (!strcmp(value_str,_(sigma_shutterspeeds[i].val))) {
 			shutterspeed = sigma_shutterspeeds[i].numval;
 			valfound = 1;
@@ -5412,7 +5412,7 @@ _get_Sony_ShutterSpeed(CONFIG_GET_ARGS) {
 	} else {
 		unsigned int i;
 		/* use our static table */
-		for (i=0;i<sizeof(sony_shuttertable)/sizeof(sony_shuttertable[0]);i++) {
+		for (i=0;i<ARRAYSIZE(sony_shuttertable);i++) {
 			x = sony_shuttertable[i].dividend;
 			y = sony_shuttertable[i].divisor;
 			if (y == 1)
@@ -5500,9 +5500,9 @@ _put_Sony_ShutterSpeed(CONFIG_PUT_ARGS) {
 	}
 
 	if (direction == 1) {
-		position_new = sizeof(sony_shuttertable)/sizeof(sony_shuttertable[0])-1;
+		position_new = ARRAYSIZE(sony_shuttertable)-1;
 
-		for (i=0;i<sizeof(sony_shuttertable)/sizeof(sony_shuttertable[0]);i++) {
+		for (i=0;i<ARRAYSIZE(sony_shuttertable);i++) {
 			a = sony_shuttertable[i].dividend;
 			b = sony_shuttertable[i].divisor;
 			position_new = i;
@@ -5512,7 +5512,7 @@ _put_Sony_ShutterSpeed(CONFIG_PUT_ARGS) {
 	} else {
 		position_new = 0;
 
-		for (i=sizeof(sony_shuttertable)/sizeof(sony_shuttertable[0])-1;i--;) {
+		for (i=ARRAYSIZE(sony_shuttertable)-1;i--;) {
 			a = sony_shuttertable[i].dividend;
 			b = sony_shuttertable[i].divisor;
 			position_new = i;
@@ -5526,7 +5526,7 @@ _put_Sony_ShutterSpeed(CONFIG_PUT_ARGS) {
 		if (old == new)
 			break;
 
-		for (i=0;i<sizeof(sony_shuttertable)/sizeof(sony_shuttertable[0]);i++) {
+		for (i=0;i<ARRAYSIZE(sony_shuttertable);i++) {
 			a = sony_shuttertable[i].dividend;
 			b = sony_shuttertable[i].divisor;
 			position_current = i;
@@ -9500,7 +9500,7 @@ _put_Panasonic_AFMode(CONFIG_PUT_ARGS)
 
 	CR (gp_widget_get_value(widget, &xval));
 
-	for (i=0;i<sizeof(panasonic_aftable)/sizeof(panasonic_aftable[0]);i++) {
+	for (i=0;i<ARRAYSIZE(panasonic_aftable);i++) {
 		if (!strcmp(panasonic_aftable[i].str, xval)) {
 			val = panasonic_aftable[i].val;
 			found = 1;
@@ -9531,7 +9531,7 @@ _get_Panasonic_AFMode(CONFIG_GET_ARGS) {
 	gp_widget_set_name (*widget, menu->name);
 
 	for (i = 0; i < listCount; i++) {
-		for (j=0;j<sizeof(panasonic_aftable)/sizeof(panasonic_aftable[0]);j++) {
+		for (j=0;j<ARRAYSIZE(panasonic_aftable);j++) {
 		sprintf(buf,"%d", list[i]);
 		if ((list[i] == currentVal) && (j == currentVal)) {
 			gp_widget_set_value (*widget, panasonic_aftable[j].str);
@@ -9540,7 +9540,7 @@ _get_Panasonic_AFMode(CONFIG_GET_ARGS) {
 		}
 		}
 	}
-	for (j=0;j<sizeof(panasonic_aftable)/sizeof(panasonic_aftable[0]);j++) {
+	for (j=0;j<ARRAYSIZE(panasonic_aftable);j++) {
 		gp_widget_add_choice (*widget, panasonic_aftable[j].str);
 	}
 	free(list);
@@ -9572,7 +9572,7 @@ _put_Panasonic_MFAdjust(CONFIG_PUT_ARGS)
 	uint32_t i;
 
 	CR (gp_widget_get_value(widget, &xval));
-	for (i=0;i<sizeof(panasonic_mftable)/sizeof(panasonic_mftable[0]);i++) {
+	for (i=0;i<ARRAYSIZE(panasonic_mftable);i++) {
 		if(!strcmp(panasonic_mftable[i].str, xval)) {
 		val = panasonic_mftable[i].val;
 		break;
@@ -9588,7 +9588,7 @@ _get_Panasonic_MFAdjust(CONFIG_GET_ARGS) {
 	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
 	gp_widget_set_name (*widget,menu->name);
 
-	for (i=0;i<sizeof(panasonic_mftable)/sizeof(panasonic_mftable[0]);i++) {
+	for (i=0;i<ARRAYSIZE(panasonic_mftable);i++) {
 		gp_widget_add_choice (*widget, panasonic_mftable[i].str);
 	}
 	gp_widget_set_value (*widget, _("None"));
@@ -9625,12 +9625,12 @@ _get_Panasonic_ExpMode(CONFIG_GET_ARGS) {
 	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
 	gp_widget_set_name (*widget, menu->name);
 
-	for (j=0;j<sizeof(panasonic_rmodetable)/sizeof(panasonic_rmodetable[0]);j++) {
+	for (j=0;j<ARRAYSIZE(panasonic_rmodetable);j++) {
 		gp_widget_add_choice (*widget, panasonic_rmodetable[j].str);
 	}
 
 	for (i = 0; i < listCount; i++) {
-		for (j=0;j<sizeof(panasonic_rmodetable)/sizeof(panasonic_rmodetable[0]);j++) {
+		for (j=0;j<ARRAYSIZE(panasonic_rmodetable);j++) {
 			sprintf(buf,"%d", list[i]);
 			if ((list[i] == currentVal) && (j == currentVal)) {
 				gp_widget_set_value (*widget, panasonic_rmodetable[j].str);
@@ -9656,7 +9656,7 @@ _put_Panasonic_ExpMode(CONFIG_PUT_ARGS)
 	uint32_t i;
 
 	CR (gp_widget_get_value(widget, &xval));
-	for (i=0;i<sizeof(panasonic_rmodetable)/sizeof(panasonic_rmodetable[0]);i++) {
+	for (i=0;i<ARRAYSIZE(panasonic_rmodetable);i++) {
 		if(!strcmp(panasonic_rmodetable[i].str, xval)) {
 			val = panasonic_rmodetable[i].val;
 			break;
@@ -9695,7 +9695,7 @@ _get_Panasonic_Recording(CONFIG_GET_ARGS) {
 	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
 	gp_widget_set_name (*widget, menu->name);
 
-	for(i = 0; i < sizeof(panasonic_recordtable) / sizeof(panasonic_recordtable[0]); i++) {
+	for(i = 0; i < ARRAYSIZE(panasonic_recordtable); i++) {
 		if (currentVal == panasonic_recordtable[i].val) {
 			strcpy(buf, panasonic_recordtable[i].str);
 		}
@@ -9741,7 +9741,7 @@ _put_Panasonic_Whitebalance(CONFIG_PUT_ARGS)
 
 	if (sscanf(xval,_("Unknown 0x%04x"), &ival))
 		val = ival;
-	for (j=0;j<sizeof(panasonic_wbtable)/sizeof(panasonic_wbtable[0]);j++) {
+	for (j=0;j<ARRAYSIZE(panasonic_wbtable);j++) {
 		if (!strcmp(xval,_(panasonic_wbtable[j].str))) {
 			val = panasonic_wbtable[j].val;
 			break;
@@ -9772,7 +9772,7 @@ _get_Panasonic_Whitebalance(CONFIG_GET_ARGS) {
 
 	for (i = 0; i < listCount; i++) {
 		sprintf(buf,_("Unknown 0x%04x"), list[i]);
-		for (j=0;j<sizeof(panasonic_wbtable)/sizeof(panasonic_wbtable[0]);j++) {
+		for (j=0;j<ARRAYSIZE(panasonic_wbtable);j++) {
 			if (panasonic_wbtable[j].val == list[i]) {
 				strcpy(buf,_(panasonic_wbtable[j].str));
 				break;
@@ -10161,7 +10161,7 @@ _get_CaptureTarget(CONFIG_GET_ARGS) {
 	if (GP_OK != gp_setting_get("ptp2","capturetarget", buf))
 		strcpy(buf,"sdram");
 
-	for (i=0;i<sizeof (capturetargets)/sizeof (capturetargets[i]);i++) {
+	for (i=0;i<ARRAYSIZE(capturetargets);i++) {
 		gp_widget_add_choice (*widget, _(capturetargets[i].label));
 		if (!strcmp (buf,capturetargets[i].name))
 			gp_widget_set_value (*widget, _(capturetargets[i].label));
@@ -10178,7 +10178,7 @@ _put_CaptureTarget(CONFIG_PUT_ARGS) {
 	char		buf[1024];
 
 	CR (gp_widget_get_value(widget, &val));
-	for (i=0;i<sizeof(capturetargets)/sizeof(capturetargets[i]);i++) {
+	for (i=0;i<ARRAYSIZE(capturetargets);i++) {
 		if (!strcmp( val, _(capturetargets[i].label))) {
 			gp_setting_set("ptp2","capturetarget",capturetargets[i].name);
 			break;
@@ -10272,7 +10272,7 @@ _get_CHDK(CONFIG_GET_ARGS) {
 	gp_widget_set_name (*widget, menu->name);
 	if (GP_OK != gp_setting_get("ptp2","chdk", buf))
 		strcpy(buf,"off");
-	for (i=0;i<sizeof (chdkonoff)/sizeof (chdkonoff[i]);i++) {
+	for (i=0;i<ARRAYSIZE(chdkonoff);i++) {
 		gp_widget_add_choice (*widget, _(chdkonoff[i].label));
 		if (!strcmp (buf,chdkonoff[i].name))
 			gp_widget_set_value (*widget, _(chdkonoff[i].label));
@@ -10286,7 +10286,7 @@ _put_CHDK(CONFIG_PUT_ARGS) {
 	char *val;
 
 	CR (gp_widget_get_value(widget, &val));
-	for (i=0;i<sizeof(chdkonoff)/sizeof(chdkonoff[i]);i++) {
+	for (i=0;i<ARRAYSIZE(chdkonoff);i++) {
 		if (!strcmp( val, _(chdkonoff[i].label))) {
 			gp_setting_set("ptp2","chdk",chdkonoff[i].name);
 			break;
@@ -10332,7 +10332,7 @@ _get_Autofocus(CONFIG_GET_ARGS) {
 	gp_widget_set_name (*widget, menu->name);
 	if (GP_OK != gp_setting_get("ptp2","autofocus", buf))
 		strcpy(buf,"on");
-	for (i=0;i<sizeof (afonoff)/sizeof (afonoff[i]);i++) {
+	for (i=0;i<ARRAYSIZE(afonoff);i++) {
 		gp_widget_add_choice (*widget, _(afonoff[i].label));
 		if (!strcmp (buf,afonoff[i].name))
 			gp_widget_set_value (*widget, _(afonoff[i].label));
@@ -10346,7 +10346,7 @@ _put_Autofocus(CONFIG_PUT_ARGS) {
 	char *val;
 
 	CR (gp_widget_get_value(widget, &val));
-	for (i=0;i<sizeof(afonoff)/sizeof(afonoff[i]);i++) {
+	for (i=0;i<ARRAYSIZE(afonoff);i++) {
 		if (!strcmp( val, _(afonoff[i].label))) {
 			gp_setting_set("ptp2","autofocus",afonoff[i].name);
 			break;
@@ -11589,7 +11589,7 @@ _get_config (Camera *camera, const char *confname, CameraWidget **outwidget, Cam
 		*outwidget = window;
 	}
 
-	for (menuno = 0; menuno < sizeof(menus)/sizeof(menus[0]) ; menuno++ ) {
+	for (menuno = 0; menuno < ARRAYSIZE(menus) ; menuno++ ) {
 		if (!menus[menuno].submenus) { /* Custom menu */
 			if (mode == MODE_GET) {
 				struct menu *cur = menus+menuno;
@@ -12031,7 +12031,7 @@ _set_config (Camera *camera, const char *confname, CameraWidget *window, GPConte
 
 	if (mode == MODE_SET)
 		CR (gp_widget_get_child_by_label (window, _("Camera and Driver Configuration"), &subwindow));
-	for (menuno = 0; menuno < sizeof(menus)/sizeof(menus[0]) ; menuno++ ) {
+	for (menuno = 0; menuno < ARRAYSIZE(menus) ; menuno++ ) {
 		if (mode == MODE_SET) {
 			ret = gp_widget_get_child_by_label (subwindow, _(menus[menuno].label), &section);
 			if (ret != GP_OK)
@@ -12307,7 +12307,7 @@ camera_lookup_by_property(Camera *camera, PTPDevicePropDesc *dpd, char **name, c
 	memset (&ab, 0, sizeof(ab));
 	gp_camera_get_abilities (camera, &ab);
 
-	for (menuno = 0; menuno < sizeof(menus)/sizeof(menus[0]) ; menuno++ ) {
+	for (menuno = 0; menuno < ARRAYSIZE(menus) ; menuno++ ) {
 		if (!menus[menuno].submenus) { /* Custom menu ... not exposed to by-property method */
 			continue;
 		}

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -1623,7 +1623,7 @@ _put_Sony_ExpCompensation(CONFIG_PUT_ARGS) {
 	ret = _put_ExpCompensation(CONFIG_PUT_NAMES);
 	if (ret != GP_OK) return ret;
 	*alreadyset = 1;
-	return _put_sony_value_i16 (&camera->pl->params, dpd->DevicePropertyCode, propval->i16, 0);
+	return _put_sony_value_i16 (&camera->pl->params, dpd->DevicePropCode, propval->i16, 0);
 }
 
 /* new method, can set directly */
@@ -1634,7 +1634,7 @@ _put_Sony_ExpCompensation2(CONFIG_PUT_ARGS) {
 	ret = _put_ExpCompensation(CONFIG_PUT_NAMES);
 	if (ret != GP_OK) return ret;
 	*alreadyset = 1;
-	return translate_ptp_result (ptp_sony_setdevicecontrolvaluea (&camera->pl->params, dpd->DevicePropertyCode, propval, PTP_DTC_INT16));
+	return translate_ptp_result (ptp_sony_setdevicecontrolvaluea (&camera->pl->params, dpd->DevicePropCode, propval, PTP_DTC_INT16));
 }
 
 static int
@@ -3341,7 +3341,7 @@ _put_Sony_ISO(CONFIG_PUT_ARGS)
 	propval->u32 = raw_iso;
 	*alreadyset = 1;
 
-	return _put_sony_value_u32(params, dpd->DevicePropertyCode, raw_iso, 1);
+	return _put_sony_value_u32(params, dpd->DevicePropCode, raw_iso, 1);
 }
 
 /* new method, can just set the value via setcontroldevicea */
@@ -3358,7 +3358,7 @@ _put_Sony_ISO2(CONFIG_PUT_ARGS)
 	propval->u32 = raw_iso;
 
 	*alreadyset = 1;
-	return translate_ptp_result (ptp_sony_setdevicecontrolvaluea(params, dpd->DevicePropertyCode, propval, PTP_DTC_UINT32));
+	return translate_ptp_result (ptp_sony_setdevicecontrolvaluea(params, dpd->DevicePropCode, propval, PTP_DTC_UINT32));
 }
 
 static int
@@ -3386,7 +3386,7 @@ _put_Sony_QX_ISO(CONFIG_PUT_ARGS)
 setiso:
 	propval->u32 = u;
 
-	/*return translate_ptp_result (ptp_sony_qx_setdevicecontrolvaluea(params, dpd->DevicePropertyCode, propval, PTP_DTC_UINT32));*/
+	/*return translate_ptp_result (ptp_sony_qx_setdevicecontrolvaluea(params, dpd->DevicePropCode, propval, PTP_DTC_UINT32));*/
 
 	return GP_OK; /* will be set by generic code */
 }
@@ -5555,7 +5555,7 @@ _put_Sony_ShutterSpeed(CONFIG_PUT_ARGS) {
 
 		a = dpd->CurrentValue.u32>>16;
 		b = dpd->CurrentValue.u32&0xffff;
-		C_PTP_REP (ptp_sony_setdevicecontrolvalueb (params, dpd->DevicePropertyCode, &value, PTP_DTC_UINT8 ));
+		C_PTP_REP (ptp_sony_setdevicecontrolvalueb (params, dpd->DevicePropCode, &value, PTP_DTC_UINT8 ));
 
 		GP_LOG_D ("shutterspeed value is (0x%x vs target 0x%x)", origval, new32);
 
@@ -5563,7 +5563,7 @@ _put_Sony_ShutterSpeed(CONFIG_PUT_ARGS) {
 		time(&start);
 		do {
 			C_PTP_REP (ptp_sony_getalldevicepropdesc (params));
-			C_PTP_REP (ptp_generic_getdevicepropdesc (params, dpd->DevicePropertyCode, dpd));
+			C_PTP_REP (ptp_generic_getdevicepropdesc (params, dpd->DevicePropCode, dpd));
 
 			if (dpd->CurrentValue.u32 == new32) {
 				GP_LOG_D ("Value matched!");
@@ -9137,7 +9137,7 @@ _put_Sony_FocusMagnifyProp(CONFIG_PUT_ARGS)
 	CR (gp_widget_get_value(widget, &val));
 	xpropval.u16 = val ? 2 : 1;
 
-	C_PTP (ptp_sony_setdevicecontrolvalueb (params, dpd->DevicePropertyCode, &xpropval, PTP_DTC_UINT16));
+	C_PTP (ptp_sony_setdevicecontrolvalueb (params, dpd->DevicePropCode, &xpropval, PTP_DTC_UINT16));
 	*alreadyset = 1;
 	return GP_OK;
 }
@@ -12296,7 +12296,7 @@ camera_lookup_by_property(Camera *camera, PTPDevicePropDesc *dpd, char **name, c
 	int 		ret;
 	PTPParams	*params = &camera->pl->params;
 	CameraAbilities	ab;
-	uint32_t	propid = dpd->DevicePropertyCode;
+	uint32_t	propid = dpd->DevicePropCode;
 	CameraWidget	*widget;
 
 	*name = NULL;

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -774,8 +774,8 @@ _get_Generic##bits##Table(CONFIG_GET_ARGS, struct deviceproptable##bits * tbl, i
 	} \
 	if (dpd->FormFlag & PTP_DPFF_Range) { \
 		type r;	\
-		for (	r = dpd->FORM.Range.MinimumValue.bits; \
-			r<=dpd->FORM.Range.MaximumValue.bits; \
+		for (	r = dpd->FORM.Range.MinValue.bits; \
+			r<=dpd->FORM.Range.MaxValue.bits; \
 			r+= dpd->FORM.Range.StepSize.bits \
 		) { \
 			isset = FALSE; \
@@ -1041,7 +1041,7 @@ _get_Range_INT8(CONFIG_GET_ARGS) {
 	gp_widget_new (GP_WIDGET_RANGE, _(menu->label), widget);
 	gp_widget_set_name ( *widget, menu->name);
 	CurrentValue = (float) dpd->CurrentValue.i8;
-	gp_widget_set_range ( *widget, (float) dpd->FORM.Range.MinimumValue.i8, (float) dpd->FORM.Range.MaximumValue.i8, (float) dpd->FORM.Range.StepSize.i8);
+	gp_widget_set_range ( *widget, (float) dpd->FORM.Range.MinValue.i8, (float) dpd->FORM.Range.MaxValue.i8, (float) dpd->FORM.Range.StepSize.i8);
 	gp_widget_set_value ( *widget, &CurrentValue);
 	return (GP_OK);
 }
@@ -1067,7 +1067,7 @@ _get_Range_UINT8(CONFIG_GET_ARGS) {
 	gp_widget_new (GP_WIDGET_RANGE, _(menu->label), widget);
 	gp_widget_set_name ( *widget, menu->name);
 	CurrentValue = (float) dpd->CurrentValue.u8;
-	gp_widget_set_range ( *widget, (float) dpd->FORM.Range.MinimumValue.u8, (float) dpd->FORM.Range.MaximumValue.u8, (float) dpd->FORM.Range.StepSize.u8);
+	gp_widget_set_range ( *widget, (float) dpd->FORM.Range.MinValue.u8, (float) dpd->FORM.Range.MaxValue.u8, (float) dpd->FORM.Range.StepSize.u8);
 	gp_widget_set_value ( *widget, &CurrentValue);
 	return (GP_OK);
 }
@@ -1145,7 +1145,7 @@ _get_INT(CONFIG_GET_ARGS) {
 	if (dpd->FormFlag == PTP_DPFF_Range) {
 		float b = 0, t = 0, s = 0;
 
-#define X(type,u) case type: b = (float)dpd->FORM.Range.MinimumValue.u; t = (float)dpd->FORM.Range.MaximumValue.u; s = (float)dpd->FORM.Range.StepSize.u; break;
+#define X(type,u) case type: b = (float)dpd->FORM.Range.MinValue.u; t = (float)dpd->FORM.Range.MaxValue.u; s = (float)dpd->FORM.Range.StepSize.u; break;
 		switch (dpd->DataType) {
 		X(PTP_DTC_UINT32,u32)
 		X(PTP_DTC_INT32,i32)
@@ -1708,8 +1708,8 @@ _get_Canon_ZoomRange(CONFIG_GET_ARGS) {
 	gp_widget_new (GP_WIDGET_RANGE, _(menu->label), widget);
 	gp_widget_set_name (*widget,menu->name);
 	f = (float)dpd->CurrentValue.u16;
-	b = (float)dpd->FORM.Range.MinimumValue.u16;
-	t = (float)dpd->FORM.Range.MaximumValue.u16;
+	b = (float)dpd->FORM.Range.MinValue.u16;
+	t = (float)dpd->FORM.Range.MaxValue.u16;
 	s = (float)dpd->FORM.Range.StepSize.u16;
 	gp_widget_set_range (*widget, b, t, s);
 	gp_widget_set_value (*widget, &f);
@@ -1768,8 +1768,8 @@ _get_Sony_Zoom(CONFIG_GET_ARGS) {
 	gp_widget_new (GP_WIDGET_RANGE, _(menu->label), widget);
 	gp_widget_set_name (*widget,menu->name);
 	f = (float)dpd->CurrentValue.u32 / 1000000;
-	b = (float)dpd->FORM.Range.MinimumValue.u32 / 1000000;
-	t = (float)dpd->FORM.Range.MaximumValue.u32 / 1000000;
+	b = (float)dpd->FORM.Range.MinValue.u32 / 1000000;
+	t = (float)dpd->FORM.Range.MaxValue.u32 / 1000000;
 	s = 1;
 	gp_widget_set_range (*widget, b, t, s);
 	gp_widget_set_value (*widget, &f);
@@ -1799,8 +1799,8 @@ _get_Nikon_WBBias(CONFIG_GET_ARGS) {
 	gp_widget_new (GP_WIDGET_RANGE, _(menu->label), widget);
 	gp_widget_set_name (*widget,menu->name);
 	f = (float)dpd->CurrentValue.i8;
-	b = (float)dpd->FORM.Range.MinimumValue.i8;
-	t = (float)dpd->FORM.Range.MaximumValue.i8;
+	b = (float)dpd->FORM.Range.MinValue.i8;
+	t = (float)dpd->FORM.Range.MaxValue.i8;
 	s = (float)dpd->FORM.Range.StepSize.i8;
 	gp_widget_set_range (*widget, b, t, s);
 	gp_widget_set_value (*widget, &f);
@@ -1829,20 +1829,20 @@ _get_Nikon_UWBBias(CONFIG_GET_ARGS) {
 	switch (dpd->DataType) {
 	case PTP_DTC_UINT16:
 		f = (float)dpd->CurrentValue.u16;
-		b = (float)dpd->FORM.Range.MinimumValue.u16;
-		t = (float)dpd->FORM.Range.MaximumValue.u16;
+		b = (float)dpd->FORM.Range.MinValue.u16;
+		t = (float)dpd->FORM.Range.MaxValue.u16;
 		s = (float)dpd->FORM.Range.StepSize.u16;
 		break;
 	case PTP_DTC_UINT8:
 		f = (float)dpd->CurrentValue.u8;
-		b = (float)dpd->FORM.Range.MinimumValue.u8;
-		t = (float)dpd->FORM.Range.MaximumValue.u8;
+		b = (float)dpd->FORM.Range.MinValue.u8;
+		t = (float)dpd->FORM.Range.MaxValue.u8;
 		s = (float)dpd->FORM.Range.StepSize.u8;
 		break;
 	case PTP_DTC_INT8:
 		f = (float)dpd->CurrentValue.i8;
-		b = (float)dpd->FORM.Range.MinimumValue.i8;
-		t = (float)dpd->FORM.Range.MaximumValue.i8;
+		b = (float)dpd->FORM.Range.MinValue.i8;
+		t = (float)dpd->FORM.Range.MaxValue.i8;
 		s = (float)dpd->FORM.Range.StepSize.i8;
 		break;
 	default:
@@ -1892,7 +1892,7 @@ _get_Nikon_WBBiasPreset(CONFIG_GET_ARGS) {
 		return (GP_ERROR);
 	gp_widget_new (GP_WIDGET_RADIO, _(menu->label), widget);
 	gp_widget_set_name (*widget,menu->name);
-	for (i = dpd->FORM.Range.MinimumValue.u8; i < dpd->FORM.Range.MaximumValue.u8; i++) {
+	for (i = dpd->FORM.Range.MinValue.u8; i < dpd->FORM.Range.MaxValue.u8; i++) {
 		sprintf (buf, "%d", i);
 		gp_widget_add_choice (*widget, buf);
 		if (i == dpd->CurrentValue.u8)
@@ -1922,8 +1922,8 @@ _get_Nikon_HueAdjustment(CONFIG_GET_ARGS) {
 		gp_widget_new (GP_WIDGET_RANGE, _(menu->label), widget);
 		gp_widget_set_name (*widget,menu->name);
 		f = (float)dpd->CurrentValue.i8;
-		b = (float)dpd->FORM.Range.MinimumValue.i8;
-		t = (float)dpd->FORM.Range.MaximumValue.i8;
+		b = (float)dpd->FORM.Range.MinValue.i8;
+		t = (float)dpd->FORM.Range.MaxValue.i8;
 		s = (float)dpd->FORM.Range.StepSize.i8;
 		gp_widget_set_range (*widget, b, t, s);
 		gp_widget_set_value (*widget, &f);
@@ -3466,12 +3466,12 @@ _get_Milliseconds(CONFIG_GET_ARGS) {
 		unsigned int s;
 
 		if (dpd->DataType == PTP_DTC_UINT32) {
-			min = dpd->FORM.Range.MinimumValue.u32;
-			max = dpd->FORM.Range.MaximumValue.u32;
+			min = dpd->FORM.Range.MinValue.u32;
+			max = dpd->FORM.Range.MaxValue.u32;
 			s = dpd->FORM.Range.StepSize.u32;
 		} else {
-			min = dpd->FORM.Range.MinimumValue.u16;
-			max = dpd->FORM.Range.MaximumValue.u16;
+			min = dpd->FORM.Range.MinValue.u16;
+			max = dpd->FORM.Range.MaxValue.u16;
 			s = dpd->FORM.Range.StepSize.u16;
 		}
 		for (i=min; i<=max; i+=s) {
@@ -3540,8 +3540,8 @@ _get_FNumber(CONFIG_GET_ARGS) {
 		gp_widget_new (GP_WIDGET_RANGE, _(menu->label), widget);
 		gp_widget_set_name (*widget, menu->name);
 		gp_widget_set_range (*widget,
-				dpd->FORM.Range.MinimumValue.u16/100.0,
-				dpd->FORM.Range.MaximumValue.u16/100.0,
+				dpd->FORM.Range.MinValue.u16/100.0,
+				dpd->FORM.Range.MaxValue.u16/100.0,
 				dpd->FORM.Range.StepSize.u16/100.0
 				);
 		value_float = dpd->CurrentValue.u16/100.0;
@@ -3800,8 +3800,8 @@ _get_Video_Framerate(CONFIG_GET_ARGS) {
 	if (dpd->FormFlag == PTP_DPFF_Range) {
 		float b, t, s;
 
-		b = (1.0*dpd->FORM.Range.MinimumValue.u32) / 1000000.0;
-		t = (1.0*dpd->FORM.Range.MaximumValue.u32) / 1000000.0;
+		b = (1.0*dpd->FORM.Range.MinValue.u32) / 1000000.0;
+		t = (1.0*dpd->FORM.Range.MaxValue.u32) / 1000000.0;
 		s = (1.0*dpd->FORM.Range.StepSize.u32) / 1000000.0;
 		gp_widget_set_range (*widget, b, t, s);
 	}
@@ -3844,12 +3844,12 @@ _get_Sharpness(CONFIG_GET_ARGS) {
 		int s;
 
 		if (dpd->DataType == PTP_DTC_UINT8) {
-			min = dpd->FORM.Range.MinimumValue.u8;
-			max = dpd->FORM.Range.MaximumValue.u8;
+			min = dpd->FORM.Range.MinValue.u8;
+			max = dpd->FORM.Range.MaxValue.u8;
 			s = dpd->FORM.Range.StepSize.u8;
 		} else {
-			min = dpd->FORM.Range.MinimumValue.i8;
-			max = dpd->FORM.Range.MaximumValue.i8;
+			min = dpd->FORM.Range.MinValue.i8;
+			max = dpd->FORM.Range.MaxValue.i8;
 			s = dpd->FORM.Range.StepSize.i8;
 		}
 		if (!s) {
@@ -3956,12 +3956,12 @@ _put_Sharpness(CONFIG_PUT_ARGS) {
 		int s;
 
 		if (dpd->DataType == PTP_DTC_UINT8) {
-			min = dpd->FORM.Range.MinimumValue.u8;
-			max = dpd->FORM.Range.MaximumValue.u8;
+			min = dpd->FORM.Range.MinValue.u8;
+			max = dpd->FORM.Range.MaxValue.u8;
 			s = dpd->FORM.Range.StepSize.u8;
 		} else {
-			min = dpd->FORM.Range.MinimumValue.i8;
-			max = dpd->FORM.Range.MaximumValue.i8;
+			min = dpd->FORM.Range.MinValue.i8;
+			max = dpd->FORM.Range.MaxValue.i8;
 			s = dpd->FORM.Range.StepSize.i8;
 		}
 		for (i=min; i<=max; i+=s) {
@@ -4620,8 +4620,8 @@ _get_FocalLength(CONFIG_GET_ARGS) {
 		step = 1.0;
 	}
 	if (dpd->FormFlag & PTP_DPFF_Range) {
-		start = dpd->FORM.Range.MinimumValue.u32/100.0;
-		end = dpd->FORM.Range.MaximumValue.u32/100.0;
+		start = dpd->FORM.Range.MinValue.u32/100.0;
+		end = dpd->FORM.Range.MaxValue.u32/100.0;
 		step = dpd->FORM.Range.StepSize.u32/100.0;
 	}
 	gp_widget_set_range (*widget, start, end, step);
@@ -4750,8 +4750,8 @@ _get_FocusDistance(CONFIG_GET_ARGS) {
 		gp_widget_new (GP_WIDGET_RANGE, _(menu->label), widget);
 		gp_widget_set_name (*widget, menu->name);
 
-		start = dpd->FORM.Range.MinimumValue.u16/100.0;
-		end = dpd->FORM.Range.MaximumValue.u16/100.0;
+		start = dpd->FORM.Range.MinValue.u16/100.0;
+		end = dpd->FORM.Range.MaxValue.u16/100.0;
 		step = dpd->FORM.Range.StepSize.u16/100.0;
 		gp_widget_set_range (*widget, start, end, step);
 		value_float = dpd->CurrentValue.u16/100.0;
@@ -5697,8 +5697,8 @@ _get_Nikon_FlashExposureCompensation(CONFIG_GET_ARGS) {
 	gp_widget_new (GP_WIDGET_RANGE, _(menu->label), widget);
 	gp_widget_set_name (*widget, menu->name);
 	gp_widget_set_range (*widget,
-		dpd->FORM.Range.MinimumValue.i8/6.0,
-		dpd->FORM.Range.MaximumValue.i8/6.0,
+		dpd->FORM.Range.MinValue.i8/6.0,
+		dpd->FORM.Range.MaxValue.i8/6.0,
 		dpd->FORM.Range.StepSize.i8/6.0
 	);
 	value_float = dpd->CurrentValue.i8/6.0;
@@ -5726,8 +5726,8 @@ _get_Nikon_LowLight(CONFIG_GET_ARGS) {
 	gp_widget_new (GP_WIDGET_RANGE, _(menu->label), widget);
 	gp_widget_set_name (*widget, menu->name);
 	gp_widget_set_range (*widget,
-		dpd->FORM.Range.MinimumValue.u8,
-		dpd->FORM.Range.MaximumValue.u8,
+		dpd->FORM.Range.MinValue.u8,
+		dpd->FORM.Range.MaxValue.u8,
 		dpd->FORM.Range.StepSize.u8
 	);
 	value_float = dpd->CurrentValue.u8;
@@ -7426,8 +7426,8 @@ _get_BatteryLevel(CONFIG_GET_ARGS) {
 	}
 	if (dpd->FormFlag == PTP_DPFF_Range) {
 		gp_widget_set_name (*widget, menu->name);
-		start = dpd->FORM.Range.MinimumValue.u8;
-		end = dpd->FORM.Range.MaximumValue.u8;
+		start = dpd->FORM.Range.MinValue.u8;
+		end = dpd->FORM.Range.MaxValue.u8;
 		value_float = dpd->CurrentValue.u8;
 		if (0 == end - start + 1) {
 			/* avoid division by 0 */
@@ -7453,12 +7453,12 @@ _get_SONY_BatteryLevel(CONFIG_GET_ARGS) {
 
 	if (dpd->FormFlag == PTP_DPFF_Range) {
 		gp_widget_set_name (*widget, menu->name);
-		start = dpd->FORM.Range.MinimumValue.i8;
-		if (dpd->FORM.Range.MinimumValue.i8 == -1)
+		start = dpd->FORM.Range.MinValue.i8;
+		if (dpd->FORM.Range.MinValue.i8 == -1)
 			start = 0; /* -1 might be special for unknown? */
 		else
-			start = dpd->FORM.Range.MinimumValue.i8;
-		end = dpd->FORM.Range.MaximumValue.i8;
+			start = dpd->FORM.Range.MinValue.i8;
+		end = dpd->FORM.Range.MaxValue.i8;
 		value_float = dpd->CurrentValue.i8;
 		if (0 == end - start + 1) {
 			/* avoid division by 0 */
@@ -11842,7 +11842,7 @@ _get_config (Camera *camera, const char *confname, CameraWidget **outwidget, Cam
 			/* simple ranges might just be enumerations */
 #define X(dtc,val) 							\
 			case dtc: 					\
-				if (	((dpd.FORM.Range.MaximumValue.val - dpd.FORM.Range.MinimumValue.val) < 128) &&	\
+				if (	((dpd.FORM.Range.MaxValue.val - dpd.FORM.Range.MinValue.val) < 128) &&	\
 					(dpd.FORM.Range.StepSize.val == 1)) {						\
 					type = GP_WIDGET_MENU;								\
 				} \
@@ -11875,10 +11875,10 @@ _get_config (Camera *camera, const char *confname, CameraWidget **outwidget, Cam
 #define X(dtc,val,vartype,format) 										\
 			case dtc: 								\
 				if (type == GP_WIDGET_RANGE) {					\
-					gp_widget_set_range ( widget, (float) dpd.FORM.Range.MinimumValue.val, (float) dpd.FORM.Range.MaximumValue.val, (float) dpd.FORM.Range.StepSize.val);\
+					gp_widget_set_range ( widget, (float) dpd.FORM.Range.MinValue.val, (float) dpd.FORM.Range.MaxValue.val, (float) dpd.FORM.Range.StepSize.val);\
 				} else {							\
 					vartype k;							\
-					for (k=dpd.FORM.Range.MinimumValue.val;k<=dpd.FORM.Range.MaximumValue.val;k+=dpd.FORM.Range.StepSize.val) { \
+					for (k=dpd.FORM.Range.MinValue.val;k<=dpd.FORM.Range.MaxValue.val;k+=dpd.FORM.Range.StepSize.val) { \
 						sprintf (buf, #format, k); 			\
 						gp_widget_add_choice (widget, buf);		\
 						if (dpd.FORM.Range.StepSize.val == 0) break;	\

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -175,11 +175,11 @@ return false,'already in play'\n\
 
 static int
 camera_prepare_canon_powershot_capture(Camera *camera, GPContext *context) {
-	uint16_t		ret;
-	PTPContainer		event;
-	PTPPropertyValue	propval;
-	PTPParams		*params = &camera->pl->params;
-	int 			found, oldtimeout;
+	uint16_t	ret;
+	PTPContainer	event;
+	PTPPropValue	propval;
+	PTPParams	*params = &camera->pl->params;
+	int 		found, oldtimeout;
 
 	if (ptp_property_issupported(params, PTP_DPC_CANON_FlashMode)) {
 		GP_LOG_D ("Canon capture mode is already set up.");
@@ -285,7 +285,7 @@ int
 camera_canon_eos_update_capture_target(Camera *camera, GPContext *context, int value) {
 	PTPParams		*params = &camera->pl->params;
 	char			buf[200];
-	PTPPropertyValue	ct_val;
+	PTPPropValue		ct_val;
 	PTPDevicePropDesc	dpd;
 	int			cardval = -1;
 
@@ -472,7 +472,7 @@ skip:
 		(strcmp(params->deviceinfo.Model,"Canon EOS M50m2") != 0)
 	) {
 		/* This code is needed on EOS m3 at least. might not be needed on others ... mess :/ */
-		PTPPropertyValue    ct_val;
+		PTPPropValue ct_val;
 
 		GP_LOG_D ("EOS M detected");
 
@@ -497,7 +497,7 @@ camera_prepare_capture (Camera *camera, GPContext *context)
 	GP_LOG_D ("prepare_capture");
 	switch (params->deviceinfo.VendorExtensionID) {
 	case PTP_VENDOR_FUJI: {
-		PTPPropertyValue propval;
+		PTPPropValue propval;
 
 		/* without the firmware update ... not an error... */
 		if (!have_prop (camera, PTP_VENDOR_FUJI, PTP_DPC_FUJI_PriorityMode))
@@ -574,7 +574,7 @@ camera_unprepare_canon_eos_capture(Camera *camera, GPContext *context) {
 		CR (ptp_canon_eos_afcancel(params));
 
 	if (is_canon_eos_m (params)) {
-		PTPPropertyValue    ct_val;
+		PTPPropValue ct_val;
 
 		ct_val.u32 = 0x0000;
 		C_PTP (ptp_canon_eos_setdevicepropvalue (params, PTP_DPC_CANON_EOS_EVFOutputDevice, &ct_val, PTP_DTC_UINT32));
@@ -622,7 +622,7 @@ camera_unprepare_capture (Camera *camera, GPContext *context)
 		_("Sorry, your Canon camera does not support Canon capture"));
 		return GP_ERROR_NOT_SUPPORTED;
 	case PTP_VENDOR_FUJI: {
-		PTPPropertyValue propval;
+		PTPPropValue propval;
 		PTPParams *params = &camera->pl->params;
 
 		if (params->inliveview) {
@@ -669,7 +669,7 @@ struct submenu;
 #define CONFIG_GET_ARGS Camera *camera, CameraWidget **widget, struct submenu* menu, PTPDevicePropDesc *dpd
 #define CONFIG_GET_NAMES camera, widget, menu, dpd
 typedef int (*get_func)(CONFIG_GET_ARGS);
-#define CONFIG_PUT_ARGS Camera *camera, CameraWidget *widget, PTPPropertyValue *propval, PTPDevicePropDesc *dpd, int *alreadyset
+#define CONFIG_PUT_ARGS Camera *camera, CameraWidget *widget, PTPPropValue *propval, PTPDevicePropDesc *dpd, int *alreadyset
 #define CONFIG_PUT_NAMES camera, widget, propval, dpd, alreadyset
 typedef int (*put_func)(CONFIG_PUT_ARGS);
 
@@ -1021,9 +1021,9 @@ _put_AUINT8_as_CHAR_ARRAY(CONFIG_PUT_ARGS) {
 	unsigned int i;
 
 	CR (gp_widget_get_value(widget, &value));
-	memset(propval,0,sizeof(PTPPropertyValue));
+	memset(propval,0,sizeof(PTPPropValue));
 	/* add \0 ? */
-	C_MEM (propval->a.v = calloc((strlen(value)+1),sizeof(PTPPropertyValue)));
+	C_MEM (propval->a.v = calloc((strlen(value)+1),sizeof(PTPPropValue)));
 	propval->a.count = strlen(value)+1;
 	for (i=0;i<strlen(value)+1;i++)
 		propval->a.v[i].u8 = value[i];
@@ -1274,7 +1274,7 @@ static int										\
 _put_sony_value_##bits (PTPParams*params, uint16_t prop, inttype value,int useenumorder) {	\
 	GPContext 		*context = ((PTPData *) params->data)->context;		\
 	PTPDevicePropDesc	dpd;							\
-	PTPPropertyValue	propval;						\
+	PTPPropValue		propval;						\
 	inttype			origval;						\
 	time_t			start,end;						\
 	int			tries = 100;	/* 100 steps allowed towards the new value */	\
@@ -3040,12 +3040,12 @@ _get_Fuji_AFDrive(CONFIG_GET_ARGS) {
 static int
 _put_Fuji_AFDrive(CONFIG_PUT_ARGS)
 {
-	PTPParams		*params = &(camera->pl->params);
-	GPContext		*context = ((PTPData *) params->data)->context;
-	PTPPropertyValue	pval;
-	uint16_t		af_start_code;
-	uint16_t		af_stop_code;
-	int			ret = GP_OK;
+	PTPParams	*params = &(camera->pl->params);
+	GPContext	*context = ((PTPData *) params->data)->context;
+	PTPPropValue	pval;
+	uint16_t	af_start_code;
+	uint16_t	af_stop_code;
+	int		ret = GP_OK;
 
 	/* get the focus mode */
 	C_PTP_REP (ptp_getdevicepropvalue (params, PTP_DPC_FocusMode, &pval, PTP_DTC_UINT16));
@@ -3113,9 +3113,9 @@ _get_Fuji_AFDriveManual(CONFIG_GET_ARGS) {
 static int
 _put_Fuji_AFDriveManual(CONFIG_PUT_ARGS)
 {
-	PTPParams               *params = &(camera->pl->params);
-	GPContext               *context = ((PTPData *) params->data)->context;
-	PTPPropertyValue        pval;
+	PTPParams     *params = &(camera->pl->params);
+	GPContext     *context = ((PTPData *) params->data)->context;
+	PTPPropValue  pval;
 	int ret;
 
 	/* Focusing first ... */
@@ -3165,7 +3165,7 @@ static int
 _put_Fuji_FocusPoint(CONFIG_PUT_ARGS) {
 	PTPParams *params = &(camera->pl->params);
 	GPContext *context = ((PTPData *) params->data)->context;
-	PTPPropertyValue pval;
+	PTPPropValue pval;
 
 	CR (gp_widget_get_value(widget, &pval.str));
 	C_PTP_REP(ptp_setdevicepropvalue(params, PTP_DPC_FUJI_FocusArea4, &pval, PTP_DTC_STR));
@@ -3188,10 +3188,10 @@ _get_Fuji_Bulb(CONFIG_GET_ARGS) {
 static int
 _put_Fuji_Bulb(CONFIG_PUT_ARGS)
 {
-	PTPParams		*params = &(camera->pl->params);
-	int			val;
-	GPContext		*context = ((PTPData *) params->data)->context;
-	PTPPropertyValue	pval;
+	PTPParams	*params = &(camera->pl->params);
+	int		val;
+	GPContext	*context = ((PTPData *) params->data)->context;
+	PTPPropValue	pval;
 
 	CR (gp_widget_get_value(widget, &val));
 	if (val) {
@@ -5447,15 +5447,15 @@ _get_Sony_ShutterSpeed(CONFIG_GET_ARGS) {
 
 static int
 _put_Sony_ShutterSpeed(CONFIG_PUT_ARGS) {
-	int			x,y,a,b,direction,position_current,position_new;
-	const char		*val;
-	float 			old,new,current;
-	PTPPropertyValue	value;
-	uint32_t		new32, origval;
-	PTPParams		*params = &(camera->pl->params);
-	GPContext 		*context = ((PTPData *) params->data)->context;
-	time_t			start,end;
-	unsigned int		i;
+	int		x,y,a,b,direction,position_current,position_new;
+	const char	*val;
+	float 		old,new,current;
+	PTPPropValue	value;
+	uint32_t	new32, origval;
+	PTPParams	*params = &(camera->pl->params);
+	GPContext 	*context = ((PTPData *) params->data)->context;
+	time_t		start,end;
+	unsigned int	i;
 
 	CR (gp_widget_get_value (widget, &val));
 
@@ -8350,10 +8350,10 @@ _get_Canon_EOS_ViewFinder(CONFIG_GET_ARGS) {
 
 static int
 _put_Canon_EOS_ViewFinder(CONFIG_PUT_ARGS) {
-	int			val;
-	uint16_t		res;
-	PTPParams		*params = &(camera->pl->params);
-	PTPPropertyValue	xval;
+	int		val;
+	uint16_t	res;
+	PTPParams	*params = &(camera->pl->params);
+	PTPPropValue	xval;
 
 	CR (gp_widget_get_value(widget, &val));
 	if (val) {
@@ -8437,9 +8437,9 @@ _put_Panasonic_ViewFinder(CONFIG_PUT_ARGS) {
 
 static int
 _get_Nikon_ViewFinder(CONFIG_GET_ARGS) {
-	int			val;
-	PTPPropertyValue	value;
-	PTPParams		*params = &(camera->pl->params);
+	int		val;
+	PTPPropValue	value;
+	PTPParams	*params = &(camera->pl->params);
 
 	gp_widget_new (GP_WIDGET_TOGGLE, _(menu->label), widget);
 	gp_widget_set_name (*widget, menu->name);
@@ -8463,7 +8463,7 @@ _put_Nikon_ViewFinder(CONFIG_PUT_ARGS) {
 
 	CR (gp_widget_get_value (widget, &val));
 	if (val) {
-		PTPPropertyValue	value;
+		PTPPropValue	value;
 
 		if (LOG_ON_PTP_E (ptp_getdevicepropvalue (params, PTP_DPC_NIKON_LiveViewStatus, &value, PTP_DTC_UINT8)) != PTP_RC_OK)
 			value.u8 = 0;
@@ -8663,7 +8663,7 @@ _put_Sony_Movie(CONFIG_PUT_ARGS)
 {
 	PTPParams *params = &(camera->pl->params);
 	int val;
-	PTPPropertyValue	value;
+	PTPPropValue value;
 	GPContext *context = ((PTPData *) params->data)->context;
 
 	CR (gp_widget_get_value(widget, &val));
@@ -8691,7 +8691,7 @@ _put_Sony_QX_Movie(CONFIG_PUT_ARGS)
 {
 	PTPParams *params = &(camera->pl->params);
 	int val;
-	PTPPropertyValue	value;
+	PTPPropValue value;
 	GPContext *context = ((PTPData *) params->data)->context;
 
 	CR (gp_widget_get_value(widget, &val));
@@ -8706,9 +8706,9 @@ _put_Sony_QX_Movie(CONFIG_PUT_ARGS)
 
 static int
 _get_Nikon_MovieProhibitCondition(CONFIG_GET_ARGS) {
-	char 			buf[2000];
-	PTPPropertyValue	value;
-	PTPParams 		*params = &(camera->pl->params);
+	char 		buf[2000];
+	PTPPropValue	value;
+	PTPParams 	*params = &(camera->pl->params);
 
 	gp_widget_new (GP_WIDGET_TEXT, _(menu->label), widget);
 	gp_widget_set_name (*widget,menu->name);
@@ -8746,9 +8746,9 @@ _get_Nikon_MovieProhibitCondition(CONFIG_GET_ARGS) {
 
 static int
 _get_Nikon_LiveViewProhibitCondition(CONFIG_GET_ARGS) {
-	char 			buf[2000];
-	PTPPropertyValue	value;
-	PTPParams 		*params = &(camera->pl->params);
+	char 		buf[2000];
+	PTPPropValue	value;
+	PTPParams 	*params = &(camera->pl->params);
 
 	gp_widget_new (GP_WIDGET_TEXT, _(menu->label), widget);
 	gp_widget_set_name (*widget,menu->name);
@@ -8806,7 +8806,7 @@ _put_Nikon_Movie(CONFIG_PUT_ARGS)
 	PTPParams *params = &(camera->pl->params);
 	int val, ret;
 	GPContext *context = ((PTPData *) params->data)->context;
-	PTPPropertyValue	value;
+	PTPPropValue value;
 
 	CR (gp_widget_get_value(widget, &val));
 	if (val) {
@@ -8919,7 +8919,7 @@ _put_Nikon_Bulb(CONFIG_PUT_ARGS)
 
 	CR (gp_widget_get_value(widget, &val));
 	if (val) {
-		PTPPropertyValue propval2;
+		PTPPropValue propval2;
 		char buf[20];
 
 		C_PTP (ptp_nikon_changecameramode (params, 1));
@@ -8994,7 +8994,7 @@ _put_Sony_Autofocus(CONFIG_PUT_ARGS)
 {
 	PTPParams *params = &(camera->pl->params);
 	int val;
-	PTPPropertyValue xpropval;
+	PTPPropValue xpropval;
 
 	CR (gp_widget_get_value(widget, &val));
 	xpropval.u16 = val ? 2 : 1;
@@ -9021,7 +9021,7 @@ _put_Sony_ManualFocus(CONFIG_PUT_ARGS)
 {
 	PTPParams *params = &(camera->pl->params);
 	float val;
-	PTPPropertyValue xpropval;
+	PTPPropValue xpropval;
 
 	CR (gp_widget_get_value(widget, &val));
 
@@ -9070,7 +9070,7 @@ _put_Sony_Capture(CONFIG_PUT_ARGS)
 {
 	PTPParams *params = &(camera->pl->params);
 	int val;
-	PTPPropertyValue xpropval;
+	PTPPropValue xpropval;
 
 	CR (gp_widget_get_value(widget, &val));
 	xpropval.u16 = val ? 2 : 1;
@@ -9096,7 +9096,7 @@ _put_Sony_Bulb(CONFIG_PUT_ARGS)
 {
 	PTPParams *params = &(camera->pl->params);
 	int val;
-	PTPPropertyValue xpropval;
+	PTPPropValue xpropval;
 
 	CR (gp_widget_get_value(widget, &val));
 	if (val) {
@@ -9132,7 +9132,7 @@ _put_Sony_FocusMagnifyProp(CONFIG_PUT_ARGS)
 {
 	PTPParams *params = &(camera->pl->params);
 	int val;
-	PTPPropertyValue xpropval;
+	PTPPropValue xpropval;
 
 	CR (gp_widget_get_value(widget, &val));
 	xpropval.u16 = val ? 2 : 1;
@@ -12000,14 +12000,14 @@ camera_get_single_config (Camera *camera, const char *confname, CameraWidget **w
 static int
 _set_config (Camera *camera, const char *confname, CameraWidget *window, GPContext *context)
 {
-	CameraWidget		*section, *widget = window, *subwindow;
-	uint16_t		ret_ptp;
-	unsigned int		menuno, submenuno;
-	int			ret;
-	PTPParams		*params = &camera->pl->params;
-	PTPPropertyValue	propval;
-	unsigned int		i;
-	CameraAbilities		ab;
+	CameraWidget	*section, *widget = window, *subwindow;
+	uint16_t	ret_ptp;
+	unsigned int	menuno, submenuno;
+	int		ret;
+	PTPParams	*params = &camera->pl->params;
+	PTPPropValue	propval;
+	unsigned int	i;
+	CameraAbilities	ab;
 	enum {
 		MODE_SET, MODE_SINGLE_SET
 	} mode = MODE_SET;

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -169,15 +169,15 @@ print_debug_deviceinfo (PTPParams *params, PTPDeviceInfo *di)
 	GP_LOG_D ("Functional Mode: 0x%04x",di->FunctionalMode);
 	GP_LOG_D ("PTP Standard Version: %d",di->StandardVersion);
 	GP_LOG_D ("Supported operations:");
-	for (i=0; i<di->OperationsSupported_len; i++)
-		GP_LOG_D ("  0x%04x (%s)", di->OperationsSupported[i], ptp_get_opcode_name (params, di->OperationsSupported[i]));
+	for (i=0; i<di->Operations_len; i++)
+		GP_LOG_D ("  0x%04x (%s)", di->Operations[i], ptp_get_opcode_name (params, di->Operations[i]));
 	GP_LOG_D ("Events Supported:");
-	for (i=0; i<di->EventsSupported_len; i++)
-		GP_LOG_D ("  0x%04x (%s)", di->EventsSupported[i], ptp_get_event_code_name (params, di->EventsSupported[i]));
+	for (i=0; i<di->Events_len; i++)
+		GP_LOG_D ("  0x%04x (%s)", di->Events[i], ptp_get_event_code_name (params, di->Events[i]));
 	GP_LOG_D ("Device Properties Supported:");
-	for (i=0; i<di->DevicePropertiesSupported_len; i++) {
-		const char *ptpname = ptp_get_property_description (params, di->DevicePropertiesSupported[i]);
-		GP_LOG_D ("  0x%04x (%s)", di->DevicePropertiesSupported[i], ptpname ? ptpname : "Unknown DPC code");
+	for (i=0; i<di->DeviceProps_len; i++) {
+		const char *ptpname = ptp_get_property_description (params, di->DeviceProps[i]);
+		GP_LOG_D ("  0x%04x (%s)", di->DeviceProps[i], ptpname ? ptpname : "Unknown DPC code");
 	}
 }
 
@@ -217,17 +217,17 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 		(camera->port->type == GP_PORT_USB) &&
 		(a.usb_product == 0x2382)
 	) {
-		C_MEM (di->OperationsSupported = realloc(di->OperationsSupported,sizeof(di->OperationsSupported[0])*(di->OperationsSupported_len + 9)));
-		di->OperationsSupported[di->OperationsSupported_len+0] = PTP_OC_PANASONIC_GetProperty;
-		di->OperationsSupported[di->OperationsSupported_len+1]  = PTP_OC_PANASONIC_SetProperty;
-		di->OperationsSupported[di->OperationsSupported_len+2]  = PTP_OC_PANASONIC_ListProperty;
-		di->OperationsSupported[di->OperationsSupported_len+3]  = PTP_OC_PANASONIC_InitiateCapture;
-		di->OperationsSupported[di->OperationsSupported_len+4]  = PTP_OC_PANASONIC_Liveview;
-		di->OperationsSupported[di->OperationsSupported_len+5]  = PTP_OC_PANASONIC_LiveviewImage;
-		di->OperationsSupported[di->OperationsSupported_len+6]  = PTP_OC_PANASONIC_MovieRecControl;
-		di->OperationsSupported[di->OperationsSupported_len+7]  = PTP_OC_PANASONIC_GetLiveViewParameters;
-		di->OperationsSupported[di->OperationsSupported_len+8]  = PTP_OC_PANASONIC_SetLiveViewParameters;
-		di->OperationsSupported_len += 9;
+		C_MEM (di->Operations = realloc(di->Operations,sizeof(di->Operations[0])*(di->Operations_len + 9)));
+		di->Operations[di->Operations_len+0] = PTP_OC_PANASONIC_GetProperty;
+		di->Operations[di->Operations_len+1]  = PTP_OC_PANASONIC_SetProperty;
+		di->Operations[di->Operations_len+2]  = PTP_OC_PANASONIC_ListProperty;
+		di->Operations[di->Operations_len+3]  = PTP_OC_PANASONIC_InitiateCapture;
+		di->Operations[di->Operations_len+4]  = PTP_OC_PANASONIC_Liveview;
+		di->Operations[di->Operations_len+5]  = PTP_OC_PANASONIC_LiveviewImage;
+		di->Operations[di->Operations_len+6]  = PTP_OC_PANASONIC_MovieRecControl;
+		di->Operations[di->Operations_len+7]  = PTP_OC_PANASONIC_GetLiveViewParameters;
+		di->Operations[di->Operations_len+8]  = PTP_OC_PANASONIC_SetLiveViewParameters;
+		di->Operations_len += 9;
 	}
 
 	/* Panasonic hack */
@@ -297,9 +297,9 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 			newdi.x[i+outerdi->x##_len] = ndi.x[i];					\
 		newdi.x##_len = ndi.x##_len + outerdi->x##_len;
 
-		DI_MERGE(OperationsSupported);
-		DI_MERGE(EventsSupported);
-		DI_MERGE(DevicePropertiesSupported);
+		DI_MERGE(Operations);
+		DI_MERGE(Events);
+		DI_MERGE(DeviceProps);
 		DI_MERGE(CaptureFormats);
 		DI_MERGE(ImageFormats);
 
@@ -387,11 +387,11 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 		PTPCanonEOSDeviceInfo x;
 
 		if (PTP_RC_OK == LOG_ON_PTP_E (ptp_canon_eos_getdeviceinfo (params, &x))) {
-			C_MEM (di->DevicePropertiesSupported = realloc(di->DevicePropertiesSupported,
-				(di->DevicePropertiesSupported_len + x.DevicePropertiesSupported_len) * sizeof(di->DevicePropertiesSupported[0])));
-			for (unsigned i=0;i<x.DevicePropertiesSupported_len;i++)
-				di->DevicePropertiesSupported[di->DevicePropertiesSupported_len + i] = x.DevicePropertiesSupported[i];
-			di->DevicePropertiesSupported_len += x.DevicePropertiesSupported_len;
+			C_MEM (di->DeviceProps = realloc(di->DeviceProps,
+				(di->DeviceProps_len + x.DeviceProps_len) * sizeof(di->DeviceProps[0])));
+			for (unsigned i=0;i<x.DeviceProps_len;i++)
+				di->DeviceProps[di->DeviceProps_len + i] = x.DeviceProps[i];
+			di->DeviceProps_len += x.DeviceProps_len;
 			ptp_canon_eos_free_deviceinfo (&x);
 		}
 
@@ -399,91 +399,91 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 	}
 
 	if (di->VendorExtensionID == PTP_VENDOR_FUJI) {
-		C_MEM (di->DevicePropertiesSupported = realloc(di->DevicePropertiesSupported,sizeof(di->DevicePropertiesSupported[0])*(di->DevicePropertiesSupported_len + 72)));
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+0] = PTP_DPC_ExposureTime;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+1] = PTP_DPC_FNumber;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+2] = 0xd38c;	/* PC Mode */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+3] = 0xd171;	/* Focus control */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+4] = 0xd21c;	/* Needed for X-T2? */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+5] = 0xd347;	/* Focus Position */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+6] = PTP_DPC_FUJI_LensZoomPos;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+7] = 0xd242;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+8] = PTP_DPC_FUJI_LiveViewImageSize; /* xt3 confirmed */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+9] = 0xd168; /* video out on/off (unconfirmed) */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+10] = PTP_DPC_FUJI_LiveViewImageQuality; /* xt3 confirmed */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+11] = PTP_DPC_FUJI_ForceMode; /* on xt3 set by webcam app to 1 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+12] = 0xd16e; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+13] = 0xd372; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+14] = 0xd020; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+15] = 0xd022; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+16] = 0xd023; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+17] = 0xd024; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+18] = 0xd025; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+19] = 0xd026; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+20] = 0xd027; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+21] = 0xd029; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+22] = 0xd16f; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+23] = 0xd02f; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+24] = 0xd395; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+25] = 0xd320; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+26] = 0xd321; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+27] = 0xd322; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+28] = 0xd323; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+29] = 0xd346; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+30] = 0xd34a; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+31] = 0xd34b; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+32] = 0xd34d; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+33] = 0xd351; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+34] = 0xd35e; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+35] = 0xd173; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+36] = 0xd365; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+37] = 0xd366; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+38] = 0xd374; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+39] = 0xd310; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+40] = 0xd359; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+41] = 0xd375; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+42] = 0xd376; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+43] = 0xd36e; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+44] = 0xd33f; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+45] = 0xd364; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+46] = 0xd34e; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+47] = 0xd02e; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+48] = 0xd36d; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+49] = 0xd38a; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+50] = 0xd36a; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+51] = 0xd36b; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+52] = 0xd36f; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+53] = 0xd370; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+54] = 0xd222; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+55] = 0xd223; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+56] = 0xd38c; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+57] = 0xd38d; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+58] = 0xd38e; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+59] = 0xd17b; /* seen on xt3 */
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+60] = PTP_DPC_ExposureBiasCompensation;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+61] = 0xd028;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+62] = 0xd02a;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+63] = 0xd02b;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+64] = 0xd02d;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+65] = 0xd156;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+66] = 0xd16b;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+67] = 0xd176;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+68] = 0xd17b;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+69] = 0xd17f;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+70] = 0xd208;
-		di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+71] = 0xd21c;
+		C_MEM (di->DeviceProps = realloc(di->DeviceProps,sizeof(di->DeviceProps[0])*(di->DeviceProps_len + 72)));
+		di->DeviceProps[di->DeviceProps_len+0] = PTP_DPC_ExposureTime;
+		di->DeviceProps[di->DeviceProps_len+1] = PTP_DPC_FNumber;
+		di->DeviceProps[di->DeviceProps_len+2] = 0xd38c;	/* PC Mode */
+		di->DeviceProps[di->DeviceProps_len+3] = 0xd171;	/* Focus control */
+		di->DeviceProps[di->DeviceProps_len+4] = 0xd21c;	/* Needed for X-T2? */
+		di->DeviceProps[di->DeviceProps_len+5] = 0xd347;	/* Focus Position */
+		di->DeviceProps[di->DeviceProps_len+6] = PTP_DPC_FUJI_LensZoomPos;
+		di->DeviceProps[di->DeviceProps_len+7] = 0xd242;
+		di->DeviceProps[di->DeviceProps_len+8] = PTP_DPC_FUJI_LiveViewImageSize; /* xt3 confirmed */
+		di->DeviceProps[di->DeviceProps_len+9] = 0xd168; /* video out on/off (unconfirmed) */
+		di->DeviceProps[di->DeviceProps_len+10] = PTP_DPC_FUJI_LiveViewImageQuality; /* xt3 confirmed */
+		di->DeviceProps[di->DeviceProps_len+11] = PTP_DPC_FUJI_ForceMode; /* on xt3 set by webcam app to 1 */
+		di->DeviceProps[di->DeviceProps_len+12] = 0xd16e; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+13] = 0xd372; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+14] = 0xd020; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+15] = 0xd022; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+16] = 0xd023; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+17] = 0xd024; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+18] = 0xd025; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+19] = 0xd026; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+20] = 0xd027; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+21] = 0xd029; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+22] = 0xd16f; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+23] = 0xd02f; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+24] = 0xd395; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+25] = 0xd320; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+26] = 0xd321; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+27] = 0xd322; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+28] = 0xd323; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+29] = 0xd346; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+30] = 0xd34a; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+31] = 0xd34b; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+32] = 0xd34d; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+33] = 0xd351; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+34] = 0xd35e; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+35] = 0xd173; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+36] = 0xd365; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+37] = 0xd366; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+38] = 0xd374; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+39] = 0xd310; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+40] = 0xd359; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+41] = 0xd375; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+42] = 0xd376; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+43] = 0xd36e; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+44] = 0xd33f; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+45] = 0xd364; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+46] = 0xd34e; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+47] = 0xd02e; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+48] = 0xd36d; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+49] = 0xd38a; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+50] = 0xd36a; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+51] = 0xd36b; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+52] = 0xd36f; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+53] = 0xd370; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+54] = 0xd222; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+55] = 0xd223; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+56] = 0xd38c; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+57] = 0xd38d; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+58] = 0xd38e; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+59] = 0xd17b; /* seen on xt3 */
+		di->DeviceProps[di->DeviceProps_len+60] = PTP_DPC_ExposureBiasCompensation;
+		di->DeviceProps[di->DeviceProps_len+61] = 0xd028;
+		di->DeviceProps[di->DeviceProps_len+62] = 0xd02a;
+		di->DeviceProps[di->DeviceProps_len+63] = 0xd02b;
+		di->DeviceProps[di->DeviceProps_len+64] = 0xd02d;
+		di->DeviceProps[di->DeviceProps_len+65] = 0xd156;
+		di->DeviceProps[di->DeviceProps_len+66] = 0xd16b;
+		di->DeviceProps[di->DeviceProps_len+67] = 0xd176;
+		di->DeviceProps[di->DeviceProps_len+68] = 0xd17b;
+		di->DeviceProps[di->DeviceProps_len+69] = 0xd17f;
+		di->DeviceProps[di->DeviceProps_len+70] = 0xd208;
+		di->DeviceProps[di->DeviceProps_len+71] = 0xd21c;
 
-		di->DevicePropertiesSupported_len += 72;
+		di->DeviceProps_len += 72;
 
 		if (ptp_operation_issupported(&camera->pl->params, PTP_OC_FUJI_GetDeviceInfo)) {
 			uint16_t	*props;
 			unsigned int	numprops;
 
 			C_PTP (ptp_fuji_getdeviceinfo (params, &props, &numprops));
-			free (di->DevicePropertiesSupported);
+			free (di->DeviceProps);
 
-			di->DevicePropertiesSupported		= props;
-			di->DevicePropertiesSupported_len	= numprops;
+			di->DeviceProps		= props;
+			di->DeviceProps_len	= numprops;
 		}
 
 	}
@@ -507,7 +507,7 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 				GP_LOG_E ("if camera is Nikon 1 series, camera should probably have flag NIKON_1 set. report that to the libgphoto2 project");
 				camera->pl->params.device_flags |= PTP_NIKON_1;
 			}
-			C_MEM (di->OperationsSupported = realloc(di->OperationsSupported,sizeof(di->OperationsSupported[0])*(di->OperationsSupported_len + 3)));
+			C_MEM (di->Operations = realloc(di->Operations,sizeof(di->Operations[0])*(di->Operations_len + 3)));
 			/* Nikon J5 does not advertise the PTP_OC_NIKON_InitiateCaptureRecInMedia cmd ... gnh */
 			/* logic: If we have one 0x920x command, we will probably have 0x9207 too. and getvendorpropcodes ... */
 
@@ -523,13 +523,13 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 			if (	!ptp_operation_issupported(&camera->pl->params, PTP_OC_NIKON_InitiateCaptureRecInMedia) &&
 				 ptp_operation_issupported(&camera->pl->params, PTP_OC_NIKON_StartLiveView)
 			) {
-				di->OperationsSupported[di->OperationsSupported_len+0] = PTP_OC_NIKON_InitiateCaptureRecInMedia;
-				di->OperationsSupported_len++;
+				di->Operations[di->Operations_len+0] = PTP_OC_NIKON_InitiateCaptureRecInMedia;
+				di->Operations_len++;
 			}
 
 			if (ptp_operation_issupported(&camera->pl->params, PTP_OC_NIKON_InitiateCaptureRecInMedia)) {
-				di->OperationsSupported[di->OperationsSupported_len+0] = PTP_OC_NIKON_GetVendorPropCodes;
-				di->OperationsSupported_len++;
+				di->Operations[di->Operations_len+0] = PTP_OC_NIKON_GetVendorPropCodes;
+				di->Operations_len++;
 			}
 
 			/* V1 and J1 are a less reliable then the newer 1 versions, no changecamera mode, no getevent, no initiatecapturerecinsdram */
@@ -541,42 +541,42 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 				/* V1: see https://github.com/gphoto/libgphoto2/issues/569 */
 				/* J1: see https://github.com/gphoto/libgphoto2/issues/716 */
 				/* S1: see https://github.com/gphoto/libgphoto2/issues/845 */
-				for (i=0;i<di->OperationsSupported_len;i++) {
-					if (di->OperationsSupported[i] == PTP_OC_NIKON_GetEvent) {
+				for (i=0;i<di->Operations_len;i++) {
+					if (di->Operations[i] == PTP_OC_NIKON_GetEvent) {
 						GP_LOG_D("On Nikon S1/J1/V1: disable NIKON_GetEvent as its unreliable");
-						di->OperationsSupported[i] = PTP_OC_GetDeviceInfo; /* overwrite */
+						di->Operations[i] = PTP_OC_GetDeviceInfo; /* overwrite */
 					}
-					if (di->OperationsSupported[i] == PTP_OC_NIKON_InitiateCaptureRecInSdram) {
+					if (di->Operations[i] == PTP_OC_NIKON_InitiateCaptureRecInSdram) {
 						GP_LOG_D("On Nikon S1/J1/V1: disable NIKON_InitiateCaptureRecInSdram as its unreliable");
-						di->OperationsSupported[i] = PTP_OC_InitiateCapture; /* overwrite */
+						di->Operations[i] = PTP_OC_InitiateCapture; /* overwrite */
 					}
 					if (!strcmp(params->deviceinfo.Model,"S1") &&
-						(di->OperationsSupported[i] == PTP_OC_NIKON_InitiateCaptureRecInMedia))
+						(di->Operations[i] == PTP_OC_NIKON_InitiateCaptureRecInMedia))
 					{
 						GP_LOG_D("On Nikon S1: disable NIKON_InitiateCaptureRecInMedia as its unreliable");
-						di->OperationsSupported[i] = PTP_OC_InitiateCapture; /* overwrite */
+						di->Operations[i] = PTP_OC_InitiateCapture; /* overwrite */
 					}
 				}
 			} else {
-				di->OperationsSupported[di->OperationsSupported_len+0] = PTP_OC_NIKON_ChangeCameraMode;
-				di->OperationsSupported_len++;
+				di->Operations[di->Operations_len+0] = PTP_OC_NIKON_ChangeCameraMode;
+				di->Operations_len++;
 			}
 		}
 		if (params->deviceinfo.Model && !strcmp(params->deviceinfo.Model,"COOLPIX A")) {
 			/* The A also hides some commands from us ... */
 			if (!ptp_operation_issupported(&camera->pl->params, PTP_OC_NIKON_GetVendorPropCodes)) {
-				C_MEM (di->OperationsSupported = realloc(di->OperationsSupported,sizeof(di->OperationsSupported[0])*(di->OperationsSupported_len + 10)));
-				di->OperationsSupported[di->OperationsSupported_len+0] = PTP_OC_NIKON_GetVendorPropCodes;
-				di->OperationsSupported[di->OperationsSupported_len+1]  = PTP_OC_NIKON_GetEvent;
-				di->OperationsSupported[di->OperationsSupported_len+2]  = PTP_OC_NIKON_AfDrive;
-				di->OperationsSupported[di->OperationsSupported_len+3]  = PTP_OC_NIKON_ChangeCameraMode;
-				di->OperationsSupported[di->OperationsSupported_len+4]  = PTP_OC_NIKON_DeviceReady;
-				di->OperationsSupported[di->OperationsSupported_len+5]  = PTP_OC_NIKON_StartLiveView;
-				di->OperationsSupported[di->OperationsSupported_len+6] = PTP_OC_NIKON_EndLiveView;
-				di->OperationsSupported[di->OperationsSupported_len+7] = PTP_OC_NIKON_GetLiveViewImg;
-				di->OperationsSupported[di->OperationsSupported_len+8] = PTP_OC_NIKON_ChangeAfArea;
-				di->OperationsSupported[di->OperationsSupported_len+9] = PTP_OC_NIKON_InitiateCaptureRecInMedia;
-				di->OperationsSupported_len += 10;
+				C_MEM (di->Operations = realloc(di->Operations,sizeof(di->Operations[0])*(di->Operations_len + 10)));
+				di->Operations[di->Operations_len+0] = PTP_OC_NIKON_GetVendorPropCodes;
+				di->Operations[di->Operations_len+1]  = PTP_OC_NIKON_GetEvent;
+				di->Operations[di->Operations_len+2]  = PTP_OC_NIKON_AfDrive;
+				di->Operations[di->Operations_len+3]  = PTP_OC_NIKON_ChangeCameraMode;
+				di->Operations[di->Operations_len+4]  = PTP_OC_NIKON_DeviceReady;
+				di->Operations[di->Operations_len+5]  = PTP_OC_NIKON_StartLiveView;
+				di->Operations[di->Operations_len+6] = PTP_OC_NIKON_EndLiveView;
+				di->Operations[di->Operations_len+7] = PTP_OC_NIKON_GetLiveViewImg;
+				di->Operations[di->Operations_len+8] = PTP_OC_NIKON_ChangeAfArea;
+				di->Operations[di->Operations_len+9] = PTP_OC_NIKON_InitiateCaptureRecInMedia;
+				di->Operations_len += 10;
 			}
 		}
 		if (params->deviceinfo.Model && (sscanf(params->deviceinfo.Model,"D%d", &nikond)))
@@ -587,67 +587,67 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 				 * https://github.com/gphoto/libgphoto2/issues/140
 				 */
 				if (!ptp_operation_issupported(&camera->pl->params, PTP_OC_NIKON_GetVendorPropCodes)) {
-					C_MEM (di->OperationsSupported = realloc(di->OperationsSupported,sizeof(di->OperationsSupported[0])*(di->OperationsSupported_len + 6)));
-					di->OperationsSupported[di->OperationsSupported_len+0]  = PTP_OC_NIKON_AfDrive;
-					di->OperationsSupported[di->OperationsSupported_len+1]  = PTP_OC_NIKON_DeviceReady;
-					di->OperationsSupported[di->OperationsSupported_len+2]  = PTP_OC_NIKON_GetPreviewImg;
-					di->OperationsSupported[di->OperationsSupported_len+3] = PTP_OC_NIKON_MfDrive;
-					di->OperationsSupported[di->OperationsSupported_len+4] = PTP_OC_NIKON_ChangeAfArea;
-					di->OperationsSupported[di->OperationsSupported_len+5] = PTP_OC_NIKON_AfDriveCancel;
-					di->OperationsSupported_len += 6;
+					C_MEM (di->Operations = realloc(di->Operations,sizeof(di->Operations[0])*(di->Operations_len + 6)));
+					di->Operations[di->Operations_len+0]  = PTP_OC_NIKON_AfDrive;
+					di->Operations[di->Operations_len+1]  = PTP_OC_NIKON_DeviceReady;
+					di->Operations[di->Operations_len+2]  = PTP_OC_NIKON_GetPreviewImg;
+					di->Operations[di->Operations_len+3] = PTP_OC_NIKON_MfDrive;
+					di->Operations[di->Operations_len+4] = PTP_OC_NIKON_ChangeAfArea;
+					di->Operations[di->Operations_len+5] = PTP_OC_NIKON_AfDriveCancel;
+					di->Operations_len += 6;
 				}
 			}
 			if ((nikond >= 3200) && (nikond < 3299)) {
 				GP_LOG_D("The D3200 hides commands from us ... adding some D7100 ones");
 				if (!ptp_operation_issupported(&camera->pl->params, PTP_OC_NIKON_GetVendorPropCodes)) {
 					/* see https://github.com/gphoto/gphoto2/issues/331 and https://github.com/gphoto/gphoto2/issues/332 */
-					C_MEM (di->OperationsSupported = realloc(di->OperationsSupported,sizeof(di->OperationsSupported[0])*(di->OperationsSupported_len + 14)));
-					di->OperationsSupported[di->OperationsSupported_len+0]  = PTP_OC_NIKON_GetEvent;
-					di->OperationsSupported[di->OperationsSupported_len+1]  = PTP_OC_NIKON_InitiateCaptureRecInSdram;
-					di->OperationsSupported[di->OperationsSupported_len+2]  = PTP_OC_NIKON_AfDrive;
-					di->OperationsSupported[di->OperationsSupported_len+3]  = PTP_OC_NIKON_ChangeCameraMode;
-					di->OperationsSupported[di->OperationsSupported_len+4]  = PTP_OC_NIKON_DeviceReady;
-					di->OperationsSupported[di->OperationsSupported_len+5]  = PTP_OC_NIKON_AfCaptureSDRAM;
-					di->OperationsSupported[di->OperationsSupported_len+6]  = PTP_OC_NIKON_DelImageSDRAM;
+					C_MEM (di->Operations = realloc(di->Operations,sizeof(di->Operations[0])*(di->Operations_len + 14)));
+					di->Operations[di->Operations_len+0]  = PTP_OC_NIKON_GetEvent;
+					di->Operations[di->Operations_len+1]  = PTP_OC_NIKON_InitiateCaptureRecInSdram;
+					di->Operations[di->Operations_len+2]  = PTP_OC_NIKON_AfDrive;
+					di->Operations[di->Operations_len+3]  = PTP_OC_NIKON_ChangeCameraMode;
+					di->Operations[di->Operations_len+4]  = PTP_OC_NIKON_DeviceReady;
+					di->Operations[di->Operations_len+5]  = PTP_OC_NIKON_AfCaptureSDRAM;
+					di->Operations[di->Operations_len+6]  = PTP_OC_NIKON_DelImageSDRAM;
 
-					di->OperationsSupported[di->OperationsSupported_len+7]  = PTP_OC_NIKON_GetPreviewImg;
-					di->OperationsSupported[di->OperationsSupported_len+8]  = PTP_OC_NIKON_StartLiveView;
-					di->OperationsSupported[di->OperationsSupported_len+9]  = PTP_OC_NIKON_EndLiveView;
-					di->OperationsSupported[di->OperationsSupported_len+10] = PTP_OC_NIKON_GetLiveViewImg;	/* confirmed works */
-					di->OperationsSupported[di->OperationsSupported_len+11] = PTP_OC_NIKON_ChangeAfArea;
-					di->OperationsSupported[di->OperationsSupported_len+12] = PTP_OC_NIKON_InitiateCaptureRecInMedia;	/* works to some degree */
-					di->OperationsSupported[di->OperationsSupported_len+13] = PTP_OC_NIKON_AfDriveCancel;
+					di->Operations[di->Operations_len+7]  = PTP_OC_NIKON_GetPreviewImg;
+					di->Operations[di->Operations_len+8]  = PTP_OC_NIKON_StartLiveView;
+					di->Operations[di->Operations_len+9]  = PTP_OC_NIKON_EndLiveView;
+					di->Operations[di->Operations_len+10] = PTP_OC_NIKON_GetLiveViewImg;	/* confirmed works */
+					di->Operations[di->Operations_len+11] = PTP_OC_NIKON_ChangeAfArea;
+					di->Operations[di->Operations_len+12] = PTP_OC_NIKON_InitiateCaptureRecInMedia;	/* works to some degree */
+					di->Operations[di->Operations_len+13] = PTP_OC_NIKON_AfDriveCancel;
 					/* probably more */
-					di->OperationsSupported_len += 14;
+					di->Operations_len += 14;
 
 				}
 			}
 			if ((nikond >= 3300) && (nikond < 3999)) {
 				GP_LOG_D("The D3xxx series hides commands from us ... adding all D7100 ones");
 				if (!ptp_operation_issupported(&camera->pl->params, PTP_OC_NIKON_GetVendorPropCodes)) {
-					C_MEM (di->OperationsSupported = realloc(di->OperationsSupported,sizeof(di->OperationsSupported[0])*(di->OperationsSupported_len + 19)));
-					di->OperationsSupported[di->OperationsSupported_len+0]  = PTP_OC_NIKON_GetVendorPropCodes;
-					di->OperationsSupported[di->OperationsSupported_len+1]  = PTP_OC_NIKON_GetEvent;
-					di->OperationsSupported[di->OperationsSupported_len+2]  = PTP_OC_NIKON_InitiateCaptureRecInSdram;
-					di->OperationsSupported[di->OperationsSupported_len+3]  = PTP_OC_NIKON_AfDrive;
-					di->OperationsSupported[di->OperationsSupported_len+4]  = PTP_OC_NIKON_ChangeCameraMode;
-					di->OperationsSupported[di->OperationsSupported_len+5]  = PTP_OC_NIKON_DeviceReady;
-					di->OperationsSupported[di->OperationsSupported_len+6]  = PTP_OC_NIKON_AfCaptureSDRAM;
-					di->OperationsSupported[di->OperationsSupported_len+7]  = PTP_OC_NIKON_DelImageSDRAM;
+					C_MEM (di->Operations = realloc(di->Operations,sizeof(di->Operations[0])*(di->Operations_len + 19)));
+					di->Operations[di->Operations_len+0]  = PTP_OC_NIKON_GetVendorPropCodes;
+					di->Operations[di->Operations_len+1]  = PTP_OC_NIKON_GetEvent;
+					di->Operations[di->Operations_len+2]  = PTP_OC_NIKON_InitiateCaptureRecInSdram;
+					di->Operations[di->Operations_len+3]  = PTP_OC_NIKON_AfDrive;
+					di->Operations[di->Operations_len+4]  = PTP_OC_NIKON_ChangeCameraMode;
+					di->Operations[di->Operations_len+5]  = PTP_OC_NIKON_DeviceReady;
+					di->Operations[di->Operations_len+6]  = PTP_OC_NIKON_AfCaptureSDRAM;
+					di->Operations[di->Operations_len+7]  = PTP_OC_NIKON_DelImageSDRAM;
 
-					di->OperationsSupported[di->OperationsSupported_len+8]  = PTP_OC_NIKON_GetPreviewImg;
-					di->OperationsSupported[di->OperationsSupported_len+9]  = PTP_OC_NIKON_StartLiveView;
-					di->OperationsSupported[di->OperationsSupported_len+10] = PTP_OC_NIKON_EndLiveView;
-					di->OperationsSupported[di->OperationsSupported_len+11] = PTP_OC_NIKON_GetLiveViewImg;
-					di->OperationsSupported[di->OperationsSupported_len+12] = PTP_OC_NIKON_MfDrive;
-					di->OperationsSupported[di->OperationsSupported_len+13] = PTP_OC_NIKON_ChangeAfArea;
-					di->OperationsSupported[di->OperationsSupported_len+14] = PTP_OC_NIKON_InitiateCaptureRecInMedia;
-					di->OperationsSupported[di->OperationsSupported_len+15] = PTP_OC_NIKON_AfDriveCancel;
-					di->OperationsSupported[di->OperationsSupported_len+16] = PTP_OC_NIKON_StartMovieRecInCard;
-					di->OperationsSupported[di->OperationsSupported_len+17] = PTP_OC_NIKON_EndMovieRec;
-					di->OperationsSupported[di->OperationsSupported_len+18] = PTP_OC_NIKON_TerminateCapture;
+					di->Operations[di->Operations_len+8]  = PTP_OC_NIKON_GetPreviewImg;
+					di->Operations[di->Operations_len+9]  = PTP_OC_NIKON_StartLiveView;
+					di->Operations[di->Operations_len+10] = PTP_OC_NIKON_EndLiveView;
+					di->Operations[di->Operations_len+11] = PTP_OC_NIKON_GetLiveViewImg;
+					di->Operations[di->Operations_len+12] = PTP_OC_NIKON_MfDrive;
+					di->Operations[di->Operations_len+13] = PTP_OC_NIKON_ChangeAfArea;
+					di->Operations[di->Operations_len+14] = PTP_OC_NIKON_InitiateCaptureRecInMedia;
+					di->Operations[di->Operations_len+15] = PTP_OC_NIKON_AfDriveCancel;
+					di->Operations[di->Operations_len+16] = PTP_OC_NIKON_StartMovieRecInCard;
+					di->Operations[di->Operations_len+17] = PTP_OC_NIKON_EndMovieRec;
+					di->Operations[di->Operations_len+18] = PTP_OC_NIKON_TerminateCapture;
 					/* probably more */
-					di->OperationsSupported_len += 19;
+					di->Operations_len += 19;
 
 				}
 			}
@@ -658,45 +658,45 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 			unsigned int	xsize;
 
 			if (PTP_RC_OK == LOG_ON_PTP_E (ptp_nikon_get_vendorpropcodes (&camera->pl->params, &xprops, &xsize))) {
-				di->DevicePropertiesSupported = realloc(di->DevicePropertiesSupported,sizeof(di->DevicePropertiesSupported[0])*(di->DevicePropertiesSupported_len + xsize));
-				if (!di->DevicePropertiesSupported) {
+				di->DeviceProps = realloc(di->DeviceProps,sizeof(di->DeviceProps[0])*(di->DeviceProps_len + xsize));
+				if (!di->DeviceProps) {
 					free (xprops);
-					C_MEM (di->DevicePropertiesSupported);
+					C_MEM (di->DeviceProps);
 				}
 				for (i=0;i<xsize;i++)
-					di->DevicePropertiesSupported[i+di->DevicePropertiesSupported_len] = xprops[i];
-				di->DevicePropertiesSupported_len += xsize;
+					di->DeviceProps[i+di->DeviceProps_len] = xprops[i];
+				di->DeviceProps_len += xsize;
 				free (xprops);
 			}
 		}
 
 		/* For nikon 1 j5, they have blanked this space */
 		if (camera->pl->params.device_flags & PTP_NIKON_1) {
-			for (i=0;i<di->DevicePropertiesSupported_len;i++)
-				if ((di->DevicePropertiesSupported[i] & 0xf000) == 0xf000)
+			for (i=0;i<di->DeviceProps_len;i++)
+				if ((di->DeviceProps[i] & 0xf000) == 0xf000)
 					break;
 			/* The J5 so far goes up to 0xf01c */
 #define NIKON_1_ADDITIONAL_DEVPROPS 29
-			if (i==di->DevicePropertiesSupported_len) {
-				C_MEM (di->DevicePropertiesSupported = realloc(di->DevicePropertiesSupported,sizeof(di->DevicePropertiesSupported[0])*(di->DevicePropertiesSupported_len + NIKON_1_ADDITIONAL_DEVPROPS+3)));
+			if (i==di->DeviceProps_len) {
+				C_MEM (di->DeviceProps = realloc(di->DeviceProps,sizeof(di->DeviceProps[0])*(di->DeviceProps_len + NIKON_1_ADDITIONAL_DEVPROPS+3)));
 				for (i=0;i<NIKON_1_ADDITIONAL_DEVPROPS;i++)
-					di->DevicePropertiesSupported[i+di->DevicePropertiesSupported_len] = 0xf000 | i;
+					di->DeviceProps[i+di->DeviceProps_len] = 0xf000 | i;
 
 				/* is returned by the J5, but readonly */
-				di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+NIKON_1_ADDITIONAL_DEVPROPS] = PTP_DPC_NIKON_ExposureTime;	// OKAY in J5
-				di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+NIKON_1_ADDITIONAL_DEVPROPS+1] = PTP_DPC_NIKON_LiveViewProhibitCondition;	// hack
-				di->DevicePropertiesSupported[di->DevicePropertiesSupported_len+NIKON_1_ADDITIONAL_DEVPROPS+2] = PTP_DPC_NIKON_LiveViewStatus;	// hack
+				di->DeviceProps[di->DeviceProps_len+NIKON_1_ADDITIONAL_DEVPROPS] = PTP_DPC_NIKON_ExposureTime;	// OKAY in J5
+				di->DeviceProps[di->DeviceProps_len+NIKON_1_ADDITIONAL_DEVPROPS+1] = PTP_DPC_NIKON_LiveViewProhibitCondition;	// hack
+				di->DeviceProps[di->DeviceProps_len+NIKON_1_ADDITIONAL_DEVPROPS+2] = PTP_DPC_NIKON_LiveViewStatus;	// hack
 
-				di->DevicePropertiesSupported_len += NIKON_1_ADDITIONAL_DEVPROPS + 3;
+				di->DeviceProps_len += NIKON_1_ADDITIONAL_DEVPROPS + 3;
 			}
 		}
 
 #if 0
 		if (!ptp_operation_issupported(&camera->pl->params, 0x9207)) {
-			C_MEM (di->OperationsSupported = realloc(di->OperationsSupported,sizeof(di->OperationsSupported[0])*(di->OperationsSupported_len + 2)));
-			di->OperationsSupported[di->OperationsSupported_len+0] = PTP_OC_NIKON_InitiateCaptureRecInSdram;
-			di->OperationsSupported[di->OperationsSupported_len+1] = PTP_OC_NIKON_AfCaptureSDRAM;
-			di->OperationsSupported_len+=2;
+			C_MEM (di->Operations = realloc(di->Operations,sizeof(di->Operations[0])*(di->Operations_len + 2)));
+			di->Operations[di->Operations_len+0] = PTP_OC_NIKON_InitiateCaptureRecInSdram;
+			di->Operations[di->Operations_len+1] = PTP_OC_NIKON_AfCaptureSDRAM;
+			di->Operations_len+=2;
 		}
 #endif
 	}
@@ -735,23 +735,23 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 					break;
 				}
 			}
-			C_MEM (di->DevicePropertiesSupported = realloc(di->DevicePropertiesSupported,sizeof(di->DevicePropertiesSupported[0])*(di->DevicePropertiesSupported_len + propcodes)));
-			C_MEM (di->OperationsSupported       = realloc(di->OperationsSupported,      sizeof(di->OperationsSupported[0])*(di->OperationsSupported_len + opcodes)));
-			C_MEM (di->EventsSupported           = realloc(di->EventsSupported,          sizeof(di->EventsSupported[0])*(di->EventsSupported_len + events)));
+			C_MEM (di->DeviceProps = realloc(di->DeviceProps, sizeof(di->DeviceProps[0])*(di->DeviceProps_len + propcodes)));
+			C_MEM (di->Operations  = realloc(di->Operations,  sizeof(di->Operations[0])*(di->Operations_len + opcodes)));
+			C_MEM (di->Events      = realloc(di->Events,      sizeof(di->Events[0])*(di->Events_len + events)));
 			j = 0; k = 0; l = 0;
 			for (i=0;i<xsize;i++) {
 				GP_LOG_D ("sony code: %x", xprops[i]);
 				switch (xprops[i] & 0x7000) {
-				case 0x1000: di->OperationsSupported      [(k++)+di->OperationsSupported_len]       = xprops[i]; break;
-				case 0x4000: di->EventsSupported          [(l++)+di->EventsSupported_len]           = xprops[i]; break;
-				case 0x5000: di->DevicePropertiesSupported[(j++)+di->DevicePropertiesSupported_len] = xprops[i]; break;
+				case 0x1000: di->Operations [(k++)+di->Operations_len]  = xprops[i]; break;
+				case 0x4000: di->Events     [(l++)+di->Events_len]      = xprops[i]; break;
+				case 0x5000: di->DeviceProps[(j++)+di->DeviceProps_len] = xprops[i]; break;
 				default:
 					break;
 				}
 			}
-			di->DevicePropertiesSupported_len += propcodes;
-			di->EventsSupported_len += events;
-			di->OperationsSupported_len += opcodes;
+			di->DeviceProps_len += propcodes;
+			di->Events_len += events;
+			di->Operations_len += opcodes;
 			free (xprops);
 			C_PTP (ptp_sony_sdioconnect (&camera->pl->params, 3, 0, 0));
 
@@ -782,23 +782,23 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 					break;
 				}
 			}
-			C_MEM (di->DevicePropertiesSupported = realloc(di->DevicePropertiesSupported,sizeof(di->DevicePropertiesSupported[0])*(di->DevicePropertiesSupported_len + propcodes)));
-			C_MEM (di->OperationsSupported       = realloc(di->OperationsSupported,      sizeof(di->OperationsSupported[0])*(di->OperationsSupported_len + opcodes)));
-			C_MEM (di->EventsSupported           = realloc(di->EventsSupported,          sizeof(di->EventsSupported[0])*(di->EventsSupported_len + events)));
+			C_MEM (di->DeviceProps = realloc(di->DeviceProps, sizeof(di->DeviceProps[0])*(di->DeviceProps_len + propcodes)));
+			C_MEM (di->Operations  = realloc(di->Operations,  sizeof(di->Operations[0])*(di->Operations_len + opcodes)));
+			C_MEM (di->Events      = realloc(di->Events,      sizeof(di->Events[0])*(di->Events_len + events)));
 			j = 0; k = 0; l = 0;
 			for (i=0;i<xsize;i++) {
 				GP_LOG_D ("sony code: %x", xprops[i]);
 				switch (xprops[i] & 0x7000) {
-				case 0x1000: di->OperationsSupported      [(k++)+di->OperationsSupported_len]       = xprops[i]; break;
-				case 0x4000: di->EventsSupported          [(l++)+di->EventsSupported_len]           = xprops[i]; break;
-				case 0x5000: di->DevicePropertiesSupported[(j++)+di->DevicePropertiesSupported_len] = xprops[i]; break;
+				case 0x1000: di->Operations [(k++)+di->Operations_len]  = xprops[i]; break;
+				case 0x4000: di->Events     [(l++)+di->Events_len]      = xprops[i]; break;
+				case 0x5000: di->DeviceProps[(j++)+di->DeviceProps_len] = xprops[i]; break;
 				default:
 					break;
 				}
 			}
-			di->DevicePropertiesSupported_len += propcodes;
-			di->EventsSupported_len += events;
-			di->OperationsSupported_len += opcodes;
+			di->DeviceProps_len += propcodes;
+			di->Events_len += events;
+			di->Operations_len += opcodes;
 			free (xprops);
 			C_PTP (ptp_sony_qx_connect (&camera->pl->params, 3, 0xda01, 0xda01));
 
@@ -812,10 +812,10 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 			int i;
 
 			C_PTP (ptp_canon_eos_getdeviceinfo (&camera->pl->params, &eosdi));
-			C_MEM (di->DevicePropertiesSupported = realloc(di->DevicePropertiesSupported,sizeof(di->DevicePropertiesSupported[0])*(di->DevicePropertiesSupported_len + eosdi.DevicePropertiesSupported_len)));
-			for (i=0;i<eosdi.DevicePropertiesSupported_len;i++)
-				di->DevicePropertiesSupported[i+di->DevicePropertiesSupported_len] = eosdi.DevicePropertiesSupported[i];
-			di->DevicePropertiesSupported_len += eosdi.DevicePropertiesSupported_len;
+			C_MEM (di->DeviceProps = realloc(di->DeviceProps,sizeof(di->DeviceProps[0])*(di->DeviceProps_len + eosdi.DeviceProps_len)));
+			for (i=0;i<eosdi.DeviceProps_len;i++)
+				di->DeviceProps[i+di->DeviceProps_len] = eosdi.DeviceProps[i];
+			di->DeviceProps_len += eosdi.DeviceProps_len;
 		}
 	}
 #endif
@@ -7949,9 +7949,9 @@ camera_summary (Camera* camera, CameraText* summary, GPContext *context)
 	 */
 	C_PTP_REP (ptp_getdeviceinfo (params, &pdi));
 	CR (fixup_cached_deviceinfo (camera, &pdi));
-	for (i=0;i<pdi.DevicePropertiesSupported_len;i++) {
+	for (i=0;i<pdi.DeviceProps_len;i++) {
 		PTPDevicePropDesc dpd;
-		unsigned int dpc = pdi.DevicePropertiesSupported[i];
+		unsigned int dpc = pdi.DeviceProps[i];
 		const char *propname = ptp_get_property_description (params, dpc);
 
 		/* drop the "EOS_" prefix */

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -8327,7 +8327,7 @@ ptp_mtp_render_metadata (
 	uint16_t ret, *props = NULL;
 	uint32_t propcnt = 0;
 	unsigned int j;
-	MTPProperties	*mprops;
+	MTPObjectProp	*mprops;
 	PTPObject	*ob;
 
 	C_PTP (ptp_object_want (params, object_id, PTPOBJECT_MTPPROPLIST_LOADED, &ob));
@@ -8343,10 +8343,10 @@ ptp_mtp_render_metadata (
 		unsigned int	i, n;
 
 		for (j=0;j<ob->mtp_props_len;j++) {
-			MTPProperties		*xpl = &mprops[j];
+			MTPObjectProp		*xpl = &mprops[j];
 
 			for (i=0;i<ARRAYSIZE(uninteresting_props);i++)
-				if (uninteresting_props[i] == xpl->property)
+				if (uninteresting_props[i] == xpl->PropCode)
 					break;
 			/* Is uninteresting. */
 			if (i != ARRAYSIZE(uninteresting_props))
@@ -8354,28 +8354,28 @@ ptp_mtp_render_metadata (
 
 			for(i=0;i<propcnt;i++) {
 				/* Mark handled property as 0 */
-				if (props[i] == xpl->property) {
+				if (props[i] == xpl->PropCode) {
 					props[i]=0;
 					break;
 				}
 			}
 
-			n = ptp_render_mtp_propname(xpl->property, sizeof(propname), propname);
+			n = ptp_render_mtp_propname(xpl->PropCode, sizeof(propname), propname);
 			gp_file_append (file, "<", 1);
 			gp_file_append (file, propname, n);
 			gp_file_append (file, ">", 1);
 
-			switch (xpl->datatype) {
-			case PTP_DTC_STR:   snprintf (text, sizeof(text), "%s", xpl->propval.str?xpl->propval.str:""); break;
-			case PTP_DTC_INT64:  sprintf (text, "%ld", xpl->propval.i64); break;
-			case PTP_DTC_INT32:  sprintf (text, "%d", xpl->propval.i32); break;
-			case PTP_DTC_INT16:  sprintf (text, "%d", xpl->propval.i16); break;
-			case PTP_DTC_INT8:   sprintf (text, "%d", xpl->propval.i8); break;
-			case PTP_DTC_UINT64: sprintf (text, "%lu", xpl->propval.u64); break;
-			case PTP_DTC_UINT32: sprintf (text, "%u", xpl->propval.u32); break;
-			case PTP_DTC_UINT16: sprintf (text, "%u", xpl->propval.u16); break;
-			case PTP_DTC_UINT8:  sprintf (text, "%u", xpl->propval.u8); break;
-			default:             sprintf (text, "Unknown type %d", xpl->datatype); break;
+			switch (xpl->DataType) {
+			case PTP_DTC_STR:   snprintf (text, sizeof(text), "%s", xpl->Value.str?xpl->Value.str:""); break;
+			case PTP_DTC_INT64:  sprintf (text, "%ld", xpl->Value.i64); break;
+			case PTP_DTC_INT32:  sprintf (text, "%d", xpl->Value.i32); break;
+			case PTP_DTC_INT16:  sprintf (text, "%d", xpl->Value.i16); break;
+			case PTP_DTC_INT8:   sprintf (text, "%d", xpl->Value.i8); break;
+			case PTP_DTC_UINT64: sprintf (text, "%lu", xpl->Value.u64); break;
+			case PTP_DTC_UINT32: sprintf (text, "%u", xpl->Value.u32); break;
+			case PTP_DTC_UINT16: sprintf (text, "%u", xpl->Value.u16); break;
+			case PTP_DTC_UINT8:  sprintf (text, "%u", xpl->Value.u8); break;
+			default:             sprintf (text, "Unknown type %d", xpl->DataType); break;
 			}
 			gp_file_append (file, text, strlen(text));
 			gp_file_append (file, "</", 2);
@@ -8518,7 +8518,7 @@ ptp_mtp_parse_metadata (
 		case PTP_DTC_UINT16: sscanf (content, "%hu", &pv.u16); break;
 		case PTP_DTC_UINT8:  sscanf (content, "%hhu", &pv.u8); break;
 		default:
-			GP_LOG_E ("mtp parser: Unknown datatype %d, content %s", opd.DataType, content);
+			GP_LOG_E ("mtp parser: Unknown DataType %d, content %s", opd.DataType, content);
 			free (content); content = NULL;
 			continue;
 			break;

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -3055,7 +3055,7 @@ camera_abilities (CameraAbilitiesList *list)
 	unsigned int i;
 	CameraAbilities a;
 
-	for (i = 0; i < sizeof(models)/sizeof(models[0]); i++) {
+	for (i = 0; i < ARRAYSIZE(models); i++) {
 		memset(&a, 0, sizeof(a));
 		strcpy (a.model, models[i].model);
 		a.status		= GP_DRIVER_STATUS_PRODUCTION;
@@ -3116,7 +3116,7 @@ camera_abilities (CameraAbilitiesList *list)
 		}
 		CR (gp_abilities_list_append (list, a));
 	}
-	for (i = 0; i < sizeof(mtp_models)/sizeof(mtp_models[0]); i++) {
+	for (i = 0; i < ARRAYSIZE(mtp_models); i++) {
 		memset(&a, 0, sizeof(a));
 		sprintf (a.model, "%s:%s", mtp_models[i].vendor, mtp_models[i].model);
 		a.status		= GP_DRIVER_STATUS_PRODUCTION;
@@ -3167,7 +3167,7 @@ camera_abilities (CameraAbilitiesList *list)
 	a.device_type       = GP_DEVICE_AUDIO_PLAYER;
 	CR (gp_abilities_list_append (list, a));
 
-	for (i = 0; i < sizeof(ptpip_models)/sizeof(ptpip_models[0]); i++) {
+	for (i = 0; i < ARRAYSIZE(ptpip_models); i++) {
 		memset(&a, 0, sizeof(a));
 		strcpy(a.model, ptpip_models[i].model);
 		a.status 		= GP_DRIVER_STATUS_TESTING;
@@ -8345,11 +8345,11 @@ ptp_mtp_render_metadata (
 		for (j=0;j<ob->nrofmtpprops;j++) {
 			MTPProperties		*xpl = &mprops[j];
 
-			for (i=0;i<sizeof(uninteresting_props)/sizeof(uninteresting_props[0]);i++)
+			for (i=0;i<ARRAYSIZE(uninteresting_props);i++)
 				if (uninteresting_props[i] == xpl->property)
 					break;
 			/* Is uninteresting. */
-			if (i != sizeof(uninteresting_props)/sizeof(uninteresting_props[0]))
+			if (i != ARRAYSIZE(uninteresting_props))
 				continue;
 
 			for(i=0;i<propcnt;i++) {
@@ -8393,7 +8393,7 @@ ptp_mtp_render_metadata (
 
 		if (!props[j]) continue; /* handle above */
 
-		for (i=sizeof(uninteresting_props)/sizeof(uninteresting_props[0]);i--;)
+		for (i=ARRAYSIZE(uninteresting_props);i--;)
 			if (uninteresting_props[i] == props[j])
 				break;
 		if (i != -1) /* Is uninteresting. */
@@ -8478,7 +8478,7 @@ ptp_mtp_parse_metadata (
 		int 			i;
 		PTPPropValue		pv;
 
-		for (i=sizeof(readonly_props)/sizeof(readonly_props[0]);i--;)
+		for (i=ARRAYSIZE(readonly_props);i--;)
 			if (readonly_props[i] == props[j])
 				break;
 		if (i != -1) /* Is read/only */
@@ -9712,7 +9712,7 @@ camera_init (Camera *camera, GPContext *context)
 	}
 #endif
 
-	for (i = 0; i<sizeof(models)/sizeof(models[0]); i++) {
+	for (i = 0; i<ARRAYSIZE(models); i++) {
 		if ((a.usb_vendor == models[i].usb_vendor) &&
 		    (a.usb_product == models[i].usb_product)) {
 			params->device_flags = models[i].device_flags;
@@ -9723,7 +9723,7 @@ camera_init (Camera *camera, GPContext *context)
 		params->device_flags |= DEVICE_FLAG_BROKEN_MTPGETOBJPROPLIST;
 	}
 	/* map the libmtp flags to ours. Currently its just 1 flag. */
-	for (i = 0; i<sizeof(mtp_models)/sizeof(mtp_models[0]); i++) {
+	for (i = 0; i<ARRAYSIZE(mtp_models); i++) {
 		if ((a.usb_vendor == mtp_models[i].usb_vendor) &&
 		    (a.usb_product == mtp_models[i].usb_product)) {
 			params->device_flags = mtp_models[i].flags;

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -6017,12 +6017,12 @@ camera_trigger_canon_eos_capture (Camera *camera, GPContext *context)
 			if (dpd.CurrentValue.u32 < 100) {
 				/* Tell the camera we have enough free space on the PC */
 #if 0
-				if (!params->uilocked)
+				if (!params->eos_uilocked)
 					ptp_canon_eos_setuilock(params);
 #endif
 				LOG_ON_PTP_E (ptp_canon_eos_pchddcapacity(params, 0x0fffffff, 0x00001000, 0x00000001));
 #if 0
-				if (!params->uilocked)
+				if (!params->eos_uilocked)
 					ptp_canon_eos_resetuilock(params);
 #endif
 			}

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -6788,7 +6788,7 @@ camera_wait_for_event (Camera *camera, int timeout,
 					/* cached devprop should have been flushed I think... */
 					C_PTP_REP (ptp_canon_eos_getdevicepropdesc (params, event.u.propid, &dpd));
 
-					dpd.DevicePropertyCode = event.u.propid;
+					dpd.DevicePropCode = event.u.propid;
 					ret = camera_lookup_by_property(camera, &dpd, &name, &content, context);
 					if (ret == GP_OK) {
 						*eventdata = aprintf("PTP Property %04x changed, \"%s\" to \"%s\"", event.u.propid, name, content?content:"");

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -7979,9 +7979,9 @@ camera_summary (Camera* camera, CameraText* summary, GPContext *context)
 			case PTP_DPFF_None:	break;
 			case PTP_DPFF_Range: {
 				APPEND_TXT ("Range [");
-				txt += snprintf_ptp_property (txt, SPACE_LEFT, &dpd.FORM.Range.MinimumValue, dpd.DataType);
+				txt += snprintf_ptp_property (txt, SPACE_LEFT, &dpd.FORM.Range.MinValue, dpd.DataType);
 				APPEND_TXT (" - ");
-				txt += snprintf_ptp_property (txt, SPACE_LEFT, &dpd.FORM.Range.MaximumValue, dpd.DataType);
+				txt += snprintf_ptp_property (txt, SPACE_LEFT, &dpd.FORM.Range.MaxValue, dpd.DataType);
 				APPEND_TXT (", step ");
 				txt += snprintf_ptp_property (txt, SPACE_LEFT, &dpd.FORM.Range.StepSize, dpd.DataType);
 				APPEND_TXT ("] value: ");

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -4949,10 +4949,10 @@ camera_sony_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pat
 	C_PTP (ptp_generic_getdevicepropdesc (params, PTP_DPC_CompressionSetting, &dpd));
 
 	GP_LOG_D ("PTP_DPC_CompressionSetting dpd.CurrentValue.u8 = %x", dpd.CurrentValue.u8);
-	GP_LOG_D ("PTP_DPC_CompressionSetting dpd.FactoryDefaultValue.u8 = %x", dpd.FactoryDefaultValue.u8);
+	GP_LOG_D ("PTP_DPC_CompressionSetting dpd.DefaultValue.u8 = %x", dpd.DefaultValue.u8);
 
 	if (dpd.CurrentValue.u8 == 0)
-		dpd.CurrentValue.u8 = dpd.FactoryDefaultValue.u8;
+		dpd.CurrentValue.u8 = dpd.DefaultValue.u8;
 	if (dpd.CurrentValue.u8 == 0x13) {
 		GP_LOG_D ("expecting raw+jpeg capture");
 	}
@@ -5102,10 +5102,10 @@ camera_sony_qx_capture (Camera *camera, CameraCaptureType type, CameraFilePath *
 	C_PTP (ptp_generic_getdevicepropdesc (params, PTP_DPC_CompressionSetting, &dpd));
 
 	GP_LOG_D ("dpd.CurrentValue.u8 = %x", dpd.CurrentValue.u8);
-	GP_LOG_D ("dpd.FactoryDefaultValue.u8 = %x", dpd.FactoryDefaultValue.u8);
+	GP_LOG_D ("dpd.DefaultValue.u8 = %x", dpd.DefaultValue.u8);
 
 	if (dpd.CurrentValue.u8 == 0)
-		dpd.CurrentValue.u8 = dpd.FactoryDefaultValue.u8;
+		dpd.CurrentValue.u8 = dpd.DefaultValue.u8;
 	if (dpd.CurrentValue.u8 == 0x13) {
 		GP_LOG_D ("expecting raw+jpeg capture");
 	}
@@ -5475,10 +5475,10 @@ camera_panasonic_capture (Camera *camera, CameraCaptureType type, CameraFilePath
 	//C_PTP (ptp_generic_getdevicepropdesc (params, PTP_DPC_CompressionSetting, &dpd));
 
 	//GP_LOG_D ("dpd.CurrentValue.u8 = %x", dpd.CurrentValue.u8);
-	//GP_LOG_D ("dpd.FactoryDefaultValue.u8 = %x", dpd.FactoryDefaultValue.u8);
+	//GP_LOG_D ("dpd.DefaultValue.u8 = %x", dpd.DefaultValue.u8);
 
 	//if (dpd.CurrentValue.u8 == 0)
-	//	dpd.CurrentValue.u8 = dpd.FactoryDefaultValue.u8;
+	//	dpd.CurrentValue.u8 = dpd.DefaultValue.u8;
 	//if (dpd.CurrentValue.u8 == 0x13) {
 	//	GP_LOG_D ("expecting raw+jpeg capture");
 	//}

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -235,7 +235,7 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 		(camera->port->type == GP_PORT_USB) &&
 		(a.usb_vendor == 0x04da)
 	) {
-		PTPPropertyValue propval;
+		PTPPropValue propval;
 		/* Panasonic changes its device info if the MTP Initiator
 		 * is set, and e.g. adds DeleteObject.
 		 * (found in Windows USB traces) */
@@ -716,7 +716,7 @@ fixup_cached_deviceinfo (Camera *camera, PTPDeviceInfo *di) {
 			uint16_t  	*xprops;
 			unsigned int	xsize = 0;
 			unsigned int	tries = 20;
-			PTPPropertyValue propval;
+			PTPPropValue propval;
 
 			C_PTP (ptp_sony_sdioconnect (&camera->pl->params, 1, 0, 0));
 			C_PTP (ptp_sony_sdioconnect (&camera->pl->params, 2, 0, 0));
@@ -3259,7 +3259,7 @@ camera_exit (Camera *camera, GPContext *context)
 			CR (camera_unprepare_capture (camera, context));
 			break;
 		case PTP_VENDOR_GP_OLYMPUS_OMD: {
-			PTPPropertyValue propval;
+			PTPPropValue propval;
 
 			propval.u16 = 0;
 			CR (ptp_setdevicepropvalue (params, 0xD052, &propval, PTP_DTC_UINT16));
@@ -3447,11 +3447,11 @@ save_jpeg_in_data_to_preview(const unsigned char *data, unsigned long size, Came
 
 static int
 camera_capture_stream_preview (Camera *camera, CameraFile *file, GPContext *context) {
-	PTPParams		*params = &camera->pl->params;
-	PTPPropertyValue	propval;
-	PTPStreamInfo		sinfo;
-	unsigned char		*data;
-	unsigned int		size;
+	PTPParams	*params = &camera->pl->params;
+	PTPPropValue	propval;
+	PTPStreamInfo	sinfo;
+	unsigned char	*data;
+	unsigned int	size;
 
 	C_PTP (ptp_getdevicepropvalue (params, PTP_DPC_EnabledStreams, &propval, PTP_DTC_UINT32));
 	if (!(propval.u32 & 1)) {	/* video enabled already ? */
@@ -3545,7 +3545,7 @@ camera_capture_preview (Camera *camera, CameraFile *file, GPContext *context)
 		}
 		/* Canon EOS DSLR preview mode */
 		if (ptp_operation_issupported(params, PTP_OC_CANON_EOS_GetViewFinderData)) {
-			PTPPropertyValue	val;
+			PTPPropValue	val;
 			/* FIXME: this might cause a focusing pass and take seconds. 20 was not
 			 * enough (would be 0.2 seconds, too short for the mirror up operation.). */
 			/* The EOS 100D takes 1.2 seconds */
@@ -3678,8 +3678,8 @@ camera_capture_preview (Camera *camera, CameraFile *file, GPContext *context)
 		gp_context_error (context, _("Sorry, your Canon camera does not support Canon Viewfinder mode"));
 		return GP_ERROR_NOT_SUPPORTED;
 	case PTP_VENDOR_NIKON: {
-		PTPPropertyValue	value;
-		int 			tries, firstimage = 0;
+		PTPPropValue	value;
+		int 		tries, firstimage = 0;
 
 		if (!ptp_operation_issupported(params, PTP_OC_NIKON_StartLiveView)) {
 			gp_context_error (context, _("Sorry, your Nikon camera does not support LiveView mode"));
@@ -3707,7 +3707,7 @@ enable_liveview:
 				LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_NIKON_RecordingMedia, &value, PTP_DTC_UINT8));
 
 			if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_NIKON_LiveViewProhibitCondition)) {
-				PTPPropertyValue	cond;
+				PTPPropValue	cond;
 
 				C_PTP (ptp_getdevicepropvalue (params, PTP_DPC_NIKON_LiveViewProhibitCondition, &cond, PTP_DTC_UINT32));
 
@@ -3960,9 +3960,9 @@ ignoreerror:
 		return GP_OK;
 	}
 	case PTP_VENDOR_GP_OLYMPUS_OMD: {
-		unsigned char		*ximage = NULL;
-		PTPPropertyValue	value;
-		int			tries = 25;
+		unsigned char	*ximage = NULL;
+		PTPPropValue	value;
+		int		tries = 25;
 
 		ret = ptp_getdevicepropvalue (params, PTP_DPC_OLYMPUS_LiveViewModeOM, &value, PTP_DTC_UINT32);
 		if (ret != PTP_RC_OK)
@@ -4026,7 +4026,7 @@ ignoreerror:
 	if (	ptp_operation_issupported(params,PTP_OC_GetStreamInfo) &&
 		ptp_property_issupported(params, PTP_DPC_SupportedStreams)
 	)  {
-		PTPPropertyValue propval;
+		PTPPropValue propval;
 
 		C_PTP (ptp_getdevicepropvalue (params, PTP_DPC_SupportedStreams, &propval, PTP_DTC_UINT32));
 		if (propval.u32 & 1) /* camera does Video streams */
@@ -4137,7 +4137,7 @@ camera_nikon_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pa
 	PTPObjectInfo		oi;
 	PTPParams		*params = &camera->pl->params;
 	PTPDevicePropDesc	propdesc;
-	PTPPropertyValue	propval;
+	PTPPropValue		propval;
 	int			i, ret, burstnumber = 1, done, tries;
 	uint32_t		newobject;
 	int			back_off_wait = 0;
@@ -4693,15 +4693,15 @@ static int
 camera_canon_capture (Camera *camera, CameraCaptureType type, CameraFilePath *path,
 		GPContext *context)
 {
-	PTPObjectInfo		oi;
-	int			found, ret, timeout, sawcapturecomplete = 0, viewfinderwason = 0;
-	PTPParams		*params = &camera->pl->params;
-	uint32_t		newobject = 0x0;
-	PTPPropertyValue	propval;
-	PTPContainer		event;
-	char 			buf[1024];
-	int			xmode = CANON_TRANSFER_CARD;
-	struct timeval		event_start;
+	PTPObjectInfo	oi;
+	int		found, ret, timeout, sawcapturecomplete = 0, viewfinderwason = 0;
+	PTPParams	*params = &camera->pl->params;
+	uint32_t	newobject = 0x0;
+	PTPPropValue	propval;
+	PTPContainer	event;
+	char 		buf[1024];
+	int		xmode = CANON_TRANSFER_CARD;
+	struct timeval	event_start;
 
 	if (!ptp_operation_issupported(params, PTP_OC_CANON_InitiateCaptureInMemory)) {
 		gp_context_error (context, _("Sorry, your Canon camera does not support Canon Capture initiation"));
@@ -4901,7 +4901,7 @@ static int
 camera_sony_capture (Camera *camera, CameraCaptureType type, CameraFilePath *path, GPContext *context)
 {
 	PTPParams	*params = &camera->pl->params;
-	PTPPropertyValue propval;
+	PTPPropValue	propval;
 	PTPContainer	event;
 	PTPObjectInfo	oi;
 	uint32_t	newobject = 0;
@@ -5080,7 +5080,7 @@ static int
 camera_sony_qx_capture (Camera *camera, CameraCaptureType type, CameraFilePath *path, GPContext *context)
 {
 	PTPParams	*params = &camera->pl->params;
-	PTPPropertyValue propval;
+	PTPPropValue	propval;
 	PTPObjectInfo	oi;
 	uint32_t	newobject = 0;
 	struct timeval	event_start;
@@ -5241,7 +5241,7 @@ static int
 camera_fuji_capture (Camera *camera, CameraCaptureType type, CameraFilePath *path, GPContext *context)
 {
 	PTPParams		*params = &camera->pl->params;
-	PTPPropertyValue	propval;
+	PTPPropValue		propval;
 	PTPObjectHandles	handles, beforehandles;
 	int			gotone;
 	uint32_t		newobject = 0, newobject2 = 0;
@@ -5566,8 +5566,8 @@ camera_olympus_omd_capture (Camera *camera, CameraCaptureType type, CameraFilePa
 	PTPContainer	event;
 	uint32_t	newobject = 0;
 	struct timeval	event_start;
-	int	     	back_off_wait = 0;
-	PTPPropertyValue propval;
+	int		back_off_wait = 0;
+	PTPPropValue	propval;
 
 	// clear out old events
 	//C_PTP_REP (ptp_check_event (params));
@@ -6235,7 +6235,7 @@ camera_trigger_capture (Camera *camera, GPContext *context)
 		/* If in liveview mode, we have to run non-af capture */
 		int inliveview = 0;
 		int tries;
-		PTPPropertyValue propval;
+		PTPPropValue propval;
 
 		C_PTP_REP (ptp_check_event (params));
 		C_PTP_REP (nikon_wait_busy (params, 100, 2000)); /* lets wait 2 seconds */
@@ -6295,7 +6295,7 @@ camera_trigger_capture (Camera *camera, GPContext *context)
 	) {
 		/* If in liveview mode, we have to run non-af capture */
 		int inliveview = 0;
-		PTPPropertyValue propval;
+		PTPPropValue propval;
 
 		C_PTP_REP (ptp_check_event (params));
 		C_PTP_REP (nikon_wait_busy (params, 20, 2000));
@@ -6333,7 +6333,7 @@ camera_trigger_capture (Camera *camera, GPContext *context)
 	) {
 		uint16_t xmode;
 		/*int viewfinderwason = 0;*/
-		PTPPropertyValue propval;
+		PTPPropValue propval;
 
 		if (!ptp_property_issupported(params, PTP_DPC_CANON_FlashMode)) {
 			/* did not call --set-config capture=on, do it for user */
@@ -6405,7 +6405,7 @@ camera_trigger_capture (Camera *camera, GPContext *context)
 	if (	(params->deviceinfo.VendorExtensionID == PTP_VENDOR_SONY) &&
 		ptp_operation_issupported(params, PTP_OC_SONY_SDIO_ControlDevice)
 	) {
-		PTPPropertyValue	propval;
+		PTPPropValue		propval;
 		struct timeval		event_start;
 		PTPContainer		event;
 		PTPDevicePropDesc	dpd;
@@ -6470,7 +6470,7 @@ camera_trigger_capture (Camera *camera, GPContext *context)
 	if (	(params->deviceinfo.VendorExtensionID == PTP_VENDOR_SONY) &&
 		ptp_operation_issupported(params, PTP_OC_SONY_QX_SetControlDeviceB)
 	) {
-		PTPPropertyValue	propval;
+		PTPPropValue		propval;
 		struct timeval		event_start;
 		PTPContainer		event;
 		PTPDevicePropDesc	dpd;
@@ -6514,7 +6514,7 @@ camera_trigger_capture (Camera *camera, GPContext *context)
 	if (	(params->deviceinfo.VendorExtensionID == PTP_VENDOR_FUJI) &&
 		ptp_operation_issupported(params, PTP_OC_InitiateCapture)
 	) {
-		PTPPropertyValue	propval;
+		PTPPropValue propval;
 
 		/* focus */
 		propval.u16 = 0x0200;
@@ -7167,7 +7167,7 @@ sonyout:
 	if (	(params->deviceinfo.VendorExtensionID == PTP_VENDOR_FUJI) &&
 		ptp_property_issupported(params, PTP_DPC_FUJI_CurrentState)
 	) {
-		PTPPropertyValue propval;
+		PTPPropValue propval;
 
 		/* reenable event wait mode */
 		if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
@@ -7529,7 +7529,7 @@ static int ptp_max(int a, int b) {
 }
 
 static int
-snprintf_ptp_property (char *txt, int spaceleft, PTPPropertyValue *data, uint16_t dt)
+snprintf_ptp_property (char *txt, int spaceleft, PTPPropValue *data, uint16_t dt)
 {
 	if (dt == PTP_DTC_STR)
 		return snprintf (txt, spaceleft, "'%s'", data->str);
@@ -7738,7 +7738,7 @@ camera_summary (Camera* camera, CameraText* summary, GPContext *context)
 	if (	ptp_operation_issupported(params,PTP_OC_GetStreamInfo) &&
 		ptp_property_issupported(params, PTP_DPC_SupportedStreams)
 	)  {
-		PTPPropertyValue propval;
+		PTPPropValue propval;
 
 		ret = ptp_getdevicepropvalue (params, PTP_DPC_SupportedStreams, &propval, PTP_DTC_UINT32);
 		if (ret == PTP_RC_OK) {
@@ -8406,7 +8406,7 @@ ptp_mtp_render_metadata (
 
 		ret = LOG_ON_PTP_E (ptp_mtp_getobjectpropdesc (params, props[j], ofc, &opd));
 		if (ret == PTP_RC_OK) {
-			PTPPropertyValue	pv;
+			PTPPropValue	pv;
 			ret = ptp_mtp_getobjectpropvalue (params, object_id, props[j], &pv, opd.DataType);
 			if (ret != PTP_RC_OK) {
 				sprintf (text, "failure to retrieve %x of oid %x, ret %x", props[j], object_id, ret);
@@ -8476,7 +8476,7 @@ ptp_mtp_parse_metadata (
 		char			*begin, *end, *content;
 		PTPObjectPropDesc	opd;
 		int 			i;
-		PTPPropertyValue	pv;
+		PTPPropValue		pv;
 
 		for (i=sizeof(readonly_props)/sizeof(readonly_props[0]);i--;)
 			if (readonly_props[i] == props[j])
@@ -9909,9 +9909,9 @@ camera_init (Camera *camera, GPContext *context)
 #if 1
 	/* Special fuji wlan init code */
 	if ((camera->port->type == GP_PORT_PTPIP)  && strstr(a.model,"Fuji")) {
-		PTPPropertyValue	propval;
-		GPPortInfo		info;
-		char 			*xpath;
+		PTPPropValue	propval;
+		GPPortInfo	info;
+		char 		*xpath;
 
 		ret = gp_port_get_info (camera->port, &info);
 		if (ret != GP_OK) {
@@ -10152,7 +10152,7 @@ camera_init (Camera *camera, GPContext *context)
 			ptp_getstorageinfo(params, params->storageids.Storage[0], &storageinfo);
 		}
 
-		PTPPropertyValue	propval;
+		PTPPropValue	propval;
 		if (!strncmp(params->deviceinfo.Model,"E-M5",4)) {
 			ptp_olympus_init_pc_mode(params);
 		}

--- a/camlibs/ptp2/olympus-wrap.c
+++ b/camlibs/ptp2/olympus-wrap.c
@@ -973,7 +973,7 @@ traverse_input_tree (PTPParams *params, xmlNodePtr node, PTPContainer *resp) {
 		if (!strcmp((char*)next->name,"param")) {
 			int x;
 			if (sscanf((char*)xmlNodeGetContent(next),"%x", &x)) {
-				if (curpar < sizeof(pars)/sizeof(pars[0]))
+				if (curpar < ARRAYSIZE(pars))
 					pars[curpar++] = x;
 				else
 					GP_LOG_E ("ignore superfluous argument %s/%x", (char*)xmlNodeGetContent(next), x);

--- a/camlibs/ptp2/olympus-wrap.c
+++ b/camlibs/ptp2/olympus-wrap.c
@@ -1198,8 +1198,8 @@ is_outer_operation (PTPParams* params, uint16_t opcode) {
 
 	/* Do nothing here, either do stuff in senddata, getdata or getresp,
 	 * which will get the PTPContainer req too. */
-	for (i=0;i<params->outer_deviceinfo.OperationsSupported_len;i++)
-		if (params->outer_deviceinfo.OperationsSupported[i]==opcode)
+	for (i=0;i<params->outer_deviceinfo.Operations_len;i++)
+		if (params->outer_deviceinfo.Operations[i]==opcode)
 			return TRUE;
 	GP_LOG_D ("is_outer_operation %04x - is WRAPPED", opcode);
 	return FALSE;

--- a/camlibs/ptp2/olympus-wrap.c
+++ b/camlibs/ptp2/olympus-wrap.c
@@ -671,7 +671,7 @@ xnext:
 
 #if 0
 static int
-parse_9301_value (PTPParams *params, const char *str, uint16_t type, PTPPropertyValue *propval) {
+parse_9301_value (PTPParams *params, const char *str, uint16_t type, PTPPropValue *propval) {
 	switch (type) {
 	case 6: { /*UINT32*/
 		unsigned int x;
@@ -822,7 +822,7 @@ parse_9301_propdesc (PTPParams *params, xmlNodePtr node, PTPDevicePropDesc *dpd)
 				n++;
 			} while (s);
 			dpd->FORM.Enum.NumberOfValues = n;
-			dpd->FORM.Enum.SupportedValue = calloc (n , sizeof(PTPPropertyValue));
+			dpd->FORM.Enum.SupportedValue = calloc (n , sizeof(PTPPropValue));
 			s = (char*)xmlNodeGetContent (next);
 			i = 0;
 			do {
@@ -858,8 +858,8 @@ parse_9301_propdesc (PTPParams *params, xmlNodePtr node, PTPDevicePropDesc *dpd)
 
 static int
 parse_1015_tree (xmlNodePtr node, uint16_t type) {
-	PTPPropertyValue	propval;
-	xmlNodePtr		next;
+	PTPPropValue	propval;
+	xmlNodePtr	next;
 
 	next = xmlFirstElementChild (node);
 	return parse_value ((char*)xmlNodeGetContent (next), type, &propval);

--- a/camlibs/ptp2/olympus-wrap.c
+++ b/camlibs/ptp2/olympus-wrap.c
@@ -434,9 +434,9 @@ olympus_xml_transfer (PTPParams *params,
 			ret = ptp_getobject (outerparams, newhandle, (unsigned char**)&resxml);
 			if (ret != PTP_RC_OK)
 				return ret;
-			evxml = malloc (oi.ObjectCompressedSize + 1);
-			memcpy (evxml, resxml, oi.ObjectCompressedSize);
-			evxml[oi.ObjectCompressedSize] = 0x00;
+			evxml = malloc (oi.ObjectSize + 1);
+			memcpy (evxml, resxml, oi.ObjectSize);
+			evxml[oi.ObjectSize] = 0x00;
 
 			GP_LOG_D ("file content: %s", evxml);
 
@@ -455,7 +455,7 @@ olympus_xml_transfer (PTPParams *params,
 			oi.ObjectFormat		= PTP_OFC_Script;
 			oi.StorageID 		= 0x80000001;
 			oi.Filename 		= "HRSPONSE.X3C";
-			oi.ObjectCompressedSize	= strlen(evxml);
+			oi.ObjectSize		= strlen(evxml);
 			size = ptp_pack_OI(params, &oi, &oidata);
 			res = ptp_transaction (outerparams, &ptp2, PTP_DP_SENDDATA, size, &oidata, NULL);
 			if (res != PTP_RC_OK)
@@ -482,7 +482,7 @@ olympus_xml_transfer (PTPParams *params,
 		oi.ObjectFormat		= PTP_OFC_Script;
 		oi.StorageID 		= 0x80000001;
 		oi.Filename 		= "HREQUEST.X3C";
-		oi.ObjectCompressedSize	= strlen(cmdxml);
+		oi.ObjectSize		= strlen(cmdxml);
 
 /*
 "HRSPONSE.X3C" ... sent back to camera after receiving an event.
@@ -525,9 +525,9 @@ redo:
 		ret = ptp_getobject (outerparams, newhandle, (unsigned char**)&resxml);
 		if (ret != PTP_RC_OK)
 			return ret;
-		*inxml = malloc (oi.ObjectCompressedSize + 1);
-		memcpy (*inxml, resxml, oi.ObjectCompressedSize);
-		(*inxml)[oi.ObjectCompressedSize] = 0x00;
+		*inxml = malloc (oi.ObjectSize + 1);
+		memcpy (*inxml, resxml, oi.ObjectSize);
+		(*inxml)[oi.ObjectSize] = 0x00;
 
 		GP_LOG_D ("file content: %s", *inxml);
 		/* parse it */
@@ -1252,9 +1252,9 @@ ums_wrap2_event_check (PTPParams* params, PTPContainer* req)
 		ret = ptp_getobject (outerparams, newhandle, (unsigned char**)&resxml);
 		if (ret != PTP_RC_OK)
 			return ret;
-		evxml = malloc (oi.ObjectCompressedSize + 1);
-		memcpy (evxml, resxml, oi.ObjectCompressedSize);
-		evxml[oi.ObjectCompressedSize] = 0x00;
+		evxml = malloc (oi.ObjectSize + 1);
+		memcpy (evxml, resxml, oi.ObjectSize);
+		evxml[oi.ObjectSize] = 0x00;
 
 		GP_LOG_D ("file content: %s", evxml);
 
@@ -1276,7 +1276,7 @@ ums_wrap2_event_check (PTPParams* params, PTPContainer* req)
 		oi.ObjectFormat		= PTP_OFC_Script;
 		oi.StorageID 		= 0x80000001;
 		oi.Filename 		= "HRSPONSE.X3C";
-		oi.ObjectCompressedSize	= strlen(evxml);
+		oi.ObjectSize		= strlen(evxml);
 		size = ptp_pack_OI(params, &oi, &oidata);
 		res = ptp_transaction (outerparams, &ptp2, PTP_DP_SENDDATA, size, &oidata, NULL);
 		if (res != PTP_RC_OK)

--- a/camlibs/ptp2/olympus-wrap.c
+++ b/camlibs/ptp2/olympus-wrap.c
@@ -798,9 +798,9 @@ parse_9301_propdesc (PTPParams *params, xmlNodePtr node, PTPDevicePropDesc *dpd)
 			dpd->GetSet = attr;
 			continue;
 		}
-		if (!strcmp((char*)next->name,"default")) {	/* propdesc.FactoryDefaultValue */
+		if (!strcmp((char*)next->name,"default")) {	/* propdesc.DefaultValue */
 			ptp_debug( params, "default value");
-			parse_9301_value (params, (char*)xmlNodeGetContent (next), type, &dpd->FactoryDefaultValue);
+			parse_9301_value (params, (char*)xmlNodeGetContent (next), type, &dpd->DefaultValue);
 			continue;
 		}
 		if (!strcmp((char*)next->name,"value")) {	/* propdesc.CurrentValue */

--- a/camlibs/ptp2/olympus-wrap.c
+++ b/camlibs/ptp2/olympus-wrap.c
@@ -837,11 +837,11 @@ parse_9301_propdesc (PTPParams *params, xmlNodePtr node, PTPDevicePropDesc *dpd)
 			char *s = (char*)xmlNodeGetContent (next);
 			dpd->FormFlag = PTP_DPFF_Range;
 			ptp_debug( params, "range");
-			parse_9301_value (params, s, type, &dpd->FORM.Range.MinimumValue); /* should turn ' ' into \0? */
+			parse_9301_value (params, s, type, &dpd->FORM.Range.MinValue); /* should turn ' ' into \0? */
 			s = strchr(s,' ');
 			if (!s) continue;
 			s++;
-			parse_9301_value (params, s, type, &dpd->FORM.Range.MaximumValue); /* should turn ' ' into \0? */
+			parse_9301_value (params, s, type, &dpd->FORM.Range.MaxValue); /* should turn ' ' into \0? */
 			s = strchr(s,' ');
 			if (!s) continue;
 			s++;

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -1704,7 +1704,7 @@ ptp_pack_EOS_CustomFuncEx (PTPParams* params, unsigned char* data, char* str)
 static inline PTPDevicePropDesc*
 ptp_find_eos_devicepropdesc(PTPParams *params, uint32_t dpc)
 {
-	for (unsigned j=0; j < params->nrofcanon_props; j++)
+	for (unsigned j=0; j < params->canon_props_len; j++)
 		if (params->canon_props[j].dpd.DevicePropCode == dpc)
 			return &params->canon_props[j].dpd;
 	return NULL;
@@ -1718,13 +1718,13 @@ _lookup_or_allocate_canon_prop(PTPParams *params, uint32_t dpc)
 	if (dpd)
 		return dpd;
 
-	unsigned j = params->nrofcanon_props;
+	unsigned j = params->canon_props_len;
 	params->canon_props = realloc(params->canon_props, sizeof(params->canon_props[0])*(j+1));
 	memset (&params->canon_props[j].dpd,0,sizeof(params->canon_props[j].dpd));
 	params->canon_props[j].dpd.DevicePropCode = dpc;
 	params->canon_props[j].dpd.GetSet = 1;
 	params->canon_props[j].dpd.FormFlag = PTP_DPFF_None;
-	params->nrofcanon_props = j+1;
+	params->canon_props_len = j+1;
 	return &params->canon_props[j].dpd;
 }
 

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -270,7 +270,7 @@ ptp_unpack_uint16_t_array(PTPParams *params, const uint8_t* data, uint32_t *offs
 #define PTP_di_VendorExtensionVersion	 6
 #define PTP_di_VendorExtensionDesc	 8
 #define PTP_di_FunctionalMode		 8
-#define PTP_di_OperationsSupported	10
+#define PTP_di_Operations	10
 
 static inline int
 ptp_unpack_DI (PTPParams *params, const unsigned char* data, PTPDeviceInfo *di, unsigned int datalen)
@@ -292,16 +292,16 @@ ptp_unpack_DI (PTPParams *params, const unsigned char* data, PTPDeviceInfo *di, 
 		return 0;
 	}
 	di->FunctionalMode = dtoh16o(data, offset);
-	if (!ptp_unpack_uint16_t_array(params, data, &offset, datalen, &di->OperationsSupported, &di->OperationsSupported_len)) {
-		ptp_debug (params, "failed to unpack OperationsSupported array");
+	if (!ptp_unpack_uint16_t_array(params, data, &offset, datalen, &di->Operations, &di->Operations_len)) {
+		ptp_debug (params, "failed to unpack Operations array");
 		return 0;
 	}
-	if (!ptp_unpack_uint16_t_array(params, data, &offset, datalen, &di->EventsSupported, &di->EventsSupported_len)) {
-		ptp_debug (params, "failed to unpack EventsSupported array");
+	if (!ptp_unpack_uint16_t_array(params, data, &offset, datalen, &di->Events, &di->Events_len)) {
+		ptp_debug (params, "failed to unpack Events array");
 		return 0;
 	}
-	if (!ptp_unpack_uint16_t_array(params, data, &offset, datalen, &di->DevicePropertiesSupported, &di->DevicePropertiesSupported_len)) {
-		ptp_debug (params, "failed to unpack DevicePropertiesSupported array");
+	if (!ptp_unpack_uint16_t_array(params, data, &offset, datalen, &di->DeviceProps, &di->DeviceProps_len)) {
+		ptp_debug (params, "failed to unpack DeviceProps array");
 		return 0;
 	}
 	if (!ptp_unpack_uint16_t_array(params, data, &offset, datalen, &di->CaptureFormats, &di->CaptureFormats_len)) {
@@ -337,8 +337,8 @@ ptp_unpack_EOS_DI (PTPParams *params, const unsigned char* data, PTPCanonEOSDevi
 
 	memset (di,0, sizeof(*di));
 
-	ptp_unpack_uint32_t_array(params, data, &offset, datalen, &di->EventsSupported, &di->EventsSupported_len);
-	ptp_unpack_uint32_t_array(params, data, &offset, datalen, &di->DevicePropertiesSupported, &di->DevicePropertiesSupported_len);
+	ptp_unpack_uint32_t_array(params, data, &offset, datalen, &di->Events, &di->Events_len);
+	ptp_unpack_uint32_t_array(params, data, &offset, datalen, &di->DeviceProps, &di->DeviceProps_len);
 	ptp_unpack_uint32_t_array(params, data, &offset, datalen, &di->unk, &di->unk_len);
 
 	return offset >= 16;

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -2285,9 +2285,9 @@ static unsigned int olcsizes[0x15][13] = {
 				ptp_debug (params, "%s OLC version is 0, skipping (might get set later)", prefix);
 				break;
 			}
-			if (olcver >= sizeof(olcsizes)/sizeof(olcsizes[0])) {
+			if (olcver >= ARRAYSIZE(olcsizes)) {
 				ptp_debug (params, "%s OLC version is 0x%02x, assuming latest known", prefix, olcver);
-				olcver = sizeof(olcsizes)/sizeof(olcsizes[0])-1;
+				olcver = ARRAYSIZE(olcsizes)-1;
 			}
 
 			mask = size >= 14 ? dtoh16a(curdata+8+4) : 0;

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -401,9 +401,9 @@ ptp_unpack_SI (PTPParams *params, const unsigned char* data, PTPStorageInfo *si,
 #define PTP_oi_StorageID		 0
 #define PTP_oi_ObjectFormat		 4
 #define PTP_oi_ProtectionStatus		 6
-#define PTP_oi_ObjectCompressedSize	 8
+#define PTP_oi_ObjectSize		 8
 #define PTP_oi_ThumbFormat		12
-#define PTP_oi_ThumbCompressedSize	14
+#define PTP_oi_ThumbSize		14
 #define PTP_oi_ThumbPixWidth		18
 #define PTP_oi_ThumbPixHeight		22
 #define PTP_oi_ImagePixWidth		26
@@ -437,11 +437,11 @@ ptp_pack_OI (PTPParams *params, PTPObjectInfo *oi, unsigned char** oidataptr)
 	htod32a(&oidata[PTP_oi_StorageID],oi->StorageID);
 	htod16a(&oidata[PTP_oi_ObjectFormat],oi->ObjectFormat);
 	htod16a(&oidata[PTP_oi_ProtectionStatus],oi->ProtectionStatus);
-	htod32a(&oidata[PTP_oi_ObjectCompressedSize],oi->ObjectCompressedSize);
+	htod32a(&oidata[PTP_oi_ObjectSize],oi->ObjectSize);
 	if (params->ocs64)
 		oidata += 4;
 	htod16a(&oidata[PTP_oi_ThumbFormat],oi->ThumbFormat);
-	htod32a(&oidata[PTP_oi_ThumbCompressedSize],oi->ThumbCompressedSize);
+	htod32a(&oidata[PTP_oi_ThumbSize],oi->ThumbSize);
 	htod32a(&oidata[PTP_oi_ThumbPixWidth],oi->ThumbPixWidth);
 	htod32a(&oidata[PTP_oi_ThumbPixHeight],oi->ThumbPixHeight);
 	htod32a(&oidata[PTP_oi_ImagePixWidth],oi->ImagePixWidth);
@@ -541,7 +541,7 @@ ptp_unpack_OI (PTPParams *params, const unsigned char* data, PTPObjectInfo *oi, 
 	oi->StorageID            = dtoh32a(data + PTP_oi_StorageID);
 	oi->ObjectFormat         = dtoh16a(data + PTP_oi_ObjectFormat);
 	oi->ProtectionStatus     = dtoh16a(data + PTP_oi_ProtectionStatus);
-	oi->ObjectCompressedSize = dtoh32a(data + PTP_oi_ObjectCompressedSize);
+	oi->ObjectSize           = dtoh32a(data + PTP_oi_ObjectSize);
 
 	/* Stupid Samsung Galaxy developers emit a 64bit objectcompressedsize */
 	if ((data[PTP_oi_filenamelen] == 0) && (data[PTP_oi_filenamelen+4] != 0)) {
@@ -551,7 +551,7 @@ ptp_unpack_OI (PTPParams *params, const unsigned char* data, PTPObjectInfo *oi, 
 		len -= 4;
 	}
 	oi->ThumbFormat         = dtoh16a(data + PTP_oi_ThumbFormat);
-	oi->ThumbCompressedSize = dtoh32a(data + PTP_oi_ThumbCompressedSize);
+	oi->ThumbSize           = dtoh32a(data + PTP_oi_ThumbSize);
 	oi->ThumbPixWidth       = dtoh32a(data + PTP_oi_ThumbPixWidth);
 	oi->ThumbPixHeight      = dtoh32a(data + PTP_oi_ThumbPixHeight);
 	oi->ImagePixWidth       = dtoh32a(data + PTP_oi_ImagePixWidth);
@@ -1349,9 +1349,9 @@ ObjectInfo for 'IMG_0199.JPG':
   StorageID: 0x00020001
   ObjectFormat: 0x3801
   ProtectionStatus: 0x0000
-  ObjectCompressedSize: 2217241
+  ObjectSize: 2217241
   ThumbFormat: 0x3808
-  ThumbCompressedSize: 5122
+  ThumbSize: 5122
   ThumbPixWidth: 160
   ThumbPixHeight: 120
   ImagePixWidth: 4000
@@ -1823,17 +1823,17 @@ ptp_unpack_EOS_events (PTPParams *params, const unsigned char* data, unsigned in
 				break;
 			}
 			e[i].type = ((ec == PTP_EC_CANON_EOS_ObjectAddedEx) ? PTP_EOSEvent_ObjectAdded : PTP_EOSEvent_ObjectInfoChanged);
-			e[i].u.object.oid                     = dtoh32a(curdata + PTP_cee_OA_ObjectID);
-			e[i].u.object.oi.StorageID            = dtoh32a(curdata + PTP_cee_OA_StorageID);
-			e[i].u.object.oi.ParentObject         = dtoh32a(curdata + PTP_cee_OA_Parent);
-			e[i].u.object.oi.ObjectFormat         = dtoh16a(curdata + PTP_cee_OA_OFC);
-			e[i].u.object.oi.ObjectCompressedSize = dtoh32a(curdata + PTP_cee_OA_Size);
-			e[i].u.object.oi.Filename             = strdup(((char*)curdata + PTP_cee_OA_Name));
+			e[i].u.object.oid              = dtoh32a(curdata + PTP_cee_OA_ObjectID);
+			e[i].u.object.oi.StorageID     = dtoh32a(curdata + PTP_cee_OA_StorageID);
+			e[i].u.object.oi.ParentObject  = dtoh32a(curdata + PTP_cee_OA_Parent);
+			e[i].u.object.oi.ObjectFormat  = dtoh16a(curdata + PTP_cee_OA_OFC);
+			e[i].u.object.oi.ObjectSize    = dtoh32a(curdata + PTP_cee_OA_Size);
+			e[i].u.object.oi.Filename      = strdup(((char*)curdata + PTP_cee_OA_Name));
 
 			ptp_debug (params, "%s objectinfo %s oid %08x, parent %08x, ofc %04x, size %ld, filename %s",
 			           prefix, ec == PTP_EC_CANON_EOS_ObjectAddedEx ? "added" : "changed",
 			           e[i].u.object.oid, e[i].u.object.oi.ParentObject, e[i].u.object.oi.ObjectFormat,
-			           e[i].u.object.oi.ObjectCompressedSize, e[i].u.object.oi.Filename);
+			           e[i].u.object.oi.ObjectSize, e[i].u.object.oi.Filename);
 			break;
 		case PTP_EC_CANON_EOS_ObjectAddedEx64:	/* FIXME: review if the data used is correct */
 			if (size < PTP_cee_OA64_Name+1) {
@@ -1841,15 +1841,15 @@ ptp_unpack_EOS_events (PTPParams *params, const unsigned char* data, unsigned in
 				break;
 			}
 			e[i].type = PTP_EOSEvent_ObjectAdded;
-			e[i].u.object.oid                     = dtoh32a(curdata + PTP_cee_OA64_ObjectID);
-			e[i].u.object.oi.StorageID            = dtoh32a(curdata + PTP_cee_OA64_StorageID);
-			e[i].u.object.oi.ParentObject         = dtoh32a(curdata + PTP_cee_OA64_Parent);
-			e[i].u.object.oi.ObjectFormat         = dtoh16a(curdata + PTP_cee_OA64_OFC);
-			e[i].u.object.oi.ObjectCompressedSize = dtoh32a(curdata + PTP_cee_OA64_Size);	/* FIXME: might be 64bit now */
-			e[i].u.object.oi.Filename             = strdup(((char*)curdata + PTP_cee_OA64_Name));
+			e[i].u.object.oid              = dtoh32a(curdata + PTP_cee_OA64_ObjectID);
+			e[i].u.object.oi.StorageID     = dtoh32a(curdata + PTP_cee_OA64_StorageID);
+			e[i].u.object.oi.ParentObject  = dtoh32a(curdata + PTP_cee_OA64_Parent);
+			e[i].u.object.oi.ObjectFormat  = dtoh16a(curdata + PTP_cee_OA64_OFC);
+			e[i].u.object.oi.ObjectSize    = dtoh32a(curdata + PTP_cee_OA64_Size);	/* FIXME: might be 64bit now */
+			e[i].u.object.oi.Filename      = strdup(((char*)curdata + PTP_cee_OA64_Name));
 			ptp_debug (params, "%s objectinfo added oid %08x, parent %08x, ofc %04x, size %ld, filename %s",
 			           prefix, e[i].u.object.oid, e[i].u.object.oi.ParentObject, e[i].u.object.oi.ObjectFormat,
-			           e[i].u.object.oi.ObjectCompressedSize, e[i].u.object.oi.Filename);
+			           e[i].u.object.oi.ObjectSize, e[i].u.object.oi.Filename);
 			break;
 		case PTP_EC_CANON_EOS_RequestObjectTransfer:
 		case PTP_EC_CANON_EOS_RequestObjectTransfer64:
@@ -1858,16 +1858,16 @@ ptp_unpack_EOS_events (PTPParams *params, const unsigned char* data, unsigned in
 				break;
 			}
 			e[i].type = PTP_EOSEvent_ObjectTransfer;
-			e[i].u.object.oid                     = dtoh32a(curdata + PTP_cee_OI_ObjectID);
-			e[i].u.object.oi.StorageID            = 0; /* use as marker */
-			e[i].u.object.oi.ObjectFormat         = dtoh16a(curdata + PTP_cee_OI_OFC);
-			e[i].u.object.oi.ParentObject         = 0; /* check, but use as marker */
-			e[i].u.object.oi.ObjectCompressedSize = dtoh32a(curdata + PTP_cee_OI_Size);
-			e[i].u.object.oi.Filename             = strdup(((char*)curdata + PTP_cee_OI_Name));
+			e[i].u.object.oid              = dtoh32a(curdata + PTP_cee_OI_ObjectID);
+			e[i].u.object.oi.StorageID     = 0; /* use as marker */
+			e[i].u.object.oi.ObjectFormat  = dtoh16a(curdata + PTP_cee_OI_OFC);
+			e[i].u.object.oi.ParentObject  = 0; /* check, but use as marker */
+			e[i].u.object.oi.ObjectSize    = dtoh32a(curdata + PTP_cee_OI_Size);
+			e[i].u.object.oi.Filename      = strdup(((char*)curdata + PTP_cee_OI_Name));
 
 			ptp_debug (params, "%s request object transfer oid %08x, ofc %04x, size %ld, filename %p",
 			           prefix, e[i].u.object.oid, e[i].u.object.oi.ObjectFormat,
-			           e[i].u.object.oi.ObjectCompressedSize, e[i].u.object.oi.Filename);
+			           e[i].u.object.oi.ObjectSize, e[i].u.object.oi.Filename);
 			break;
 		case PTP_EC_CANON_EOS_AvailListChanged: {	/* property desc */
 			if (size < PTP_cee_DPD_Data) {
@@ -2739,8 +2739,8 @@ ptp_unpack_canon_directory (
 		oi->ObjectFormat	= dtoh16a(cur + ptp_canon_dir_ofc);
 		oi->ParentObject	= dtoh32a(cur + ptp_canon_dir_parentid);
 		oi->Filename		= strdup((char*)(cur + ptp_canon_dir_name));
-		oi->ObjectCompressedSize= dtoh32a(cur + ptp_canon_dir_size);
-		oi->ThumbCompressedSize	= dtoh32a(cur + ptp_canon_dir_thumbsize);
+		oi->ObjectSize		= dtoh32a(cur + ptp_canon_dir_size);
+		oi->ThumbSize		= dtoh32a(cur + ptp_canon_dir_thumbsize);
 		oi->ImagePixWidth	= dtoh32a(cur + ptp_canon_dir_width);
 		oi->ImagePixHeight	= dtoh32a(cur + ptp_canon_dir_height);
 		oi->CaptureDate		= oi->ModificationDate = dtoh32a(cur + ptp_canon_dir_unixtime);
@@ -2839,15 +2839,15 @@ ptp_unpack_ptp11_manifest (
 		if (offset + 34 + 2 > datalen)
 			goto tooshort;
 
-		oif->ObjectHandle            = dtoh32o(data, offset);
-		oif->StorageID               = dtoh32o(data, offset);
-		oif->ObjectFormat            = dtoh16o(data, offset);
-		oif->ProtectionStatus        = dtoh16o(data, offset);
-		oif->ObjectCompressedSize64  = dtoh64o(data, offset);
-		oif->ParentObject            = dtoh32o(data, offset);
-		oif->AssociationType         = dtoh16o(data, offset);
-		oif->AssociationDesc         = dtoh32o(data, offset);
-		oif->SequenceNumber          = dtoh32o(data, offset);
+		oif->ObjectHandle      = dtoh32o(data, offset);
+		oif->StorageID         = dtoh32o(data, offset);
+		oif->ObjectFormat      = dtoh16o(data, offset);
+		oif->ProtectionStatus  = dtoh16o(data, offset);
+		oif->ObjectSize64      = dtoh64o(data, offset);
+		oif->ParentObject      = dtoh32o(data, offset);
+		oif->AssociationType   = dtoh16o(data, offset);
+		oif->AssociationDesc   = dtoh32o(data, offset);
+		oif->SequenceNumber    = dtoh32o(data, offset);
 
 		if (!ptp_unpack_string(params, data, &offset, datalen, &oif->Filename))
 			goto tooshort;

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -651,10 +651,10 @@ ptp_unpack_DPV (
 }
 
 /* Device Property pack/unpack */
-#define PTP_dpd_DevicePropertyCode	0
-#define PTP_dpd_DataType		2
-#define PTP_dpd_GetSet			4
-#define PTP_dpd_DefaultValue		5
+#define PTP_dpd_DevicePropCode	0
+#define PTP_dpd_DataType	2
+#define PTP_dpd_GetSet		4
+#define PTP_dpd_DefaultValue	5
 
 static inline int
 ptp_unpack_DPD (PTPParams *params, const unsigned char* data, PTPDevicePropDesc *dpd, unsigned int dpdlen, uint32_t *offset)
@@ -664,10 +664,10 @@ ptp_unpack_DPD (PTPParams *params, const unsigned char* data, PTPDevicePropDesc 
 	memset (dpd, 0, sizeof(*dpd));
 	if (dpdlen <= 5)
 		return 0;
-	dpd->DevicePropertyCode = dtoh16a(data + PTP_dpd_DevicePropertyCode);
-	dpd->DataType           = dtoh16a(data + PTP_dpd_DataType);
-	dpd->GetSet             = dtoh8a (data + PTP_dpd_GetSet);
-	dpd->FormFlag=PTP_DPFF_None;
+	dpd->DevicePropCode = dtoh16a(data + PTP_dpd_DevicePropCode);
+	dpd->DataType       = dtoh16a(data + PTP_dpd_DataType);
+	dpd->GetSet         = dtoh8a (data + PTP_dpd_GetSet);
+	dpd->FormFlag       = PTP_DPFF_None;
 
 	*offset = PTP_dpd_DefaultValue;
 	ret = ptp_unpack_DPV (params, data, offset, dpdlen, &dpd->DefaultValue, dpd->DataType);
@@ -733,7 +733,7 @@ outofmemory:
 }
 
 /* Device Property pack/unpack */
-#define PTP_dpd_Sony_DevicePropertyCode		0
+#define PTP_dpd_Sony_DevicePropCode		0
 #define PTP_dpd_Sony_DataType			2
 #define PTP_dpd_Sony_GetSet		4
 #define PTP_dpd_Sony_IsEnabled			5
@@ -750,12 +750,12 @@ ptp_unpack_Sony_DPD (PTPParams *params, const unsigned char* data, PTPDeviceProp
 		return 0;
 
 	memset (dpd, 0, sizeof(*dpd));
-	dpd->DevicePropertyCode = dtoh16a(data + PTP_dpd_Sony_DevicePropertyCode);
-	dpd->DataType           = dtoh16a(data + PTP_dpd_Sony_DataType);
-	dpd->GetSet             = dtoh8a (data + PTP_dpd_Sony_GetSet);
-	isenabled               = dtoh8a (data + PTP_dpd_Sony_IsEnabled);
+	dpd->DevicePropCode = dtoh16a(data + PTP_dpd_Sony_DevicePropCode);
+	dpd->DataType       = dtoh16a(data + PTP_dpd_Sony_DataType);
+	dpd->GetSet         = dtoh8a (data + PTP_dpd_Sony_GetSet);
+	isenabled           = dtoh8a (data + PTP_dpd_Sony_IsEnabled);
 
-	ptp_debug (params, "prop 0x%04x, datatype 0x%04x, isEnabled %d getset %d", dpd->DevicePropertyCode, dpd->DataType, isenabled, dpd->GetSet);
+	ptp_debug (params, "prop 0x%04x, datatype 0x%04x, isEnabled %d getset %d", dpd->DevicePropCode, dpd->DataType, isenabled, dpd->GetSet);
 
 	switch (isenabled) {
 	case 0: /* grayed out */
@@ -904,7 +904,7 @@ static inline void
 duplicate_DevicePropDesc(const PTPDevicePropDesc *src, PTPDevicePropDesc *dst) {
 	int i;
 
-	dst->DevicePropertyCode	= src->DevicePropertyCode;
+	dst->DevicePropCode	= src->DevicePropCode;
 	dst->DataType		= src->DataType;
 	dst->GetSet		= src->GetSet;
 
@@ -1705,7 +1705,7 @@ static inline PTPDevicePropDesc*
 ptp_find_eos_devicepropdesc(PTPParams *params, uint32_t dpc)
 {
 	for (unsigned j=0; j < params->nrofcanon_props; j++)
-		if (params->canon_props[j].dpd.DevicePropertyCode == dpc)
+		if (params->canon_props[j].dpd.DevicePropCode == dpc)
 			return &params->canon_props[j].dpd;
 	return NULL;
 }
@@ -1721,7 +1721,7 @@ _lookup_or_allocate_canon_prop(PTPParams *params, uint32_t dpc)
 	unsigned j = params->nrofcanon_props;
 	params->canon_props = realloc(params->canon_props, sizeof(params->canon_props[0])*(j+1));
 	memset (&params->canon_props[j].dpd,0,sizeof(params->canon_props[j].dpd));
-	params->canon_props[j].dpd.DevicePropertyCode = dpc;
+	params->canon_props[j].dpd.DevicePropCode = dpc;
 	params->canon_props[j].dpd.GetSet = 1;
 	params->canon_props[j].dpd.FormFlag = PTP_DPFF_None;
 	params->nrofcanon_props = j+1;

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -654,7 +654,7 @@ ptp_unpack_DPV (
 #define PTP_dpd_DevicePropertyCode	0
 #define PTP_dpd_DataType		2
 #define PTP_dpd_GetSet			4
-#define PTP_dpd_FactoryDefaultValue	5
+#define PTP_dpd_DefaultValue		5
 
 static inline int
 ptp_unpack_DPD (PTPParams *params, const unsigned char* data, PTPDevicePropDesc *dpd, unsigned int dpdlen, uint32_t *offset)
@@ -669,8 +669,8 @@ ptp_unpack_DPD (PTPParams *params, const unsigned char* data, PTPDevicePropDesc 
 	dpd->GetSet             = dtoh8a (data + PTP_dpd_GetSet);
 	dpd->FormFlag=PTP_DPFF_None;
 
-	*offset = PTP_dpd_FactoryDefaultValue;
-	ret = ptp_unpack_DPV (params, data, offset, dpdlen, &dpd->FactoryDefaultValue, dpd->DataType);
+	*offset = PTP_dpd_DefaultValue;
+	ret = ptp_unpack_DPV (params, data, offset, dpdlen, &dpd->DefaultValue, dpd->DataType);
 	if (!ret) goto outofmemory;
 	if ((dpd->DataType == PTP_DTC_STR) && (*offset == dpdlen))
 		return 1;
@@ -737,7 +737,7 @@ outofmemory:
 #define PTP_dpd_Sony_DataType			2
 #define PTP_dpd_Sony_GetSet		4
 #define PTP_dpd_Sony_IsEnabled			5
-#define PTP_dpd_Sony_FactoryDefaultValue	6
+#define PTP_dpd_Sony_DefaultValue		6
 	/* PTP_dpd_SonyCurrentValue 		6 + sizeof(DataType) */
 
 static inline int
@@ -746,7 +746,7 @@ ptp_unpack_Sony_DPD (PTPParams *params, const unsigned char* data, PTPDeviceProp
 	unsigned int ret;
 	unsigned int isenabled;
 
-	if (!data || dpdlen < PTP_dpd_Sony_FactoryDefaultValue)
+	if (!data || dpdlen < PTP_dpd_Sony_DefaultValue)
 		return 0;
 
 	memset (dpd, 0, sizeof(*dpd));
@@ -770,8 +770,8 @@ ptp_unpack_Sony_DPD (PTPParams *params, const unsigned char* data, PTPDeviceProp
 
 	dpd->FormFlag=PTP_DPFF_None;
 
-	*poffset = PTP_dpd_Sony_FactoryDefaultValue;
-	ret = ptp_unpack_DPV (params, data, poffset, dpdlen, &dpd->FactoryDefaultValue, dpd->DataType);
+	*poffset = PTP_dpd_Sony_DefaultValue;
+	ret = ptp_unpack_DPV (params, data, poffset, dpdlen, &dpd->DefaultValue, dpd->DataType);
 	if (!ret) goto outofmemory;
 	if ((dpd->DataType == PTP_DTC_STR) && (*poffset == dpdlen))
 		return 1;
@@ -783,7 +783,7 @@ ptp_unpack_Sony_DPD (PTPParams *params, const unsigned char* data, PTPDeviceProp
 	   values). In both cases Form Flag should be set to 0x00 and FORM is
 	   not present. */
 
-	if (*poffset==PTP_dpd_Sony_FactoryDefaultValue)
+	if (*poffset==PTP_dpd_Sony_DefaultValue)
 		return 1;
 
 	dpd->FormFlag = dtoh8o(data, *poffset);
@@ -908,7 +908,7 @@ duplicate_DevicePropDesc(const PTPDevicePropDesc *src, PTPDevicePropDesc *dst) {
 	dst->DataType		= src->DataType;
 	dst->GetSet		= src->GetSet;
 
-	duplicate_PropertyValue (&src->FactoryDefaultValue, &dst->FactoryDefaultValue, src->DataType);
+	duplicate_PropertyValue (&src->DefaultValue, &dst->DefaultValue, src->DataType);
 	duplicate_PropertyValue (&src->CurrentValue, &dst->CurrentValue, src->DataType);
 
 	dst->FormFlag		= src->FormFlag;
@@ -932,7 +932,7 @@ duplicate_DevicePropDesc(const PTPDevicePropDesc *src, PTPDevicePropDesc *dst) {
 #define PTP_opd_ObjectPropertyCode	0
 #define PTP_opd_DataType		2
 #define PTP_opd_GetSet			4
-#define PTP_opd_FactoryDefaultValue	5
+#define PTP_opd_DefaultValue		5
 
 static inline int
 ptp_unpack_OPD (PTPParams *params, const unsigned char* data, PTPObjectPropDesc *opd, unsigned int opdlen)
@@ -948,8 +948,8 @@ ptp_unpack_OPD (PTPParams *params, const unsigned char* data, PTPObjectPropDesc 
 	opd->DataType           = dtoh16a(data + PTP_opd_DataType);
 	opd->GetSet             = dtoh8a (data + PTP_opd_GetSet);
 
-	offset = PTP_opd_FactoryDefaultValue;
-	ret = ptp_unpack_DPV (params, data, &offset, opdlen, &opd->FactoryDefaultValue, opd->DataType);
+	offset = PTP_opd_DefaultValue;
+	ret = ptp_unpack_DPV (params, data, &offset, opdlen, &opd->DefaultValue, opd->DataType);
 	if (!ret) goto outofmemory;
 
 	if (offset + sizeof(uint32_t) > opdlen) goto outofmemory;
@@ -2160,45 +2160,45 @@ ptp_unpack_EOS_events (PTPParams *params, const unsigned char* data, unsigned in
 			}
 			switch (dpd->DataType) {
 			case PTP_DTC_INT32:
-				dpd->FactoryDefaultValue.i32	= dtoh32a(xdata);
-				dpd->CurrentValue.i32		= dtoh32a(xdata);
+				dpd->DefaultValue.i32 = dtoh32a(xdata);
+				dpd->CurrentValue.i32 = dtoh32a(xdata);
 				ptp_debug (params, INDENT "prop %x value == %d (i32)", dpc, dpd->CurrentValue.i32);
 				break;
 			case PTP_DTC_UINT32:
-				dpd->FactoryDefaultValue.u32	= dtoh32a(xdata);
-				dpd->CurrentValue.u32		= dtoh32a(xdata);
+				dpd->DefaultValue.u32 = dtoh32a(xdata);
+				dpd->CurrentValue.u32 = dtoh32a(xdata);
 				ptp_debug (params, INDENT "prop %x value == 0x%08x (u32)", dpc, dpd->CurrentValue.u32);
 				break;
 			case PTP_DTC_INT16:
-				dpd->FactoryDefaultValue.i16	= dtoh16a(xdata);
-				dpd->CurrentValue.i16		= dtoh16a(xdata);
+				dpd->DefaultValue.i16 = dtoh16a(xdata);
+				dpd->CurrentValue.i16 = dtoh16a(xdata);
 				ptp_debug (params, INDENT "prop %x value == %d (i16)", dpc, dpd->CurrentValue.i16);
 				break;
 			case PTP_DTC_UINT16:
-				dpd->FactoryDefaultValue.u16	= dtoh16a(xdata);
-				dpd->CurrentValue.u16		= dtoh16a(xdata);
+				dpd->DefaultValue.u16 = dtoh16a(xdata);
+				dpd->CurrentValue.u16 = dtoh16a(xdata);
 				ptp_debug (params, INDENT "prop %x value == 0x%04x (u16)", dpc, dpd->CurrentValue.u16);
 				break;
 			case PTP_DTC_UINT8:
-				dpd->FactoryDefaultValue.u8	= dtoh8a(xdata);
-				dpd->CurrentValue.u8		= dtoh8a(xdata);
+				dpd->DefaultValue.u8  = dtoh8a(xdata);
+				dpd->CurrentValue.u8  = dtoh8a(xdata);
 				ptp_debug (params, INDENT "prop %x value == 0x%02x (u8)", dpc, dpd->CurrentValue.u8);
 				break;
 			case PTP_DTC_INT8:
-				dpd->FactoryDefaultValue.i8	= dtoh8a(xdata);
-				dpd->CurrentValue.i8		= dtoh8a(xdata);
+				dpd->DefaultValue.i8  = dtoh8a(xdata);
+				dpd->CurrentValue.i8  = dtoh8a(xdata);
 				ptp_debug (params, INDENT "prop %x value == %d (i8)", dpc, dpd->CurrentValue.i8);
 				break;
 			case PTP_DTC_STR: {
 #if 0 /* 5D MII and 400D aktually store plain ASCII in their string properties */
-				dpd->FactoryDefaultValue.str	= ptp_unpack_string(params, data, 0, &len);
+				dpd->DefaultValue.str	= ptp_unpack_string(params, data, 0, &len);
 				dpd->CurrentValue.str		= ptp_unpack_string(params, data, 0, &len);
 #else
-				free (dpd->FactoryDefaultValue.str);
-				dpd->FactoryDefaultValue.str	= strdup( (char*)xdata );
+				free (dpd->DefaultValue.str);
+				dpd->DefaultValue.str = strdup( (char*)xdata );
 
 				free (dpd->CurrentValue.str);
-				dpd->CurrentValue.str		= strdup( (char*)xdata );
+				dpd->CurrentValue.str = strdup( (char*)xdata );
 #endif
 				ptp_debug (params, INDENT "prop %x value == '%s' (str)", dpc, dpd->CurrentValue.str);
 				break;
@@ -2215,24 +2215,24 @@ ptp_unpack_EOS_events (PTPParams *params, const unsigned char* data, unsigned in
 			case PTP_DPC_CANON_EOS_ImageFormatSD:
 			case PTP_DPC_CANON_EOS_ImageFormatExtHD:
 				dpd->DataType = PTP_DTC_UINT16;
-				dpd->FactoryDefaultValue.u16	= ptp_unpack_EOS_ImageFormat( params, &xdata );
-				dpd->CurrentValue.u16		= dpd->FactoryDefaultValue.u16;
+				dpd->DefaultValue.u16 = ptp_unpack_EOS_ImageFormat( params, &xdata );
+				dpd->CurrentValue.u16 = dpd->DefaultValue.u16;
 				ptp_debug (params, INDENT "prop %x value == 0x%04x (u16)", dpc, dpd->CurrentValue.u16);
 				break;
 			case PTP_DPC_CANON_EOS_CustomFuncEx:
 				dpd->DataType = PTP_DTC_STR;
-				free (dpd->FactoryDefaultValue.str);
+				free (dpd->DefaultValue.str);
 				free (dpd->CurrentValue.str);
-				dpd->FactoryDefaultValue.str	= ptp_unpack_EOS_CustomFuncEx( params, &xdata );
-				dpd->CurrentValue.str		= strdup( (char*)dpd->FactoryDefaultValue.str );
+				dpd->DefaultValue.str = ptp_unpack_EOS_CustomFuncEx( params, &xdata );
+				dpd->CurrentValue.str = strdup( (char*)dpd->DefaultValue.str );
 				ptp_debug (params, INDENT "prop %x value == %s", dpc, dpd->CurrentValue.str);
 				break;
 			case PTP_DPC_CANON_EOS_FocusInfoEx:
 				dpd->DataType = PTP_DTC_STR;
-				free (dpd->FactoryDefaultValue.str);
+				free (dpd->DefaultValue.str);
 				free (dpd->CurrentValue.str);
-				dpd->FactoryDefaultValue.str	= ptp_unpack_EOS_FocusInfoEx( params, &xdata, xsize );
-				dpd->CurrentValue.str		= strdup( (char*)dpd->FactoryDefaultValue.str );
+				dpd->DefaultValue.str = ptp_unpack_EOS_FocusInfoEx( params, &xdata, xsize );
+				dpd->CurrentValue.str = strdup( (char*)dpd->DefaultValue.str );
 				ptp_debug (params, INDENT "prop %x value == %s", dpc, dpd->CurrentValue.str);
 				break;
 			/* case PTP_DPC_CANON_EOS_ShutterReleaseCounter:

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -929,10 +929,10 @@ duplicate_DevicePropDesc(const PTPDevicePropDesc *src, PTPDevicePropDesc *dst) {
 	}
 }
 
-#define PTP_opd_ObjectPropertyCode	0
-#define PTP_opd_DataType		2
-#define PTP_opd_GetSet			4
-#define PTP_opd_DefaultValue		5
+#define PTP_opd_ObjectPropCode	0
+#define PTP_opd_DataType	2
+#define PTP_opd_GetSet		4
+#define PTP_opd_DefaultValue	5
 
 static inline int
 ptp_unpack_OPD (PTPParams *params, const unsigned char* data, PTPObjectPropDesc *opd, unsigned int opdlen)
@@ -944,9 +944,9 @@ ptp_unpack_OPD (PTPParams *params, const unsigned char* data, PTPObjectPropDesc 
 	if (opdlen < 5)
 		return 0;
 
-	opd->ObjectPropertyCode = dtoh16a(data + PTP_opd_ObjectPropertyCode);
-	opd->DataType           = dtoh16a(data + PTP_opd_DataType);
-	opd->GetSet             = dtoh8a (data + PTP_opd_GetSet);
+	opd->ObjectPropCode = dtoh16a(data + PTP_opd_ObjectPropCode);
+	opd->DataType       = dtoh16a(data + PTP_opd_DataType);
+	opd->GetSet         = dtoh8a (data + PTP_opd_GetSet);
 
 	offset = PTP_opd_DefaultValue;
 	ret = ptp_unpack_DPV (params, data, &offset, opdlen, &opd->DefaultValue, opd->DataType);

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -604,7 +604,7 @@ ptp_unpack_OI (PTPParams *params, const unsigned char* data, PTPObjectInfo *oi, 
 static inline unsigned int
 ptp_unpack_DPV (
 	PTPParams *params, const unsigned char* data, unsigned int *offset, unsigned int total,
-	PTPPropertyValue* value, uint16_t datatype
+	PTPPropValue* value, uint16_t datatype
 ) {
 	if (*offset >= total)	/* we are at the end or over the end of the buffer */
 		return 0;
@@ -864,7 +864,7 @@ outofmemory:
 }
 
 static inline void
-duplicate_PropertyValue (const PTPPropertyValue *src, PTPPropertyValue *dst, uint16_t type) {
+duplicate_PropertyValue (const PTPPropValue *src, PTPPropValue *dst, uint16_t type) {
 	if (type == PTP_DTC_STR) {
 		if (src->str)
 			dst->str = strdup(src->str);
@@ -1020,7 +1020,7 @@ outofmemory:
 }
 
 static inline uint32_t
-ptp_pack_DPV (PTPParams *params, PTPPropertyValue* value, unsigned char** dpvptr, uint16_t datatype)
+ptp_pack_DPV (PTPParams *params, PTPPropValue* value, unsigned char** dpvptr, uint16_t datatype)
 {
 	unsigned char* dpv=NULL;
 	uint32_t size=0;
@@ -1901,7 +1901,7 @@ ptp_unpack_EOS_events (PTPParams *params, const unsigned char* data, unsigned in
 			dpd->FormFlag = PTP_DPFF_Enumeration;
 			dpd->FORM.Enum.NumberOfValues = dpd_count;
 			free (dpd->FORM.Enum.SupportedValue);
-			dpd->FORM.Enum.SupportedValue = calloc (dpd_count, sizeof (PTPPropertyValue));
+			dpd->FORM.Enum.SupportedValue = calloc (dpd_count, sizeof (PTPPropValue));
 
 			switch (dpc) {
 			case PTP_DPC_CANON_EOS_ImageFormat:

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -690,9 +690,9 @@ ptp_unpack_DPD (PTPParams *params, const unsigned char* data, PTPDevicePropDesc 
 
 	switch (dpd->FormFlag) {
 	case PTP_DPFF_Range:
-		ret = ptp_unpack_DPV (params, data, offset, dpdlen, &dpd->FORM.Range.MinimumValue, dpd->DataType);
+		ret = ptp_unpack_DPV (params, data, offset, dpdlen, &dpd->FORM.Range.MinValue, dpd->DataType);
 		if (!ret) goto outofmemory;
-		ret = ptp_unpack_DPV (params, data, offset, dpdlen, &dpd->FORM.Range.MaximumValue, dpd->DataType);
+		ret = ptp_unpack_DPV (params, data, offset, dpdlen, &dpd->FORM.Range.MaxValue, dpd->DataType);
 		if (!ret) goto outofmemory;
 		ret = ptp_unpack_DPV (params, data, offset, dpdlen, &dpd->FORM.Range.StepSize, dpd->DataType);
 		if (!ret) goto outofmemory;
@@ -791,9 +791,9 @@ ptp_unpack_Sony_DPD (PTPParams *params, const unsigned char* data, PTPDeviceProp
 
 	switch (dpd->FormFlag) {
 	case PTP_DPFF_Range:
-		ret = ptp_unpack_DPV (params, data, poffset, dpdlen, &dpd->FORM.Range.MinimumValue, dpd->DataType);
+		ret = ptp_unpack_DPV (params, data, poffset, dpdlen, &dpd->FORM.Range.MinValue, dpd->DataType);
 		if (!ret) goto outofmemory;
-		ret = ptp_unpack_DPV (params, data, poffset, dpdlen, &dpd->FORM.Range.MaximumValue, dpd->DataType);
+		ret = ptp_unpack_DPV (params, data, poffset, dpdlen, &dpd->FORM.Range.MaxValue, dpd->DataType);
 		if (!ret) goto outofmemory;
 		ret = ptp_unpack_DPV (params, data, poffset, dpdlen, &dpd->FORM.Range.StepSize, dpd->DataType);
 		if (!ret) goto outofmemory;
@@ -914,8 +914,8 @@ duplicate_DevicePropDesc(const PTPDevicePropDesc *src, PTPDevicePropDesc *dst) {
 	dst->FormFlag		= src->FormFlag;
 	switch (src->FormFlag) {
 	case PTP_DPFF_Range:
-		duplicate_PropertyValue (&src->FORM.Range.MinimumValue, &dst->FORM.Range.MinimumValue, src->DataType);
-		duplicate_PropertyValue (&src->FORM.Range.MaximumValue, &dst->FORM.Range.MaximumValue, src->DataType);
+		duplicate_PropertyValue (&src->FORM.Range.MinValue, &dst->FORM.Range.MinValue, src->DataType);
+		duplicate_PropertyValue (&src->FORM.Range.MaxValue, &dst->FORM.Range.MaxValue, src->DataType);
 		duplicate_PropertyValue (&src->FORM.Range.StepSize,     &dst->FORM.Range.StepSize,     src->DataType);
 		break;
 	case PTP_DPFF_Enumeration:
@@ -960,9 +960,9 @@ ptp_unpack_OPD (PTPParams *params, const unsigned char* data, PTPObjectPropDesc 
 
 	switch (opd->FormFlag) {
 	case PTP_OPFF_Range:
-		ret = ptp_unpack_DPV (params, data, &offset, opdlen, &opd->FORM.Range.MinimumValue, opd->DataType);
+		ret = ptp_unpack_DPV (params, data, &offset, opdlen, &opd->FORM.Range.MinValue, opd->DataType);
 		if (!ret) goto outofmemory;
-		ret = ptp_unpack_DPV (params, data, &offset, opdlen, &opd->FORM.Range.MaximumValue, opd->DataType);
+		ret = ptp_unpack_DPV (params, data, &offset, opdlen, &opd->FORM.Range.MaxValue, opd->DataType);
 		if (!ret) goto outofmemory;
 		ret = ptp_unpack_DPV (params, data, &offset, opdlen, &opd->FORM.Range.StepSize, opd->DataType);
 		if (!ret) goto outofmemory;

--- a/camlibs/ptp2/ptp-private.h
+++ b/camlibs/ptp2/ptp-private.h
@@ -115,8 +115,6 @@ inline static int log_on_ptp_error_helper( int _r, const char* _func, const char
 	}\
 } while (0)
 
-#define ARRAYSIZE(ARRAY) (sizeof(ARRAY) / sizeof(ARRAY[0]))
-
 static inline int
 is_canon_eos_m(PTPParams *params) {
 	if (params->deviceinfo.VendorExtensionID != PTP_VENDOR_CANON) return 0;

--- a/camlibs/ptp2/ptp-private.h
+++ b/camlibs/ptp2/ptp-private.h
@@ -141,7 +141,7 @@ have_eos_prop(PTPParams *params, uint16_t vendor, uint16_t prop) {
 	/* The special Canon EOS property set gets special treatment. */
 	if ((params->deviceinfo.VendorExtensionID != PTP_VENDOR_CANON) || (vendor != PTP_VENDOR_CANON))
 		return 0;
-	for (i=0;i<params->nrofcanon_props;i++)
+	for (i=0;i<params->canon_props_len;i++)
 		if (params->canon_props[i].dpd.DevicePropCode == prop)
 			return 1;
 	return 0;

--- a/camlibs/ptp2/ptp-private.h
+++ b/camlibs/ptp2/ptp-private.h
@@ -144,7 +144,7 @@ have_eos_prop(PTPParams *params, uint16_t vendor, uint16_t prop) {
 	if ((params->deviceinfo.VendorExtensionID != PTP_VENDOR_CANON) || (vendor != PTP_VENDOR_CANON))
 		return 0;
 	for (i=0;i<params->nrofcanon_props;i++)
-		if (params->canon_props[i].dpd.DevicePropertyCode == prop)
+		if (params->canon_props[i].dpd.DevicePropCode == prop)
 			return 1;
 	return 0;
 }

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -5446,7 +5446,7 @@ ptp_mtp_setobjectreferences (PTPParams* params, uint32_t handle, uint32_t* ohArr
 }
 
 uint16_t
-ptp_mtp_getobjectproplist_generic (PTPParams* params, uint32_t handle, uint32_t formats, uint32_t properties, uint32_t propertygroups, uint32_t level, MTPProperties **props, int *nrofprops)
+ptp_mtp_getobjectproplist_generic (PTPParams* params, uint32_t handle, uint32_t formats, uint32_t properties, uint32_t propertygroups, uint32_t level, MTPObjectProp **props, int *nrofprops)
 {
 	PTPContainer	ptp;
 	unsigned char	*data = NULL;
@@ -5460,7 +5460,7 @@ ptp_mtp_getobjectproplist_generic (PTPParams* params, uint32_t handle, uint32_t 
 }
 
 uint16_t
-ptp_mtp_getobjectproplist_level (PTPParams* params, uint32_t handle, uint32_t level, MTPProperties **props, int *nrofprops)
+ptp_mtp_getobjectproplist_level (PTPParams* params, uint32_t handle, uint32_t level, MTPObjectProp **props, int *nrofprops)
 {
 	return ptp_mtp_getobjectproplist_generic (params, handle,
 		0x00000000U,  /* 0x00000000U should be "all formats" */
@@ -5474,20 +5474,20 @@ ptp_mtp_getobjectproplist_level (PTPParams* params, uint32_t handle, uint32_t le
 
 
 uint16_t
-ptp_mtp_getobjectproplist (PTPParams* params, uint32_t handle, MTPProperties **props, int *nrofprops)
+ptp_mtp_getobjectproplist (PTPParams* params, uint32_t handle, MTPObjectProp **props, int *nrofprops)
 {
 	return ptp_mtp_getobjectproplist_level(params, handle, 0xFFFFFFFFU, props, nrofprops);
 }
 
 uint16_t
-ptp_mtp_getobjectproplist_single (PTPParams* params, uint32_t handle, MTPProperties **props, int *nrofprops)
+ptp_mtp_getobjectproplist_single (PTPParams* params, uint32_t handle, MTPObjectProp **props, int *nrofprops)
 {
 	return ptp_mtp_getobjectproplist_level(params, handle, 0, props, nrofprops);
 }
 
 uint16_t
 ptp_mtp_sendobjectproplist (PTPParams* params, uint32_t* store, uint32_t* parenthandle, uint32_t* handle,
-			    uint16_t objecttype, uint64_t objectsize, MTPProperties *props, int nrofprops)
+			    uint16_t objecttype, uint64_t objectsize, MTPObjectProp *props, int nrofprops)
 {
 	PTPContainer	ptp;
 	uint16_t	ret;
@@ -5510,7 +5510,7 @@ ptp_mtp_sendobjectproplist (PTPParams* params, uint32_t* store, uint32_t* parent
 }
 
 uint16_t
-ptp_mtp_setobjectproplist (PTPParams* params, MTPProperties *props, int nrofprops)
+ptp_mtp_setobjectproplist (PTPParams* params, MTPObjectProp *props, int nrofprops)
 {
 	PTPContainer	ptp;
 	uint16_t	ret;
@@ -9440,20 +9440,20 @@ ptp_render_mtp_propname(uint16_t propid, int spaceleft, char *txt)
 /*
  * Allocate and default-initialize a few object properties.
  */
-MTPProperties *
-ptp_get_new_object_prop_entry(MTPProperties **props, int *nrofprops)
+MTPObjectProp *
+ptp_get_new_object_prop_entry(MTPObjectProp **props, int *nrofprops)
 {
-	MTPProperties *newprops;
-	MTPProperties *prop;
+	MTPObjectProp *newprops;
+	MTPObjectProp *prop;
 
-	newprops = realloc(*props,sizeof(MTPProperties)*(*nrofprops+1));
+	newprops = realloc(*props,sizeof(MTPObjectProp)*(*nrofprops+1));
 	if (newprops == NULL)
 		return NULL;
 	prop = &newprops[*nrofprops];
-	prop->property = PTP_OPC_StorageID; /* Should be "unknown" */
-	prop->datatype = PTP_DTC_UNDEF;
+	prop->PropCode = PTP_OPC_StorageID; /* Should be "unknown" */
+	prop->DataType = PTP_DTC_UNDEF;
 	prop->ObjectHandle = 0x00000000U;
-	prop->propval.str = NULL;
+	prop->Value.str = NULL;
 
 	(*props) = newprops;
 	(*nrofprops)++;
@@ -9461,26 +9461,26 @@ ptp_get_new_object_prop_entry(MTPProperties **props, int *nrofprops)
 }
 
 void
-ptp_destroy_object_prop(MTPProperties *prop)
+ptp_destroy_object_prop(MTPObjectProp *prop)
 {
 	if (!prop)
 		return;
 
-	if (prop->datatype == PTP_DTC_STR && prop->propval.str != NULL)
-		free(prop->propval.str);
-	else if ((prop->datatype == PTP_DTC_AINT8 || prop->datatype == PTP_DTC_AINT16 ||
-		  prop->datatype == PTP_DTC_AINT32 || prop->datatype == PTP_DTC_AINT64 || prop->datatype == PTP_DTC_AINT128 ||
-		  prop->datatype == PTP_DTC_AUINT8 || prop->datatype == PTP_DTC_AUINT16 ||
-		  prop->datatype == PTP_DTC_AUINT32 || prop->datatype == PTP_DTC_AUINT64 || prop->datatype ==  PTP_DTC_AUINT128)
-		&& prop->propval.a.v != NULL)
-	free(prop->propval.a.v);
+	if (prop->DataType == PTP_DTC_STR && prop->Value.str != NULL)
+		free(prop->Value.str);
+	else if ((prop->DataType == PTP_DTC_AINT8 || prop->DataType == PTP_DTC_AINT16 ||
+		  prop->DataType == PTP_DTC_AINT32 || prop->DataType == PTP_DTC_AINT64 || prop->DataType == PTP_DTC_AINT128 ||
+		  prop->DataType == PTP_DTC_AUINT8 || prop->DataType == PTP_DTC_AUINT16 ||
+		  prop->DataType == PTP_DTC_AUINT32 || prop->DataType == PTP_DTC_AUINT64 || prop->DataType ==  PTP_DTC_AUINT128)
+		&& prop->Value.a.v != NULL)
+	free(prop->Value.a.v);
 }
 
 void
-ptp_destroy_object_prop_list(MTPProperties *props, int nrofprops)
+ptp_destroy_object_prop_list(MTPObjectProp *props, int nrofprops)
 {
 	int i;
-	MTPProperties *prop = props;
+	MTPObjectProp *prop = props;
 
 	for (i=0;i<nrofprops;i++,prop++)
 		ptp_destroy_object_prop(prop);
@@ -9491,11 +9491,11 @@ ptp_destroy_object_prop_list(MTPProperties *props, int nrofprops)
  * Find a certain object property in the cache, i.e. a certain metadata
  * item for a certain object handle.
  */
-MTPProperties *
+MTPObjectProp *
 ptp_find_object_prop_in_cache(PTPParams *params, uint32_t const handle, uint32_t const attribute_id)
 {
 	unsigned int	i;
-	MTPProperties	*prop;
+	MTPObjectProp	*prop;
 	PTPObject	*ob;
 	uint16_t	ret;
 
@@ -9504,7 +9504,7 @@ ptp_find_object_prop_in_cache(PTPParams *params, uint32_t const handle, uint32_t
 		return NULL;
 	prop = ob->mtp_props;
 	for (i=0;i<ob->mtp_props_len;i++) {
-		if (attribute_id == prop->property)
+		if (attribute_id == prop->PropCode)
 			return prop;
 		prop++;
 	}
@@ -9723,7 +9723,7 @@ read64bit:		;
 		(!(ob->flags & PTPOBJECT_MTPPROPLIST_LOADED))
 	) {
 		int		nrofprops = 0;
-		MTPProperties 	*props = NULL;
+		MTPObjectProp 	*props = NULL;
 
 		if (params->device_flags & DEVICE_FLAG_BROKEN_MTPGETOBJPROPLIST) {
 			want &= ~PTPOBJECT_MTPPROPLIST_LOADED;
@@ -9746,62 +9746,62 @@ read64bit:		;
 		/* Override the ObjectInfo data with data from properties */
 		if (params->device_flags & DEVICE_FLAG_PROPLIST_OVERRIDES_OI) {
 			unsigned int i;
-			MTPProperties *prop = ob->mtp_props;
+			MTPObjectProp *prop = ob->mtp_props;
 
 			for (i=0;i<ob->mtp_props_len;i++,prop++) {
 				/* in case we got all subtree objects */
 				if (prop->ObjectHandle != handle) continue;
 
-				switch (prop->property) {
+				switch (prop->PropCode) {
 				case PTP_OPC_StorageID:
-					ob->oi.StorageID = prop->propval.u32;
+					ob->oi.StorageID = prop->Value.u32;
 					break;
 				case PTP_OPC_ObjectFormat:
-					ob->oi.ObjectFormat = prop->propval.u16;
+					ob->oi.ObjectFormat = prop->Value.u16;
 					break;
 				case PTP_OPC_ProtectionStatus:
-					ob->oi.ProtectionStatus = prop->propval.u16;
+					ob->oi.ProtectionStatus = prop->Value.u16;
 					break;
 				case PTP_OPC_ObjectSize:
-					if (prop->datatype == PTP_DTC_UINT64) {
-						ob->oi.ObjectSize = prop->propval.u64;
-					} else if (prop->datatype == PTP_DTC_UINT32) {
-						ob->oi.ObjectSize = prop->propval.u32;
+					if (prop->DataType == PTP_DTC_UINT64) {
+						ob->oi.ObjectSize = prop->Value.u64;
+					} else if (prop->DataType == PTP_DTC_UINT32) {
+						ob->oi.ObjectSize = prop->Value.u32;
 					}
 					break;
 				case PTP_OPC_AssociationType:
-					ob->oi.AssociationType = prop->propval.u16;
+					ob->oi.AssociationType = prop->Value.u16;
 					break;
 				case PTP_OPC_AssociationDesc:
-					ob->oi.AssociationDesc = prop->propval.u32;
+					ob->oi.AssociationDesc = prop->Value.u32;
 					break;
 				case PTP_OPC_ObjectFileName:
-					if (prop->propval.str) {
+					if (prop->Value.str) {
 						free(ob->oi.Filename);
-						ob->oi.Filename = strdup(prop->propval.str);
+						ob->oi.Filename = strdup(prop->Value.str);
 					}
 					break;
 				case PTP_OPC_DateCreated:
-					ob->oi.CaptureDate = ptp_unpack_PTPTIME(prop->propval.str);
+					ob->oi.CaptureDate = ptp_unpack_PTPTIME(prop->Value.str);
 					break;
 				case PTP_OPC_DateModified:
-					ob->oi.ModificationDate = ptp_unpack_PTPTIME(prop->propval.str);
+					ob->oi.ModificationDate = ptp_unpack_PTPTIME(prop->Value.str);
 					break;
 				case PTP_OPC_Keywords:
-					if (prop->propval.str) {
+					if (prop->Value.str) {
 						free(ob->oi.Keywords);
-						ob->oi.Keywords = strdup(prop->propval.str);
+						ob->oi.Keywords = strdup(prop->Value.str);
 					}
 					break;
 				case PTP_OPC_ParentObject:
-					ob->oi.ParentObject = prop->propval.u32;
+					ob->oi.ParentObject = prop->Value.u32;
 					break;
 				}
 			}
 		}
 
 #if 0
-		MTPProperties 	*xpl;
+		MTPObjectProp 	*xpl;
 		int j;
 		PTPObjectInfo	oinfo;
 
@@ -9809,84 +9809,84 @@ read64bit:		;
 		/* hmm, not necessary ... only if we would use it */
 		for (j=0;j<nrofprops;j++) {
 			xpl = &props[j];
-			switch (xpl->property) {
+			switch (xpl->PropCode) {
 			case PTP_OPC_ParentObject:
-				if (xpl->datatype != PTP_DTC_UINT32) {
-					ptp_debug (params, "ptp2/mtpfast: parentobject has type 0x%x???", xpl->datatype);
+				if (xpl->DataType != PTP_DTC_UINT32) {
+					ptp_debug (params, "ptp2/mtpfast: parentobject has type 0x%x???", xpl->DataType);
 					break;
 				}
-				oinfo.ParentObject = xpl->propval.u32;
-				ptp_debug (params, "ptp2/mtpfast: parent 0x%x", xpl->propval.u32);
+				oinfo.ParentObject = xpl->Value.u32;
+				ptp_debug (params, "ptp2/mtpfast: parent 0x%x", xpl->Value.u32);
 				break;
 			case PTP_OPC_ObjectFormat:
-				if (xpl->datatype != PTP_DTC_UINT16) {
-					ptp_debug (params, "ptp2/mtpfast: objectformat has type 0x%x???", xpl->datatype);
+				if (xpl->DataType != PTP_DTC_UINT16) {
+					ptp_debug (params, "ptp2/mtpfast: objectformat has type 0x%x???", xpl->DataType);
 					break;
 				}
-				oinfo.ObjectFormat = xpl->propval.u16;
-				ptp_debug (params, "ptp2/mtpfast: ofc 0x%x", xpl->propval.u16);
+				oinfo.ObjectFormat = xpl->Value.u16;
+				ptp_debug (params, "ptp2/mtpfast: ofc 0x%x", xpl->Value.u16);
 				break;
 			case PTP_OPC_ObjectSize:
-				switch (xpl->datatype) {
+				switch (xpl->DataType) {
 				case PTP_DTC_UINT32:
-					oinfo.ObjectSize = xpl->propval.u32;
+					oinfo.ObjectSize = xpl->Value.u32;
 					break;
 				case PTP_DTC_UINT64:
-					oinfo.ObjectSize = xpl->propval.u64;
+					oinfo.ObjectSize = xpl->Value.u64;
 					break;
 				default:
-					ptp_debug (params, "ptp2/mtpfast: objectsize has type 0x%x???", xpl->datatype);
+					ptp_debug (params, "ptp2/mtpfast: objectsize has type 0x%x???", xpl->DataType);
 					break;
 				}
-				ptp_debug (params, "ptp2/mtpfast: objectsize %u", xpl->propval.u32);
+				ptp_debug (params, "ptp2/mtpfast: objectsize %u", xpl->Value.u32);
 				break;
 			case PTP_OPC_StorageID:
-				if (xpl->datatype != PTP_DTC_UINT32) {
-					ptp_debug (params, "ptp2/mtpfast: storageid has type 0x%x???", xpl->datatype);
+				if (xpl->DataType != PTP_DTC_UINT32) {
+					ptp_debug (params, "ptp2/mtpfast: storageid has type 0x%x???", xpl->DataType);
 					break;
 				}
-				oinfo.StorageID = xpl->propval.u32;
-				ptp_debug (params, "ptp2/mtpfast: storageid 0x%x", xpl->propval.u32);
+				oinfo.StorageID = xpl->Value.u32;
+				ptp_debug (params, "ptp2/mtpfast: storageid 0x%x", xpl->Value.u32);
 				break;
 			case PTP_OPC_ProtectionStatus:/*UINT16*/
-				if (xpl->datatype != PTP_DTC_UINT16) {
-					ptp_debug (params, "ptp2/mtpfast: protectionstatus has type 0x%x???", xpl->datatype);
+				if (xpl->DataType != PTP_DTC_UINT16) {
+					ptp_debug (params, "ptp2/mtpfast: protectionstatus has type 0x%x???", xpl->DataType);
 					break;
 				}
-				oinfo.ProtectionStatus = xpl->propval.u16;
-				ptp_debug (params, "ptp2/mtpfast: protection 0x%x", xpl->propval.u16);
+				oinfo.ProtectionStatus = xpl->Value.u16;
+				ptp_debug (params, "ptp2/mtpfast: protection 0x%x", xpl->Value.u16);
 				break;
 			case PTP_OPC_ObjectFileName:
-				if (xpl->datatype != PTP_DTC_STR) {
-					ptp_debug (params, "ptp2/mtpfast: filename has type 0x%x???", xpl->datatype);
+				if (xpl->DataType != PTP_DTC_STR) {
+					ptp_debug (params, "ptp2/mtpfast: filename has type 0x%x???", xpl->DataType);
 					break;
 				}
-				if (xpl->propval.str) {
-					ptp_debug (params, "ptp2/mtpfast: filename %s", xpl->propval.str);
-					oinfo.Filename = strdup(xpl->propval.str);
+				if (xpl->Value.str) {
+					ptp_debug (params, "ptp2/mtpfast: filename %s", xpl->Value.str);
+					oinfo.Filename = strdup(xpl->Value.str);
 				} else {
 					oinfo.Filename = NULL;
 				}
 				break;
 			case PTP_OPC_DateCreated:
-				if (xpl->datatype != PTP_DTC_STR) {
-					ptp_debug (params, "ptp2/mtpfast: datecreated has type 0x%x???", xpl->datatype);
+				if (xpl->DataType != PTP_DTC_STR) {
+					ptp_debug (params, "ptp2/mtpfast: datecreated has type 0x%x???", xpl->DataType);
 					break;
 				}
-				ptp_debug (params, "ptp2/mtpfast: capturedate %s", xpl->propval.str);
-				oinfo.CaptureDate = ptp_unpack_PTPTIME (xpl->propval.str);
+				ptp_debug (params, "ptp2/mtpfast: capturedate %s", xpl->Value.str);
+				oinfo.CaptureDate = ptp_unpack_PTPTIME (xpl->Value.str);
 				break;
 			case PTP_OPC_DateModified:
-				if (xpl->datatype != PTP_DTC_STR) {
-					ptp_debug (params, "ptp2/mtpfast: datemodified has type 0x%x???", xpl->datatype);
+				if (xpl->DataType != PTP_DTC_STR) {
+					ptp_debug (params, "ptp2/mtpfast: datemodified has type 0x%x???", xpl->DataType);
 					break;
 				}
-				ptp_debug (params, "ptp2/mtpfast: moddate %s", xpl->propval.str);
-				oinfo.ModificationDate = ptp_unpack_PTPTIME (xpl->propval.str);
+				ptp_debug (params, "ptp2/mtpfast: moddate %s", xpl->Value.str);
+				oinfo.ModificationDate = ptp_unpack_PTPTIME (xpl->Value.str);
 				break;
 			default:
-				if ((xpl->property & 0xfff0) == 0xdc00)
-					ptp_debug (params, "ptp2/mtpfast:case %x type %x unhandled", xpl->property, xpl->datatype);
+				if ((xpl->PropCode & 0xfff0) == 0xdc00)
+					ptp_debug (params, "ptp2/mtpfast:case %x type %x unhandled", xpl->PropCode, xpl->DataType);
 				break;
 			}
 		}

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -578,8 +578,8 @@ ptp_canon_eos_getdeviceinfo (PTPParams* params, PTPCanonEOSDeviceInfo*di)
 void ptp_canon_eos_free_deviceinfo (PTPCanonEOSDeviceInfo *di)
 {
 	if (!di) return;
-	free (di->EventsSupported);
-	free (di->DevicePropertiesSupported);
+	free (di->Events);
+	free (di->DeviceProps);
 	free (di->unk);
 	memset(di, 0, sizeof(*di));
 }
@@ -671,8 +671,8 @@ parse_9301_cmd_tree (PTPParams *params, xmlNodePtr node, PTPDeviceInfo *di)
 		cnt++;
 		next = xmlNextElementSibling (next);
 	}
-	di->OperationsSupported_len = cnt;
-	di->OperationsSupported = calloc (cnt,sizeof(di->OperationsSupported[0]));
+	di->Operations_len = cnt;
+	di->Operations = calloc (cnt,sizeof(di->Operations[0]));
 	cnt = 0;
 	next = xmlFirstElementChild (node);
 	while (next) {
@@ -680,7 +680,7 @@ parse_9301_cmd_tree (PTPParams *params, xmlNodePtr node, PTPDeviceInfo *di)
 
 		sscanf((char*)next->name, "c%04x", &p);
 		ptp_debug( params, "cmd %s / 0x%04x", next->name, p);
-		di->OperationsSupported[cnt++] = p;
+		di->Operations[cnt++] = p;
 		next = xmlNextElementSibling (next);
 	}
 	return PTP_RC_OK;
@@ -888,8 +888,8 @@ parse_9301_prop_tree (PTPParams *params, xmlNodePtr node, PTPDeviceInfo *di)
 		next = xmlNextElementSibling (next);
 	}
 
-	di->DevicePropertiesSupported_len = cnt;
-	di->DevicePropertiesSupported = calloc (cnt,sizeof(di->DevicePropertiesSupported[0]));
+	di->DeviceProps_len = cnt;
+	di->DeviceProps = calloc (cnt,sizeof(di->DeviceProps[0]));
 	cnt = 0;
 	next = xmlFirstElementChild (node);
 	while (next) {
@@ -900,7 +900,7 @@ parse_9301_prop_tree (PTPParams *params, xmlNodePtr node, PTPDeviceInfo *di)
 		ptp_debug( params, "prop %s / 0x%04x", next->name, p);
 		parse_9301_propdesc (params, xmlFirstElementChild (next), &dpd);
 		dpd.DevicePropCode = p;
-		di->DevicePropertiesSupported[cnt++] = p;
+		di->DeviceProps[cnt++] = p;
 
 		/* add to cache of device propdesc */
 		for (i=0;i<params->nrofdeviceproperties;i++)
@@ -935,8 +935,8 @@ parse_9301_event_tree (PTPParams *params, xmlNodePtr node, PTPDeviceInfo *di)
 		cnt++;
 		next = xmlNextElementSibling (next);
 	}
-	di->EventsSupported_len = cnt;
-	di->EventsSupported = calloc (cnt,sizeof(di->EventsSupported[0]));
+	di->Events_len = cnt;
+	di->Events = calloc (cnt,sizeof(di->Events[0]));
 	cnt = 0;
 	next = xmlFirstElementChild (node);
 	while (next) {
@@ -944,7 +944,7 @@ parse_9301_event_tree (PTPParams *params, xmlNodePtr node, PTPDeviceInfo *di)
 
 		sscanf((char*)next->name, "e%04x", &p);
 		ptp_debug( params, "event %s / 0x%04x", next->name, p);
-		di->EventsSupported[cnt++] = p;
+		di->Events[cnt++] = p;
 		next = xmlNextElementSibling (next);
 	}
 	return PTP_RC_OK;
@@ -5942,8 +5942,8 @@ ptp_event_issupported(PTPParams* params, uint16_t event)
 {
 	unsigned int i=0;
 
-	for (;i<params->deviceinfo.EventsSupported_len;i++) {
-		if (params->deviceinfo.EventsSupported[i]==event)
+	for (;i<params->deviceinfo.Events_len;i++) {
+		if (params->deviceinfo.Events[i]==event)
 			return 1;
 	}
 	return 0;
@@ -5955,8 +5955,8 @@ ptp_property_issupported(PTPParams* params, uint16_t property)
 {
 	unsigned int i;
 
-	for (i=0;i<params->deviceinfo.DevicePropertiesSupported_len;i++)
-		if (params->deviceinfo.DevicePropertiesSupported[i]==property)
+	for (i=0;i<params->deviceinfo.DeviceProps_len;i++)
+		if (params->deviceinfo.DeviceProps[i]==property)
 			return 1;
 	return 0;
 }
@@ -5972,9 +5972,9 @@ ptp_free_deviceinfo (PTPDeviceInfo *di)
 	free (di->ImageFormats);
 	free (di->CaptureFormats);
 	free (di->VendorExtensionDesc);
-	free (di->OperationsSupported);
-	free (di->EventsSupported);
-	free (di->DevicePropertiesSupported);
+	free (di->Operations);
+	free (di->Events);
+	free (di->DeviceProps);
 	memset(di, 0, sizeof(*di));
 }
 

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -8515,7 +8515,7 @@ ptp_render_ofc(PTPParams* params, uint16_t ofc, int spaceleft, char *txt)
 	unsigned int i;
 
 	if (!(ofc & 0x8000)) {
-		for (i=0;i<sizeof(ptp_ofc_trans)/sizeof(ptp_ofc_trans[0]);i++)
+		for (i=0;i<ARRAYSIZE(ptp_ofc_trans);i++)
 			if (ofc == ptp_ofc_trans[i].ofc)
 				return snprintf(txt, spaceleft, "%s", _(ptp_ofc_trans[i].format));
 	} else {
@@ -8554,7 +8554,7 @@ ptp_render_ofc(PTPParams* params, uint16_t ofc, int spaceleft, char *txt)
 			break;
 		case PTP_VENDOR_MICROSOFT:
 		case PTP_VENDOR_MTP:
-			for (i=0;i<sizeof(ptp_ofc_mtp_trans)/sizeof(ptp_ofc_mtp_trans[0]);i++)
+			for (i=0;i<ARRAYSIZE(ptp_ofc_mtp_trans);i++)
 				if (ofc == ptp_ofc_mtp_trans[i].ofc)
 					return snprintf(txt, spaceleft, "%s", _(ptp_ofc_mtp_trans[i].format));
 			break;
@@ -9099,7 +9099,7 @@ ptp_get_opcode_name(PTPParams* params, uint16_t opcode)
 #define RETURN_NAME_FROM_TABLE(TABLE, OPCODE) \
 { \
 	unsigned int i; \
-	for (i=0; i<sizeof(TABLE)/sizeof(TABLE[0]); i++) \
+	for (i=0; i<ARRAYSIZE(TABLE); i++) \
 		if (OPCODE == TABLE[i].opcode) \
 			return _(TABLE[i].name); \
 	return _("Unknown PTP_OC"); \
@@ -9226,7 +9226,7 @@ ptp_get_event_code_name(PTPParams* params, uint16_t event_code)
 	unsigned int	i;
 	uint16_t	vendor = params->deviceinfo.VendorExtensionID;
 
-	for (i=0; i<sizeof(ptp_event_codes)/sizeof(ptp_event_codes[0]); i++)
+	for (i=0; i<ARRAYSIZE(ptp_event_codes); i++)
 		if ((ptp_event_codes[i].code == event_code) && ((ptp_event_codes[i].vendor == 0) || (ptp_event_codes[i].vendor == vendor)))
 			return ptp_event_codes[i].name;
 	return "Unknown Event";
@@ -9431,7 +9431,7 @@ int
 ptp_render_mtp_propname(uint16_t propid, int spaceleft, char *txt)
 {
 	unsigned int i;
-	for (i=0;i<sizeof(ptp_opc_trans)/sizeof(ptp_opc_trans[0]);i++)
+	for (i=0;i<ARRAYSIZE(ptp_opc_trans);i++)
 		if (propid == ptp_opc_trans[i].id)
 			return snprintf(txt, spaceleft, "%s", ptp_opc_trans[i].name);
 	return snprintf (txt, spaceleft,"unknown(%04x)", propid);

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -687,7 +687,7 @@ parse_9301_cmd_tree (PTPParams *params, xmlNodePtr node, PTPDeviceInfo *di)
 }
 
 static int
-parse_9301_value (PTPParams *params, const char *str, uint16_t type, PTPPropertyValue *propval)
+parse_9301_value (PTPParams *params, const char *str, uint16_t type, PTPPropValue *propval)
 {
 	switch (type) {
 	case 6: { /*UINT32*/
@@ -841,7 +841,7 @@ parse_9301_propdesc (PTPParams *params, xmlNodePtr next, PTPDevicePropDesc *dpd)
 				n++;
 			} while (s);
 			dpd->FORM.Enum.NumberOfValues = n;
-			dpd->FORM.Enum.SupportedValue = calloc (n , sizeof(PTPPropertyValue));
+			dpd->FORM.Enum.SupportedValue = calloc (n , sizeof(PTPPropValue));
 			s = (char*)xmlNodeGetContent (next);
 			i = 0;
 			do {
@@ -1370,7 +1370,7 @@ uint16_t
 ptp_olympus_init_pc_mode (PTPParams* params)
 {
 	uint16_t		ret;
-	PTPPropertyValue	propval;
+	PTPPropValue	propval;
 	PTPContainer		event;
 	int			i;
 
@@ -2019,7 +2019,7 @@ ptp_opensession (PTPParams* params, uint32_t session)
 }
 
 void
-ptp_free_devicepropvalue(uint16_t dt, PTPPropertyValue* dpd)
+ptp_free_devicepropvalue(uint16_t dt, PTPPropValue* dpd)
 {
 	switch (dt) {
 	case PTP_DTC_INT8:	case PTP_DTC_UINT8:
@@ -2837,7 +2837,7 @@ ptp_getdevicepropdesc (PTPParams* params, uint32_t propcode,
 
 uint16_t
 ptp_getdevicepropvalue (PTPParams* params, uint32_t propcode,
-			PTPPropertyValue* value, uint16_t datatype)
+			PTPPropValue* value, uint16_t datatype)
 {
 	PTPContainer	ptp;
 	unsigned char	*data = NULL;
@@ -2855,7 +2855,7 @@ ptp_getdevicepropvalue (PTPParams* params, uint32_t propcode,
 
 uint16_t
 ptp_setdevicepropvalue (PTPParams* params, uint32_t propcode,
-			PTPPropertyValue *value, uint16_t datatype)
+			PTPPropValue *value, uint16_t datatype)
 {
 	PTPContainer	ptp;
 	uint16_t	ret;
@@ -4049,7 +4049,7 @@ ptp_canon_eos_setdevicepropvalueex (PTPParams* params, unsigned char* data, unsi
 
 uint16_t
 ptp_canon_eos_setdevicepropvalue (PTPParams* params,
-	uint16_t propcode, PTPPropertyValue *value, uint16_t datatype
+	uint16_t propcode, PTPPropValue *value, uint16_t datatype
 ) {
 	PTPContainer	ptp;
 	uint16_t	ret;
@@ -4641,7 +4641,7 @@ ptp_sony_qx_getalldevicepropdesc (PTPParams* params) {
 
 uint16_t
 ptp_sony_setdevicecontrolvaluea (PTPParams* params, uint16_t propcode,
-			PTPPropertyValue *value, uint16_t datatype)
+			PTPPropValue *value, uint16_t datatype)
 {
 	PTPContainer	ptp;
 	uint16_t	ret;
@@ -4657,7 +4657,7 @@ ptp_sony_setdevicecontrolvaluea (PTPParams* params, uint16_t propcode,
 
 uint16_t
 ptp_sony_qx_setdevicecontrolvaluea (PTPParams* params, uint16_t propcode,
-			PTPPropertyValue *value, uint16_t datatype)
+			PTPPropValue *value, uint16_t datatype)
 {
 	PTPContainer	ptp;
 	uint16_t	ret;
@@ -4673,7 +4673,7 @@ ptp_sony_qx_setdevicecontrolvaluea (PTPParams* params, uint16_t propcode,
 
 uint16_t
 ptp_sony_setdevicecontrolvalueb (PTPParams* params, uint16_t propcode,
-			PTPPropertyValue *value, uint16_t datatype)
+			PTPPropValue *value, uint16_t datatype)
 {
 	PTPContainer	ptp;
 	uint16_t	ret;
@@ -4689,7 +4689,7 @@ ptp_sony_setdevicecontrolvalueb (PTPParams* params, uint16_t propcode,
 
 uint16_t
 ptp_sony_qx_setdevicecontrolvalueb (PTPParams* params, uint16_t propcode,
-			PTPPropertyValue *value, uint16_t datatype)
+			PTPPropValue *value, uint16_t datatype)
 {
 	PTPContainer	ptp;
 	uint16_t	ret;
@@ -4862,7 +4862,7 @@ done:
  **/
 uint16_t
 ptp_generic_setdevicepropvalue (PTPParams* params, uint32_t propcode,
-	PTPPropertyValue *value, uint16_t datatype)
+	PTPPropValue *value, uint16_t datatype)
 {
 	unsigned int i;
 
@@ -5368,7 +5368,7 @@ ptp_mtp_getobjectpropdesc (
 uint16_t
 ptp_mtp_getobjectpropvalue (
 	PTPParams* params, uint32_t oid, uint16_t opc,
-	PTPPropertyValue *value, uint16_t datatype
+	PTPPropValue *value, uint16_t datatype
 ) {
 	PTPContainer	ptp;
 	uint16_t	ret = PTP_RC_OK;
@@ -5400,7 +5400,7 @@ ptp_mtp_getobjectpropvalue (
 uint16_t
 ptp_mtp_setobjectpropvalue (
 	PTPParams* params, uint32_t oid, uint16_t opc,
-	PTPPropertyValue *value, uint16_t datatype
+	PTPPropValue *value, uint16_t datatype
 ) {
 	PTPContainer	ptp;
 	uint16_t	ret;
@@ -7700,7 +7700,7 @@ ptp_get_property_description(PTPParams* params, uint32_t dpc)
 }
 
 static int64_t
-_value_to_num(PTPPropertyValue *data, uint16_t dt) {
+_value_to_num(PTPPropValue *data, uint16_t dt) {
 	if (dt == PTP_DTC_STR) {
 		if (!data->str)
 			return 0;

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -899,12 +899,12 @@ parse_9301_prop_tree (PTPParams *params, xmlNodePtr node, PTPDeviceInfo *di)
 		sscanf((char*)next->name, "p%04x", &p);
 		ptp_debug( params, "prop %s / 0x%04x", next->name, p);
 		parse_9301_propdesc (params, xmlFirstElementChild (next), &dpd);
-		dpd.DevicePropertyCode = p;
+		dpd.DevicePropCode = p;
 		di->DevicePropertiesSupported[cnt++] = p;
 
 		/* add to cache of device propdesc */
 		for (i=0;i<params->nrofdeviceproperties;i++)
-			if (params->deviceproperties[i].desc.DevicePropertyCode == p)
+			if (params->deviceproperties[i].desc.DevicePropCode == p)
 				break;
 		if (i == params->nrofdeviceproperties) {
 			params->deviceproperties = realloc(params->deviceproperties,(i+1)*sizeof(params->deviceproperties[0]));
@@ -3598,7 +3598,7 @@ handle_event_internal (PTPParams *params, PTPContainer *event)
 
 		/* mark the property for a forced refresh on the next query */
 		for (i=0;i<params->nrofdeviceproperties;i++)
-			if (params->deviceproperties[i].desc.DevicePropertyCode == event->Param1) {
+			if (params->deviceproperties[i].desc.DevicePropCode == event->Param1) {
 				params->deviceproperties[i].timestamp = 0;
 				break;
 			}
@@ -4564,10 +4564,10 @@ _ptp_sony_getalldevicepropdesc (PTPParams* params, uint16_t opcode)
 		if (!ptp_unpack_Sony_DPD (params, dpddata, &dpd, size, &readlen))
 			break;
 
-		propcode = dpd.DevicePropertyCode;
+		propcode = dpd.DevicePropCode;
 
 		for (i=0;i<params->nrofdeviceproperties;i++)
-			if (params->deviceproperties[i].desc.DevicePropertyCode == propcode)
+			if (params->deviceproperties[i].desc.DevicePropCode == propcode)
 				break;
 
 		/* debug output to see what changes */
@@ -4597,7 +4597,7 @@ _ptp_sony_getalldevicepropdesc (PTPParams* params, uint16_t opcode)
 		params->deviceproperties[i].desc = dpd;
 		params->deviceproperties[i].timestamp = now;
 #if 0
-		ptp_debug (params, "dpd.DevicePropertyCode %04x, readlen %d, getset %d", dpd.DevicePropertyCode, readlen, dpd.GetSet);
+		ptp_debug (params, "dpd.DevicePropCode %04x, readlen %d, getset %d", dpd.DevicePropCode, readlen, dpd.GetSet);
 		switch (dpd.DataType) {
 		case PTP_DTC_INT8:
 			ptp_debug (params, "value %d/%x", dpd.CurrentValue.i8, dpd.CurrentValue.i8);
@@ -4763,7 +4763,7 @@ ptp_generic_getdevicepropdesc (PTPParams *params, uint32_t propcode, PTPDevicePr
 	time(&now);
 
 	for (i=0;i<params->nrofdeviceproperties;i++)
-		if (params->deviceproperties[i].desc.DevicePropertyCode == propcode)
+		if (params->deviceproperties[i].desc.DevicePropCode == propcode)
 			break;
 	if (i == params->nrofdeviceproperties) {
 		params->deviceproperties = realloc(params->deviceproperties,(i+1)*sizeof(params->deviceproperties[0]));
@@ -4804,7 +4804,7 @@ ptp_generic_getdevicepropdesc (PTPParams *params, uint32_t propcode, PTPDevicePr
 		CHECK_PTP_RC(ptp_sony_getalldevicepropdesc (params));
 
 		for (i=0;i<params->nrofdeviceproperties;i++)
-			if (params->deviceproperties[i].desc.DevicePropertyCode == propcode)
+			if (params->deviceproperties[i].desc.DevicePropCode == propcode)
 				break;
 		if (i == params->nrofdeviceproperties) {
 			ptp_debug (params, "alpha property 0x%04x not found?\n", propcode);
@@ -4818,7 +4818,7 @@ ptp_generic_getdevicepropdesc (PTPParams *params, uint32_t propcode, PTPDevicePr
 		CHECK_PTP_RC(ptp_sony_qx_getalldevicepropdesc (params));
 
 		for (i=0;i<params->nrofdeviceproperties;i++)
-			if (params->deviceproperties[i].desc.DevicePropertyCode == propcode)
+			if (params->deviceproperties[i].desc.DevicePropCode == propcode)
 				break;
 		if (i == params->nrofdeviceproperties) {
 			ptp_debug (params, "qx property 0x%04x not found?\n", propcode);
@@ -4868,7 +4868,7 @@ ptp_generic_setdevicepropvalue (PTPParams* params, uint32_t propcode,
 
 	/* reset the cache entry */
 	for (i=0;i<params->nrofdeviceproperties;i++)
-		if (params->deviceproperties[i].desc.DevicePropertyCode == propcode)
+		if (params->deviceproperties[i].desc.DevicePropCode == propcode)
 			break;
 	if (i != params->nrofdeviceproperties)
 		params->deviceproperties[i].timestamp = 0;
@@ -5879,7 +5879,7 @@ ptp_fuji_getdeviceinfo (PTPParams* params, uint16_t **props, unsigned int *numpr
 
 		if (!ptp_unpack_DPD(params, data, &dpd, dsize, &offset))
 			break;
-		(*props)[i] = dpd.DevicePropertyCode;
+		(*props)[i] = dpd.DevicePropCode;
 	}
 	free (data);
 	return PTP_RC_OK;
@@ -5921,7 +5921,7 @@ ptp_fuji_getevents (PTPParams* params, uint16_t** events, uint16_t* count)
 
 				/* reset the property cache entry for refetch ... */
 				for (j=0;j<params->nrofdeviceproperties;j++)
-					if (params->deviceproperties[j].desc.DevicePropertyCode == param)
+					if (params->deviceproperties[j].desc.DevicePropCode == param)
 						break;
 				if (j != params->nrofdeviceproperties) {
 					params->deviceproperties[j].timestamp = 0;

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -3370,7 +3370,7 @@ ptp_list_folder_eos (PTPParams *params, uint32_t storage, uint32_t handle) {
 				else
 					params->objects[params->nrofobjects].oi.ProtectionStatus = PTP_PS_NoProtection;
 				params->objects[params->nrofobjects].canon_flags = tmp[i].Flags;
-				params->objects[params->nrofobjects].oi.ObjectCompressedSize = tmp[i].ObjectSize;
+				params->objects[params->nrofobjects].oi.ObjectSize = tmp[i].ObjectSize;
 				params->objects[params->nrofobjects].oi.CaptureDate = tmp[i].Time;
 				params->objects[params->nrofobjects].oi.ModificationDate = tmp[i].Time;
 				params->objects[params->nrofobjects].flags |= PTPOBJECT_OBJECTINFO_LOADED;
@@ -3492,7 +3492,7 @@ ptp_list_folder (PTPParams *params, uint32_t storage, uint32_t handle) {
 			ob->oi.StorageID 		= oifs[i].StorageID;
 			ob->oi.ObjectFormat 		= oifs[i].ObjectFormat;
 			ob->oi.ProtectionStatus 	= oifs[i].ProtectionStatus;
-			ob->oi.ObjectCompressedSize	= oifs[i].ObjectCompressedSize64;
+			ob->oi.ObjectSize		= oifs[i].ObjectSize64;
 			ob->oi.ParentObject		= oifs[i].ParentObject;
 
 			/* bad iOS, returns StorageID instead of 0x0 */
@@ -9674,13 +9674,13 @@ ptp_object_want (PTPParams *params, uint32_t handle, unsigned int want, PTPObjec
 
 		/* Detect if the file is larger than 4GB ... indicator is size 0xffffffff ...
 		 * In that case explicitly request the MTP object proplist to get the right size */
-		if (ob->oi.ObjectCompressedSize == 0xffffffffUL) {
+		if (ob->oi.ObjectSize == 0xffffffffUL) {
 			uint64_t	newsize;
 			if (	(params->deviceinfo.VendorExtensionID == PTP_VENDOR_NIKON)	&&
 				ptp_operation_issupported(params,PTP_OC_NIKON_GetObjectSize)	&&
 				(PTP_RC_OK == ptp_nikon_getobjectsize(params, handle, &newsize))
 			) {
-				ob->oi.ObjectCompressedSize = newsize;
+				ob->oi.ObjectSize = newsize;
 				goto read64bit;
 			}
 			/* more methods like e.g. for Canon */
@@ -9764,9 +9764,9 @@ read64bit:		;
 					break;
 				case PTP_OPC_ObjectSize:
 					if (prop->datatype == PTP_DTC_UINT64) {
-						ob->oi.ObjectCompressedSize = prop->propval.u64;
+						ob->oi.ObjectSize = prop->propval.u64;
 					} else if (prop->datatype == PTP_DTC_UINT32) {
-						ob->oi.ObjectCompressedSize = prop->propval.u32;
+						ob->oi.ObjectSize = prop->propval.u32;
 					}
 					break;
 				case PTP_OPC_AssociationType:
@@ -9829,10 +9829,10 @@ read64bit:		;
 			case PTP_OPC_ObjectSize:
 				switch (xpl->datatype) {
 				case PTP_DTC_UINT32:
-					oinfo.ObjectCompressedSize = xpl->propval.u32;
+					oinfo.ObjectSize = xpl->propval.u32;
 					break;
 				case PTP_DTC_UINT64:
-					oinfo.ObjectCompressedSize = xpl->propval.u64;
+					oinfo.ObjectSize = xpl->propval.u64;
 					break;
 				default:
 					ptp_debug (params, "ptp2/mtpfast: objectsize has type 0x%x???", xpl->datatype);

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -856,11 +856,11 @@ parse_9301_propdesc (PTPParams *params, xmlNodePtr next, PTPDevicePropDesc *dpd)
 			char *s = (char*)xmlNodeGetContent (next);
 			dpd->FormFlag = PTP_DPFF_Range;
 			ptp_debug( params, "range");
-			parse_9301_value (params, s, type, &dpd->FORM.Range.MinimumValue); /* should turn ' ' into \0? */
+			parse_9301_value (params, s, type, &dpd->FORM.Range.MinValue); /* should turn ' ' into \0? */
 			s = strchr(s,' ');
 			if (!s) continue;
 			s++;
-			parse_9301_value (params, s, type, &dpd->FORM.Range.MaximumValue); /* should turn ' ' into \0? */
+			parse_9301_value (params, s, type, &dpd->FORM.Range.MaxValue); /* should turn ' ' into \0? */
 			s = strchr(s,' ');
 			if (!s) continue;
 			s++;
@@ -2051,8 +2051,8 @@ ptp_free_devicepropdesc(PTPDevicePropDesc* dpd)
 	ptp_free_devicepropvalue (dpd->DataType, &dpd->CurrentValue);
 	switch (dpd->FormFlag) {
 	case PTP_DPFF_Range:
-		ptp_free_devicepropvalue (dpd->DataType, &dpd->FORM.Range.MinimumValue);
-		ptp_free_devicepropvalue (dpd->DataType, &dpd->FORM.Range.MaximumValue);
+		ptp_free_devicepropvalue (dpd->DataType, &dpd->FORM.Range.MinValue);
+		ptp_free_devicepropvalue (dpd->DataType, &dpd->FORM.Range.MaxValue);
 		ptp_free_devicepropvalue (dpd->DataType, &dpd->FORM.Range.StepSize);
 		break;
 	case PTP_DPFF_Enumeration:
@@ -2077,8 +2077,8 @@ ptp_free_objectpropdesc(PTPObjectPropDesc* opd)
 	case PTP_OPFF_None:
 		break;
 	case PTP_OPFF_Range:
-		ptp_free_devicepropvalue (opd->DataType, &opd->FORM.Range.MinimumValue);
-		ptp_free_devicepropvalue (opd->DataType, &opd->FORM.Range.MaximumValue);
+		ptp_free_devicepropvalue (opd->DataType, &opd->FORM.Range.MinValue);
+		ptp_free_devicepropvalue (opd->DataType, &opd->FORM.Range.MaxValue);
 		ptp_free_devicepropvalue (opd->DataType, &opd->FORM.Range.StepSize);
 		break;
 	case PTP_OPFF_Enumeration:

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -817,9 +817,9 @@ parse_9301_propdesc (PTPParams *params, xmlNodePtr next, PTPDevicePropDesc *dpd)
 			dpd->GetSet = attr;
 			continue;
 		}
-		if (!strcmp((char*)next->name,"default")) {	/* propdesc.FactoryDefaultValue */
+		if (!strcmp((char*)next->name,"default")) {	/* propdesc.DefaultValue */
 			ptp_debug( params, "default value");
-			parse_9301_value (params, (char*)xmlNodeGetContent (next), type, &dpd->FactoryDefaultValue);
+			parse_9301_value (params, (char*)xmlNodeGetContent (next), type, &dpd->DefaultValue);
 			continue;
 		}
 		if (!strcmp((char*)next->name,"value")) {	/* propdesc.CurrentValue */
@@ -2047,7 +2047,7 @@ ptp_free_devicepropdesc(PTPDevicePropDesc* dpd)
 {
 	uint16_t i;
 
-	ptp_free_devicepropvalue (dpd->DataType, &dpd->FactoryDefaultValue);
+	ptp_free_devicepropvalue (dpd->DataType, &dpd->DefaultValue);
 	ptp_free_devicepropvalue (dpd->DataType, &dpd->CurrentValue);
 	switch (dpd->FormFlag) {
 	case PTP_DPFF_Range:
@@ -2072,7 +2072,7 @@ ptp_free_objectpropdesc(PTPObjectPropDesc* opd)
 {
 	uint16_t i;
 
-	ptp_free_devicepropvalue (opd->DataType, &opd->FactoryDefaultValue);
+	ptp_free_devicepropvalue (opd->DataType, &opd->DefaultValue);
 	switch (opd->FormFlag) {
 	case PTP_OPFF_None:
 		break;

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -70,6 +70,7 @@ static inline uint32_t _post_inc(uint32_t* o, int n)
 #define dtoh32o(a, o)  dtoh32a((a) + _post_inc(&o, sizeof(uint32_t)))
 #define dtoh64o(a, o)  dtoh64a((a) + _post_inc(&o, sizeof(uint64_t)))
 
+#define ARRAYSIZE(ARRAY) (sizeof(ARRAY) / sizeof(ARRAY[0]))
 
 /* USB interface class */
 #ifndef USB_CLASS_PTP

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -3822,12 +3822,15 @@ struct _MTPPropertyDesc {
 };
 typedef struct _MTPPropertyDesc MTPPropertyDesc;
 
+#if 0
+/* currently unused */
 struct _MTPObjectFormat {
 	uint16_t	ofc;
 	MTPPropertyDesc	*pds;
 	unsigned int	pds_len;
 };
 typedef struct _MTPObjectFormat MTPObjectFormat;
+#endif
 
 struct _PanasonicLiveViewSize {
 	uint16_t	width;
@@ -3881,8 +3884,11 @@ struct _PTPParams {
 	int		split_header_data;
 	int		ocs64; /* 64bit objectsize */
 
+#if 0
+	/* currently unused */
 	MTPObjectFormat	*objectformats;
 	unsigned int	objectformats_len;
+#endif
 
 	/* PTP: internal structures used by ptp driver */
 	PTPObject	*objects;

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -3804,8 +3804,8 @@ struct _PTPObject {
 
 	PTPObjectInfo	oi;
 	uint32_t	canon_flags;
-	MTPProperties	*mtpprops;
-	unsigned int	nrofmtpprops;
+	MTPProperties	*mtp_props;
+	unsigned int	mtp_props_len;
 };
 typedef struct _PTPObject PTPObject;
 
@@ -3824,8 +3824,8 @@ typedef struct _MTPPropertyDesc MTPPropertyDesc;
 
 struct _MTPObjectFormat {
 	uint16_t	ofc;
-	unsigned int	nrofpds;
 	MTPPropertyDesc	*pds;
+	unsigned int	pds_len;
 };
 typedef struct _MTPObjectFormat MTPObjectFormat;
 
@@ -3881,18 +3881,18 @@ struct _PTPParams {
 	int		split_header_data;
 	int		ocs64; /* 64bit objectsize */
 
-	int		nrofobjectformats;
 	MTPObjectFormat	*objectformats;
+	unsigned int	objectformats_len;
 
 	/* PTP: internal structures used by ptp driver */
 	PTPObject	*objects;
-	unsigned int	nrofobjects;
+	unsigned int	objects_len;
 
 	PTPDeviceInfo	deviceinfo;
 
 	/* PTP: the current event queue */
 	PTPContainer	*events;
-	unsigned int	nrofevents;
+	unsigned int	events_len;
 
 	/* Capture count for SDRAM capture style images */
 	unsigned int		capcnt;
@@ -3908,19 +3908,19 @@ struct _PTPParams {
 	int			storagechanged;
 
 	/* PTP: Device Property Caching */
-	PTPDeviceProperty	*deviceproperties;
-	unsigned int		nrofdeviceproperties;
+	PTPDeviceProperty	*dpd_cache;
+	unsigned int		dpd_cache_len;
 
 	/* PTP: Canon specific flags list */
 	PTPCanon_Property	*canon_props;
-	unsigned int		nrofcanon_props;
+	unsigned int		canon_props_len;
 	int			canon_viewfinder_on;
 	int			canon_event_mode;
 	int			uilocked;
 
 	/* PTP: Canon EOS event queue */
 	PTPCanonEOSEvent	*eos_events;
-	unsigned int		nrofeos_events;
+	unsigned int		eos_events_len;
 	int			eos_captureenabled;
 	int			eos_camerastatus;
 
@@ -4396,7 +4396,7 @@ uint16_t ptp_canon_checkevent (PTPParams* params,
 #define ptp_canon_eos_setrequestrollingpitchinglevel(params,onoff)	ptp_generic_no_data(params,PTP_OC_CANON_EOS_SetRequestRollingPitchingLevel,1,onoff)
 uint16_t ptp_canon_eos_getremotemode (PTPParams*, uint32_t *);
 uint16_t ptp_canon_eos_capture (PTPParams* params, uint32_t *result);
-uint16_t ptp_canon_eos_getevent (PTPParams* params, PTPCanonEOSEvent **events, int *nrofevents);
+uint16_t ptp_canon_eos_getevent (PTPParams* params, PTPCanonEOSEvent **events, int *events_len);
 uint16_t ptp_canon_getpartialobject (PTPParams* params, uint32_t handle,
 				uint32_t offset, uint32_t size,
 				uint32_t pos, unsigned char** block,

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1706,13 +1706,13 @@ union _PTPPropValue {
 typedef union _PTPPropValue PTPPropValue;
 
 /* Metadata lists for MTP operations */
-struct _MTPProperties {
-	uint16_t 	 property;
-	uint16_t 	 datatype;
+struct _MTPObjectProp {
+	uint16_t 	 PropCode;
+	uint16_t 	 DataType;
 	uint32_t 	 ObjectHandle;
-	PTPPropValue propval;
+	PTPPropValue Value;
 };
-typedef struct _MTPProperties MTPProperties;
+typedef struct _MTPObjectProp MTPObjectProp;
 
 struct _PTPPropDescRangeForm {
 	PTPPropValue MinValue;
@@ -3804,7 +3804,7 @@ struct _PTPObject {
 
 	PTPObjectInfo	oi;
 	uint32_t	canon_flags;
-	MTPProperties	*mtp_props;
+	MTPObjectProp	*mtp_props;
 	unsigned int	mtp_props_len;
 };
 typedef struct _PTPObject PTPObject;
@@ -4183,13 +4183,13 @@ uint16_t ptp_mtp_setobjectpropvalue (PTPParams* params, uint32_t oid, uint16_t o
 				PTPPropValue *value, uint16_t datatype);
 uint16_t ptp_mtp_getobjectreferences (PTPParams* params, uint32_t handle, uint32_t** ohArray, uint32_t* arraylen);
 uint16_t ptp_mtp_setobjectreferences (PTPParams* params, uint32_t handle, uint32_t* ohArray, uint32_t arraylen);
-uint16_t ptp_mtp_getobjectproplist_generic (PTPParams* params, uint32_t handle, uint32_t formats, uint32_t properties, uint32_t propertygroups, uint32_t level, MTPProperties **props, int *nrofprops);
-uint16_t ptp_mtp_getobjectproplist_level (PTPParams* params, uint32_t handle, uint32_t level, MTPProperties **props, int *nrofprops);
-uint16_t ptp_mtp_getobjectproplist (PTPParams* params, uint32_t handle, MTPProperties **props, int *nrofprops);
-uint16_t ptp_mtp_getobjectproplist_single (PTPParams* params, uint32_t handle, MTPProperties **props, int *nrofprops);
+uint16_t ptp_mtp_getobjectproplist_generic (PTPParams* params, uint32_t handle, uint32_t formats, uint32_t properties, uint32_t propertygroups, uint32_t level, MTPObjectProp **props, int *nrofprops);
+uint16_t ptp_mtp_getobjectproplist_level (PTPParams* params, uint32_t handle, uint32_t level, MTPObjectProp **props, int *nrofprops);
+uint16_t ptp_mtp_getobjectproplist (PTPParams* params, uint32_t handle, MTPObjectProp **props, int *nrofprops);
+uint16_t ptp_mtp_getobjectproplist_single (PTPParams* params, uint32_t handle, MTPObjectProp **props, int *nrofprops);
 uint16_t ptp_mtp_sendobjectproplist (PTPParams* params, uint32_t* store, uint32_t* parenthandle, uint32_t* handle,
-				     uint16_t objecttype, uint64_t objectsize, MTPProperties *props, int nrofprops);
-uint16_t ptp_mtp_setobjectproplist (PTPParams* params, MTPProperties *props, int nrofprops);
+				     uint16_t objecttype, uint64_t objectsize, MTPObjectProp *props, int nrofprops);
+uint16_t ptp_mtp_setobjectproplist (PTPParams* params, MTPObjectProp *props, int nrofprops);
 
 /* Microsoft MTPZ (Zune) extensions */
 uint16_t ptp_mtpz_sendwmdrmpdapprequest (PTPParams*, unsigned char *, uint32_t);
@@ -4903,10 +4903,10 @@ ptp_render_property_value(PTPParams* params, uint16_t dpc,
 				PTPDevicePropDesc *dpd, unsigned int length, char *out);
 int ptp_render_ofc(PTPParams* params, uint16_t ofc, int spaceleft, char *txt);
 int ptp_render_mtp_propname(uint16_t propid, int spaceleft, char *txt);
-MTPProperties *ptp_get_new_object_prop_entry(MTPProperties **props, int *nrofprops);
-void ptp_destroy_object_prop(MTPProperties *prop);
-void ptp_destroy_object_prop_list(MTPProperties *props, int nrofprops);
-MTPProperties *ptp_find_object_prop_in_cache(PTPParams *params, uint32_t const handle, uint32_t const attribute_id);
+MTPObjectProp *ptp_get_new_object_prop_entry(MTPObjectProp **props, int *nrofprops);
+void ptp_destroy_object_prop(MTPObjectProp *prop);
+void ptp_destroy_object_prop_list(MTPObjectProp *props, int nrofprops);
+MTPObjectProp *ptp_find_object_prop_in_cache(PTPParams *params, uint32_t const handle, uint32_t const attribute_id);
 uint16_t ptp_remove_object_from_cache(PTPParams *params, uint32_t handle);
 uint16_t ptp_add_object_to_cache(PTPParams *params, uint32_t handle);
 uint16_t ptp_object_want (PTPParams *, uint32_t handle, unsigned int want, PTPObject**retob);

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1422,12 +1422,12 @@ struct _PTPDeviceInfo {
 	uint16_t VendorExtensionVersion;
 	char	*VendorExtensionDesc;
 	uint16_t FunctionalMode;
-	uint32_t OperationsSupported_len;
-	uint16_t *OperationsSupported;
-	uint32_t EventsSupported_len;
-	uint16_t *EventsSupported;
-	uint32_t DevicePropertiesSupported_len;
-	uint16_t *DevicePropertiesSupported;
+	uint32_t Operations_len;
+	uint16_t *Operations;
+	uint32_t Events_len;
+	uint16_t *Events;
+	uint32_t DeviceProps_len;
+	uint16_t *DeviceProps;
 	uint32_t CaptureFormats_len;
 	uint16_t *CaptureFormats;
 	uint32_t ImageFormats_len;
@@ -1899,11 +1899,11 @@ typedef struct _PTPCanon_Property {
 
 typedef struct _PTPCanonEOSDeviceInfo {
 	/* length */
-	uint32_t EventsSupported_len;
-	uint32_t *EventsSupported;
+	uint32_t Events_len;
+	uint32_t *Events;
 
-	uint32_t DevicePropertiesSupported_len;
-	uint32_t *DevicePropertiesSupported;
+	uint32_t DeviceProps_len;
+	uint32_t *DeviceProps;
 
 	uint32_t unk_len;
 	uint32_t *unk;
@@ -4854,8 +4854,8 @@ ptp_operation_issupported(PTPParams* params, uint16_t operation)
 	if (operation == PTP_OC_CANON_EOS_GetDeviceInfoEx && params->deviceinfo.Model && !strcmp(params->deviceinfo.Model,"Canon EOS R5m2"))
 		return 0;
 
-	for (;i<params->deviceinfo.OperationsSupported_len;i++) {
-		if (params->deviceinfo.OperationsSupported[i]==operation)
+	for (;i<params->deviceinfo.Operations_len;i++) {
+		if (params->deviceinfo.Operations[i]==operation)
 			return 1;
 	}
 	return 0;

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -3922,13 +3922,13 @@ struct _PTPParams {
 	unsigned int		canon_props_len;
 	int			canon_viewfinder_on;
 	int			canon_event_mode;
-	int			uilocked;
 
 	/* PTP: Canon EOS event queue */
 	PTPCanonEOSEvent	*eos_events;
 	unsigned int		eos_events_len;
 	int			eos_captureenabled;
 	int			eos_camerastatus;
+	int			eos_uilocked;
 
 	/* PTP: Nikon specifics */
 	int			controlmode;

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1742,7 +1742,7 @@ typedef struct _PTPPropDescStringForm PTPPropDescStringForm;
 
 struct _PTPDevicePropDesc {
 	/* while this is 16 bit in the standard, Nikon for some weird reason started using 0x0001Dxxx */
-	uint32_t		DevicePropertyCode;
+	uint32_t		DevicePropCode;
 	uint16_t		DataType;
 	uint8_t			GetSet;
 	PTPPropValue	DefaultValue;

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1744,7 +1744,7 @@ struct _PTPDevicePropDesc {
 	uint32_t		DevicePropertyCode;
 	uint16_t		DataType;
 	uint8_t			GetSet;
-	PTPPropertyValue	FactoryDefaultValue;
+	PTPPropertyValue	DefaultValue;
 	PTPPropertyValue	CurrentValue;
 	uint8_t			FormFlag;
 	union	{
@@ -1760,7 +1760,7 @@ struct _PTPObjectPropDesc {
 	uint16_t		ObjectPropertyCode;
 	uint16_t		DataType;
 	uint8_t			GetSet;
-	PTPPropertyValue	FactoryDefaultValue;
+	PTPPropertyValue	DefaultValue;
 	uint32_t		GroupCode;
 	uint8_t			FormFlag;
 	union	{

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1494,9 +1494,9 @@ struct _PTPObjectInfo {
 	 * but we keep the general object size here
 	 * that also arrives via other methods and so
 	 * use 64bit */
-	uint64_t ObjectCompressedSize;
+	uint64_t ObjectSize;
 	uint16_t ThumbFormat;
-	uint32_t ThumbCompressedSize;
+	uint32_t ThumbSize;
 	uint32_t ThumbPixWidth;
 	uint32_t ThumbPixHeight;
 	uint32_t ImagePixWidth;
@@ -1518,7 +1518,7 @@ struct _PTPObjectFilesystemInfo {
 	uint32_t StorageID;
 	uint16_t ObjectFormat;
 	uint16_t ProtectionStatus;
-	uint64_t ObjectCompressedSize64;
+	uint64_t ObjectSize64;
 	uint32_t ParentObject;
 	uint16_t AssociationType;
 	uint32_t AssociationDesc;

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1713,8 +1713,8 @@ struct _MTPProperties {
 typedef struct _MTPProperties MTPProperties;
 
 struct _PTPPropDescRangeForm {
-	PTPPropertyValue 	MinimumValue;
-	PTPPropertyValue 	MaximumValue;
+	PTPPropertyValue 	MinValue;
+	PTPPropertyValue 	MaxValue;
 	PTPPropertyValue 	StepSize;
 };
 typedef struct _PTPPropDescRangeForm PTPPropDescRangeForm;

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1758,7 +1758,7 @@ typedef struct _PTPDevicePropDesc PTPDevicePropDesc;
 /* Object Property Describing Dataset (DevicePropDesc) */
 
 struct _PTPObjectPropDesc {
-	uint16_t		ObjectPropertyCode;
+	uint16_t		ObjectPropCode;
 	uint16_t		DataType;
 	uint8_t			GetSet;
 	PTPPropValue	DefaultValue;

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1682,9 +1682,10 @@ typedef struct _PTPObjectFilesystemInfo PTPObjectFilesystemInfo;
 #define PTP_AC_ReadOnly				0x0001
 #define PTP_AC_ReadOnly_with_Object_Deletion	0x0002
 
-/* Property Describing Dataset, Range Form */
-
-union _PTPPropertyValue {
+/* Dataset containing the value of a (device or object) property.
+ * There is no direct equivalent of this in the PTP specification.
+ * The variable sized untyped data block containing a value is called DTS in the spec. */
+union _PTPPropValue {
 	char		*str;	/* common string, malloced */
 	uint8_t		u8;
 	int8_t		i8;
@@ -1697,25 +1698,25 @@ union _PTPPropertyValue {
 	/* XXXX: 128 bit signed and unsigned missing */
 	struct array {
 		uint32_t	count;
-		union _PTPPropertyValue	*v;	/* malloced, count elements */
+		union _PTPPropValue	*v;	/* malloced, count elements */
 	} a;
 };
 
-typedef union _PTPPropertyValue PTPPropertyValue;
+typedef union _PTPPropValue PTPPropValue;
 
 /* Metadata lists for MTP operations */
 struct _MTPProperties {
-	uint16_t 	 	property;
-	uint16_t 	 	datatype;
-	uint32_t 	 	ObjectHandle;
-	PTPPropertyValue 	propval;
+	uint16_t 	 property;
+	uint16_t 	 datatype;
+	uint32_t 	 ObjectHandle;
+	PTPPropValue propval;
 };
 typedef struct _MTPProperties MTPProperties;
 
 struct _PTPPropDescRangeForm {
-	PTPPropertyValue 	MinValue;
-	PTPPropertyValue 	MaxValue;
-	PTPPropertyValue 	StepSize;
+	PTPPropValue MinValue;
+	PTPPropValue MaxValue;
+	PTPPropValue StepSize;
 };
 typedef struct _PTPPropDescRangeForm PTPPropDescRangeForm;
 
@@ -1723,7 +1724,7 @@ typedef struct _PTPPropDescRangeForm PTPPropDescRangeForm;
 
 struct _PTPPropDescEnumForm {
 	uint16_t		NumberOfValues;
-	PTPPropertyValue	*SupportedValue;	/* malloced */
+	PTPPropValue	*SupportedValue;	/* malloced */
 };
 typedef struct _PTPPropDescEnumForm PTPPropDescEnumForm;
 
@@ -1744,8 +1745,8 @@ struct _PTPDevicePropDesc {
 	uint32_t		DevicePropertyCode;
 	uint16_t		DataType;
 	uint8_t			GetSet;
-	PTPPropertyValue	DefaultValue;
-	PTPPropertyValue	CurrentValue;
+	PTPPropValue	DefaultValue;
+	PTPPropValue	CurrentValue;
 	uint8_t			FormFlag;
 	union	{
 		PTPPropDescEnumForm	Enum;
@@ -1760,7 +1761,7 @@ struct _PTPObjectPropDesc {
 	uint16_t		ObjectPropertyCode;
 	uint16_t		DataType;
 	uint8_t			GetSet;
-	PTPPropertyValue	DefaultValue;
+	PTPPropValue	DefaultValue;
 	uint32_t		GroupCode;
 	uint8_t			FormFlag;
 	union	{
@@ -4148,11 +4149,11 @@ uint16_t ptp_getdevicepropdesc	(PTPParams* params, uint32_t propcode,
 uint16_t ptp_generic_getdevicepropdesc (PTPParams *params, uint32_t propcode,
 				PTPDevicePropDesc *dpd);
 uint16_t ptp_getdevicepropvalue	(PTPParams* params, uint32_t propcode,
-				PTPPropertyValue* value, uint16_t datatype);
+				PTPPropValue* value, uint16_t datatype);
 uint16_t ptp_setdevicepropvalue (PTPParams* params, uint32_t propcode,
-				PTPPropertyValue* value, uint16_t datatype);
+				PTPPropValue* value, uint16_t datatype);
 uint16_t ptp_generic_setdevicepropvalue (PTPParams* params, uint32_t propcode,
-				PTPPropertyValue* value, uint16_t datatype);
+				PTPPropValue* value, uint16_t datatype);
 uint16_t ptp_getfilesystemmanifest (PTPParams* params, uint32_t storage,
 				uint32_t objectformatcode, uint32_t associationOH,
 				uint64_t *numoifs, PTPObjectFilesystemInfo **oifs);
@@ -4176,9 +4177,9 @@ int ptp_get_one_eos_event (PTPParams *params, PTPCanonEOSEvent *eos_event);
 uint16_t ptp_mtp_getobjectpropdesc (PTPParams* params, uint16_t opc, uint16_t ofc,
 				PTPObjectPropDesc *objectpropertydesc);
 uint16_t ptp_mtp_getobjectpropvalue (PTPParams* params, uint32_t oid, uint16_t opc,
-				PTPPropertyValue *value, uint16_t datatype);
+				PTPPropValue *value, uint16_t datatype);
 uint16_t ptp_mtp_setobjectpropvalue (PTPParams* params, uint32_t oid, uint16_t opc,
-				PTPPropertyValue *value, uint16_t datatype);
+				PTPPropValue *value, uint16_t datatype);
 uint16_t ptp_mtp_getobjectreferences (PTPParams* params, uint32_t handle, uint32_t** ohArray, uint32_t* arraylen);
 uint16_t ptp_mtp_setobjectreferences (PTPParams* params, uint32_t handle, uint32_t* ohArray, uint32_t arraylen);
 uint16_t ptp_mtp_getobjectproplist_generic (PTPParams* params, uint32_t handle, uint32_t formats, uint32_t properties, uint32_t propertygroups, uint32_t level, MTPProperties **props, int *nrofprops);
@@ -4503,7 +4504,7 @@ uint16_t ptp_canon_eos_905f (PTPParams* params, uint32_t);
 uint16_t ptp_canon_eos_getdevicepropdesc (PTPParams* params, uint16_t propcode,
 				PTPDevicePropDesc *devicepropertydesc);
 uint16_t ptp_canon_eos_setdevicepropvalue (PTPParams* params, uint16_t propcode,
-				PTPPropertyValue* value, uint16_t datatype);
+				PTPPropValue* value, uint16_t datatype);
 uint16_t ptp_nikon_get_vendorpropcodes (PTPParams* params, uint16_t **props, unsigned int *size);
 uint16_t ptp_nikon_curve_download (PTPParams* params,
 				unsigned char **data, unsigned int *size);
@@ -4524,13 +4525,13 @@ uint16_t ptp_sony_getdevicepropdesc (PTPParams* params, uint16_t propcode,
 uint16_t ptp_sony_getalldevicepropdesc (PTPParams* params);
 uint16_t ptp_sony_qx_getalldevicepropdesc (PTPParams* params);
 uint16_t ptp_sony_setdevicecontrolvaluea (PTPParams* params, uint16_t propcode,
-				PTPPropertyValue* value, uint16_t datatype);
+				PTPPropValue* value, uint16_t datatype);
 uint16_t ptp_sony_qx_setdevicecontrolvaluea (PTPParams* params, uint16_t propcode,
-				PTPPropertyValue* value, uint16_t datatype);
+				PTPPropValue* value, uint16_t datatype);
 uint16_t ptp_sony_setdevicecontrolvalueb (PTPParams* params, uint16_t propcode,
-				PTPPropertyValue* value, uint16_t datatype);
+				PTPPropValue* value, uint16_t datatype);
 uint16_t ptp_sony_qx_setdevicecontrolvalueb (PTPParams* params, uint16_t propcode,
-				PTPPropertyValue* value, uint16_t datatype);
+				PTPPropValue* value, uint16_t datatype);
 uint16_t ptp_sony_9280 (PTPParams* params, uint32_t additional, uint32_t data1, uint32_t data2, uint32_t data3, uint32_t data4, uint8_t x, uint8_t y);
 uint16_t ptp_sony_9281 (PTPParams* params, uint32_t param1);
 /**
@@ -4866,7 +4867,7 @@ int ptp_property_issupported	(PTPParams* params, uint16_t property);
 void ptp_free_params		(PTPParams *params);
 void ptp_free_objectpropdesc	(PTPObjectPropDesc*);
 void ptp_free_devicepropdesc	(PTPDevicePropDesc*);
-void ptp_free_devicepropvalue	(uint16_t, PTPPropertyValue*);
+void ptp_free_devicepropvalue	(uint16_t, PTPPropValue*);
 void ptp_free_deviceinfo	(PTPDeviceInfo *);
 void ptp_free_objectinfo	(PTPObjectInfo *oi);
 void ptp_free_object		(PTPObject *oi);

--- a/libgphoto2_port/vusb/vcamera.c
+++ b/libgphoto2_port/vusb/vcamera.c
@@ -611,7 +611,7 @@ ptp_deviceinfo_write(vcamera *cam, ptpcontainer *ptp) {
 			opcodes[i+ptp_functions[0].nroffunctions] = ptp_functions[vendor].functions[i].code;
 	}
 
-	x += put_16bit_le_array(data+x,opcodes,cnt);	/* OperationsSupported */
+	x += put_16bit_le_array(data+x,opcodes,cnt);	/* Operations */
 	free (opcodes);
 
 	events[0] = 0x4002;
@@ -619,12 +619,12 @@ ptp_deviceinfo_write(vcamera *cam, ptpcontainer *ptp) {
 	events[2] = 0x4006;
 	events[3] = 0x400a;
 	events[4] = 0x400d;
-	x += put_16bit_le_array(data+x,events,sizeof(events)/sizeof(events[0]));	/* EventsSupported */
+	x += put_16bit_le_array(data+x,events,sizeof(events)/sizeof(events[0]));	/* Events */
 
 	devprops = malloc(sizeof(ptp_properties)/sizeof(ptp_properties[0])*sizeof(uint16_t));
 	for (i=0;i<sizeof(ptp_properties)/sizeof(ptp_properties[0]);i++)
 		devprops[i] = ptp_properties[i].code;
-	x += put_16bit_le_array(data+x,devprops,sizeof(ptp_properties)/sizeof(ptp_properties[0]));/* DevicePropertiesSupported */
+	x += put_16bit_le_array(data+x,devprops,sizeof(ptp_properties)/sizeof(ptp_properties[0]));/* DeviceProps */
 	free (devprops);
 
 	imageformats[0] = 0x3801;

--- a/libgphoto2_port/vusb/vcamera.c
+++ b/libgphoto2_port/vusb/vcamera.c
@@ -330,7 +330,7 @@ struct _PTPDevicePropDesc {
 	uint16_t                DevicePropertyCode;
 	uint16_t                DataType;
 	uint8_t                 GetSet;
-	PTPPropertyValue        FactoryDefaultValue;
+	PTPPropertyValue        DefaultValue;
 	PTPPropertyValue        CurrentValue;
 	uint8_t                 FormFlag;
 	union {
@@ -358,7 +358,7 @@ ptp_free_devicepropdesc(PTPDevicePropDesc* dpd)
 {
 	uint16_t i;
 
-	ptp_free_devicepropvalue (dpd->DataType, &dpd->FactoryDefaultValue);
+	ptp_free_devicepropvalue (dpd->DataType, &dpd->DefaultValue);
 	ptp_free_devicepropvalue (dpd->DataType, &dpd->CurrentValue);
 	switch (dpd->FormFlag) {
 	case /* PTP_DPFF_Range */ 0x01:
@@ -1317,7 +1317,7 @@ ptp_getdevicepropdesc_write(vcamera *cam, ptpcontainer *ptp) {
 	x += put_16bit_le (data+x, desc.DevicePropertyCode);
 	x += put_16bit_le (data+x, desc.DataType);
 	x += put_8bit_le  (data+x, desc.GetSet);
-	x += put_propval  (data+x, desc.DataType, &desc.FactoryDefaultValue);
+	x += put_propval  (data+x, desc.DataType, &desc.DefaultValue);
 	x += put_propval  (data+x, desc.DataType, &desc.CurrentValue);
 	x += put_8bit_le  (data+x, desc.FormFlag);
 	switch (desc.FormFlag) {
@@ -1566,7 +1566,7 @@ ptp_battery_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
 	desc->DevicePropertyCode	= 0x5001;
 	desc->DataType			= 2;	/* uint8 */
 	desc->GetSet			= 0;	/* Get only */
-	desc->FactoryDefaultValue.u8	= 50;
+	desc->DefaultValue.u8		= 50;
 	desc->CurrentValue.u8		= 50;
 	desc->FormFlag			= 0x01; /* range */
 	desc->FORM.Range.MinimumValue.u8= 0;
@@ -1588,7 +1588,7 @@ ptp_imagesize_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
 	desc->DevicePropertyCode		= 0x5003;
 	desc->DataType				= 0xffff;	/* STR */
 	desc->GetSet				= 0;		/* Get only */
-	desc->FactoryDefaultValue.str		= strdup("640x480");
+	desc->DefaultValue.str		= strdup("640x480");
 	desc->CurrentValue.str			= strdup("640x480");
 	desc->FormFlag				= 0x02; /* enum */
 	desc->FORM.Enum.NumberOfValues 		= 3;
@@ -1614,7 +1614,7 @@ ptp_shutterspeed_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
 	desc->DataType				= 0x0006;	/* UINT32 */
 	desc->GetSet				= 1;		/* Get/Set */
 	if (!cam->shutterspeed) cam->shutterspeed = 100; /* 1/100 * 10000 */
-	desc->FactoryDefaultValue.u32		= cam->shutterspeed;
+	desc->DefaultValue.u32			= cam->shutterspeed;
 	desc->CurrentValue.u32			= cam->shutterspeed;
 	desc->FormFlag				= 0x02; /* enum */
 	desc->FORM.Enum.NumberOfValues 		= 9;
@@ -1654,7 +1654,7 @@ ptp_fnumber_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
 	desc->DataType				= 0x0004;	/* UINT16 */
 	desc->GetSet				= 1;		/* Get/Set */
 	if (!cam->fnumber) cam->fnumber = 280; /* 2.8 * 100 */
-	desc->FactoryDefaultValue.u16		= cam->fnumber;
+	desc->DefaultValue.u16			= cam->fnumber;
 	desc->CurrentValue.u16			= cam->fnumber;
 	desc->FormFlag				= 0x02; /* enum */
 	desc->FORM.Enum.NumberOfValues 		= 18;
@@ -1703,7 +1703,7 @@ ptp_exposurebias_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
 	desc->DataType				= 0x0003;	/* INT16 */
 	desc->GetSet				= 1;		/* Get/Set */
 	if (!cam->exposurebias) cam->exposurebias = 0; /* 0.0 */
-	desc->FactoryDefaultValue.i16		= cam->exposurebias;
+	desc->DefaultValue.i16			= cam->exposurebias;
 	desc->CurrentValue.i16			= cam->exposurebias;
 	desc->FormFlag				= 0x02; /* enum */
 	desc->FORM.Enum.NumberOfValues 		= 13;
@@ -1752,8 +1752,8 @@ ptp_datetime_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
 	desc->GetSet			= 1;		/* get only */
 	time(&xtime);
 	tm = gmtime(&xtime);
-	desc->FactoryDefaultValue.str	= aprintf("%04d%02d%02dT%02d%02d%02d",tm->tm_year+1900,tm->tm_mon+1,tm->tm_mday,tm->tm_hour,tm->tm_min,tm->tm_sec);
-	desc->CurrentValue.str		= strdup (desc->FactoryDefaultValue.str);
+	desc->DefaultValue.str		= aprintf("%04d%02d%02dT%02d%02d%02d",tm->tm_year+1900,tm->tm_mon+1,tm->tm_mday,tm->tm_hour,tm->tm_min,tm->tm_sec);
+	desc->CurrentValue.str		= strdup (desc->DefaultValue.str);
 	desc->FormFlag			= 0; /* no form */
 	/*ptp_inject_interrupt (cam, 1000, 0x4006, 1, 0x5011, 0xffffffff);*/
 	return 1;

--- a/libgphoto2_port/vusb/vcamera.c
+++ b/libgphoto2_port/vusb/vcamera.c
@@ -327,7 +327,7 @@ typedef struct _PTPPropDescEnumForm PTPPropDescEnumForm;
 /* Device Property Describing Dataset (DevicePropDesc) */
 
 struct _PTPDevicePropDesc {
-	uint16_t        DevicePropertyCode;
+	uint16_t        DevicePropCode;
 	uint16_t        DataType;
 	uint8_t         GetSet;
 	PTPPropValue    DefaultValue;
@@ -1314,7 +1314,7 @@ ptp_getdevicepropdesc_write(vcamera *cam, ptpcontainer *ptp) {
 	data = malloc(2000);
 	ptp_properties[i].getdesc (cam, &desc);
 
-	x += put_16bit_le (data+x, desc.DevicePropertyCode);
+	x += put_16bit_le (data+x, desc.DevicePropCode);
 	x += put_16bit_le (data+x, desc.DataType);
 	x += put_8bit_le  (data+x, desc.GetSet);
 	x += put_propval  (data+x, desc.DataType, &desc.DefaultValue);
@@ -1563,7 +1563,7 @@ ptp_setdevicepropvalue_write_data(vcamera *cam, ptpcontainer *ptp, unsigned char
 /**************************  Properties *****************************************************/
 static int
 ptp_battery_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
-	desc->DevicePropertyCode	= 0x5001;
+	desc->DevicePropCode		= 0x5001;
 	desc->DataType			= 2;	/* uint8 */
 	desc->GetSet			= 0;	/* Get only */
 	desc->DefaultValue.u8		= 50;
@@ -1585,7 +1585,7 @@ ptp_battery_getvalue (vcamera* cam, PTPPropValue *val) {
 
 static int
 ptp_imagesize_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
-	desc->DevicePropertyCode		= 0x5003;
+	desc->DevicePropCode		= 0x5003;
 	desc->DataType				= 0xffff;	/* STR */
 	desc->GetSet				= 0;		/* Get only */
 	desc->DefaultValue.str			= strdup("640x480");
@@ -1610,7 +1610,7 @@ ptp_imagesize_getvalue (vcamera* cam, PTPPropValue *val) {
 
 static int
 ptp_shutterspeed_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
-	desc->DevicePropertyCode		= 0x500D;
+	desc->DevicePropCode		= 0x500D;
 	desc->DataType				= 0x0006;	/* UINT32 */
 	desc->GetSet				= 1;		/* Get/Set */
 	if (!cam->shutterspeed) cam->shutterspeed = 100; /* 1/100 * 10000 */
@@ -1650,7 +1650,7 @@ ptp_shutterspeed_setvalue (vcamera* cam, PTPPropValue *val) {
 
 static int
 ptp_fnumber_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
-	desc->DevicePropertyCode		= 0x5007;
+	desc->DevicePropCode		= 0x5007;
 	desc->DataType				= 0x0004;	/* UINT16 */
 	desc->GetSet				= 1;		/* Get/Set */
 	if (!cam->fnumber) cam->fnumber = 280; /* 2.8 * 100 */
@@ -1699,7 +1699,7 @@ ptp_fnumber_setvalue (vcamera* cam, PTPPropValue *val) {
 
 static int
 ptp_exposurebias_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
-	desc->DevicePropertyCode		= 0x5010;
+	desc->DevicePropCode			= 0x5010;
 	desc->DataType				= 0x0003;	/* INT16 */
 	desc->GetSet				= 1;		/* Get/Set */
 	if (!cam->exposurebias) cam->exposurebias = 0; /* 0.0 */
@@ -1747,14 +1747,14 @@ ptp_datetime_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
 	struct tm		*tm;
 	time_t			xtime;
 
-	desc->DevicePropertyCode	= 0x5011;
-	desc->DataType			= 0xffff;	/* string */
-	desc->GetSet			= 1;		/* get only */
+	desc->DevicePropCode	= 0x5011;
+	desc->DataType		= 0xffff;	/* string */
+	desc->GetSet		= 1;		/* get only */
 	time(&xtime);
 	tm = gmtime(&xtime);
-	desc->DefaultValue.str		= aprintf("%04d%02d%02dT%02d%02d%02d",tm->tm_year+1900,tm->tm_mon+1,tm->tm_mday,tm->tm_hour,tm->tm_min,tm->tm_sec);
-	desc->CurrentValue.str		= strdup (desc->DefaultValue.str);
-	desc->FormFlag			= 0; /* no form */
+	desc->DefaultValue.str	= aprintf("%04d%02d%02dT%02d%02d%02d",tm->tm_year+1900,tm->tm_mon+1,tm->tm_mday,tm->tm_hour,tm->tm_min,tm->tm_sec);
+	desc->CurrentValue.str	= strdup (desc->DefaultValue.str);
+	desc->FormFlag		= 0; /* no form */
 	/*ptp_inject_interrupt (cam, 1000, 0x4006, 1, 0x5011, 0xffffffff);*/
 	return 1;
 }

--- a/libgphoto2_port/vusb/vcamera.c
+++ b/libgphoto2_port/vusb/vcamera.c
@@ -310,8 +310,8 @@ typedef union _PTPPropertyValue {
 } PTPPropertyValue;
 
 struct _PTPPropDescRangeForm {
-	PTPPropertyValue        MinimumValue;
-	PTPPropertyValue        MaximumValue;
+	PTPPropertyValue        MinValue;
+	PTPPropertyValue        MaxValue;
 	PTPPropertyValue        StepSize;
 };
 typedef struct _PTPPropDescRangeForm PTPPropDescRangeForm;
@@ -362,8 +362,8 @@ ptp_free_devicepropdesc(PTPDevicePropDesc* dpd)
 	ptp_free_devicepropvalue (dpd->DataType, &dpd->CurrentValue);
 	switch (dpd->FormFlag) {
 	case /* PTP_DPFF_Range */ 0x01:
-		ptp_free_devicepropvalue (dpd->DataType, &dpd->FORM.Range.MinimumValue);
-		ptp_free_devicepropvalue (dpd->DataType, &dpd->FORM.Range.MaximumValue);
+		ptp_free_devicepropvalue (dpd->DataType, &dpd->FORM.Range.MinValue);
+		ptp_free_devicepropvalue (dpd->DataType, &dpd->FORM.Range.MaxValue);
 		ptp_free_devicepropvalue (dpd->DataType, &dpd->FORM.Range.StepSize);
 		break;
 	case /* PTP_DPFF_Enumeration */ 0x02:
@@ -1323,8 +1323,8 @@ ptp_getdevicepropdesc_write(vcamera *cam, ptpcontainer *ptp) {
 	switch (desc.FormFlag) {
 	case 0:	break;
 	case 1:	/* range */
-		x += put_propval (data+x, desc.DataType, &desc.FORM.Range.MinimumValue);
-		x += put_propval (data+x, desc.DataType, &desc.FORM.Range.MaximumValue);
+		x += put_propval (data+x, desc.DataType, &desc.FORM.Range.MinValue);
+		x += put_propval (data+x, desc.DataType, &desc.FORM.Range.MaxValue);
 		x += put_propval (data+x, desc.DataType, &desc.FORM.Range.StepSize);
 		break;
 	case 2:	/* ENUM */
@@ -1569,8 +1569,8 @@ ptp_battery_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
 	desc->DefaultValue.u8		= 50;
 	desc->CurrentValue.u8		= 50;
 	desc->FormFlag			= 0x01; /* range */
-	desc->FORM.Range.MinimumValue.u8= 0;
-	desc->FORM.Range.MaximumValue.u8= 100;
+	desc->FORM.Range.MinValue.u8	= 0;
+	desc->FORM.Range.MaxValue.u8	= 100;
 	desc->FORM.Range.StepSize.u8	= 1;
 	ptp_inject_interrupt (cam, 1000, 0x4006, 1, 0x5001, 0xffffffff);
 	return 1;
@@ -1588,7 +1588,7 @@ ptp_imagesize_getdesc (vcamera* cam, PTPDevicePropDesc *desc) {
 	desc->DevicePropertyCode		= 0x5003;
 	desc->DataType				= 0xffff;	/* STR */
 	desc->GetSet				= 0;		/* Get only */
-	desc->DefaultValue.str		= strdup("640x480");
+	desc->DefaultValue.str			= strdup("640x480");
 	desc->CurrentValue.str			= strdup("640x480");
 	desc->FormFlag				= 0x02; /* enum */
 	desc->FORM.Enum.NumberOfValues 		= 3;

--- a/libgphoto2_port/vusb/vcamera.c
+++ b/libgphoto2_port/vusb/vcamera.c
@@ -960,9 +960,9 @@ ptp_getobjectinfo_write(vcamera *cam, ptpcontainer *ptp) {
 #endif
 	x += put_16bit_le (data+x, ofc);
 	x += put_16bit_le (data+x, 0); 			/* ProtectionStatus, no protection */
-	x += put_32bit_le (data+x, cur->stbuf.st_size); /* ObjectCompressedSize */
+	x += put_32bit_le (data+x, cur->stbuf.st_size); /* ObjectSize */
 	x += put_16bit_le (data+x, thumbofc); 		/* ThumbFormat */
-	x += put_32bit_le (data+x, thumbsize); 		/* ThumbCompressedSize */
+	x += put_32bit_le (data+x, thumbsize); 		/* ThumbSize */
 	x += put_32bit_le (data+x, thumbwidth); 	/* ThumbPixWidth */
 	x += put_32bit_le (data+x, thumbheight);	/* ThumbPixHeight */
 	x += put_32bit_le (data+x, imagewidth); 	/* ImagePixWidth */


### PR DESCRIPTION
This is a whole bunch of rather trivial renaming patches with the goals to:
 * increase internal consistency
 * increase consistency with specification
 * increase readability

If I didn't screw up, this is only changing names of symbols and fixes whitespace where affected. It does not change the
behavior of the code in any way.