### PR TITLE
More array abstraction use in ptp2

### DIFF
--- a/camlibs/ptp2/Makefile-files
+++ b/camlibs/ptp2/Makefile-files
@@ -32,6 +32,7 @@ ptp2_la_SOURCES      += %reldir%/olympus-wrap.h
 ptp2_la_SOURCES      += %reldir%/chdk.c
 ptp2_la_SOURCES      += %reldir%/fujiptpip.c
 ptp2_la_SOURCES      += %reldir%/ptpip-private.h
+ptp2_la_SOURCES      += %reldir%/array.h
 
 ptp2_la_CFLAGS        = $(camlib_cflags)
 ptp2_la_CPPFLAGS      = $(camlib_cppflags)

--- a/camlibs/ptp2/array.h
+++ b/camlibs/ptp2/array.h
@@ -1,0 +1,121 @@
+/* array.h
+ *
+ * Copyright (C) 2024 Axel Waggershauser <awagger@web.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+#ifndef CAMLIBS_PTP2_ARRAY_H
+#define CAMLIBS_PTP2_ARRAY_H
+
+#define ARRAYSIZE(ARRAY) (sizeof(ARRAY) / sizeof(ARRAY[0]))
+
+#define move(dst, src) do { \
+	dst = src; \
+	memset(&(src), 0, sizeof(src)); \
+} while(0)
+
+/* The follow set of macros implements a generic array or list of TYPE.
+ * This is basically a TYPE* pointer and a length integer. This structure
+ * together with the typical use-cases repeats regularly throughout the
+ * codebase. It raises the level of abstraction and improves code
+ * readabilty. axxel is a c++ developer and misses his STL ;)
+ *
+ * A typical life-cycle lookes like this:
+ *
+ * typedef ARRAY_OF(PTPObject) PTPObjects;
+ * PTPObjects objects;
+ * array_push_back(&objects, some_value);
+ * PTPObject *o;
+ * array_push_back_empty(&objects, &o);
+ * o->some_prop = 1;
+ * for_each(PTPObject*, pobj, objects)
+ *     pobj->call_some_func();
+ * free_array_recursive(&objects, ptp_free_object);
+ */
+
+#define ARRAY_OF(TYPE) struct ArrayOf##TYPE \
+{ \
+	TYPE *val; \
+	uint32_t len; \
+}
+
+/* TODO: with support for C23, we can improve the for_each macro by dropping the TYPE argument
+ *     #define for_each(PTR, ARRAY) for (typeof(ARRAY.val) PTR = ARRAY.val; PTR != ARRAY.val + ARRAY.len; ++PTR)
+ */
+#define for_each(TYPE, PTR, ARRAY) \
+	for (TYPE PTR = ARRAY.val; PTR != ARRAY.val + ARRAY.len; ++PTR)
+
+#define free_array(ARRAY) do { \
+	free ((ARRAY)->val); \
+	(ARRAY)->val = 0; \
+	(ARRAY)->len = 0; \
+} while (0)
+
+#define free_array_recusive(ARRAY, DESTRUCTOR) do { \
+	for (uint32_t _i = 0; _i < (ARRAY)->len; ++_i) \
+		DESTRUCTOR (&(ARRAY)->val[_i]); \
+	free_array (ARRAY); \
+} while (0)
+
+#define array_extend_capacity(ARRAY, LEN) do { \
+	(ARRAY)->val = realloc((ARRAY)->val, ((ARRAY)->len + (LEN)) * sizeof((ARRAY)->val[0])); \
+	if (!(ARRAY)->val) { \
+		GP_LOG_E ("Out of memory: 'realloc' of %ld bytes failed.", ((ARRAY)->len + (LEN)) * sizeof((ARRAY)->val[0])); \
+		return GP_ERROR_NO_MEMORY; \
+	} \
+	memset((ARRAY)->val + (ARRAY)->len, 0, LEN * sizeof((ARRAY)->val[0])); \
+} while(0)
+
+#define array_push_back_empty(ARRAY, PITER) do { \
+	array_extend_capacity(ARRAY, 1); \
+	*PITER = &(ARRAY)->val[(ARRAY)->len++]; \
+} while(0)
+
+#define array_push_back(ARRAY, VAL) do { \
+	array_extend_capacity(ARRAY, 1); \
+	move((ARRAY)->val[(ARRAY)->len++], VAL); \
+} while(0)
+
+#define array_append_copy(DST, SRC) do { \
+	array_extend_capacity(DST, (SRC)->len); \
+	memcpy((DST)->val + (DST)->len, (SRC)->val, (SRC)->len * sizeof((SRC)->val[0])); \
+	(DST)->len += (SRC)->len; \
+} while(0)
+
+#define array_append(DST, SRC) do { \
+	if ((DST)->len) { \
+		array_append_copy(DST, SRC); \
+		free_array (SRC); \
+	} else { \
+		free_array (DST); \
+		*(DST) = *(SRC); \
+	} \
+} while(0)
+
+#define array_remove(ARRAY, ITER) do { \
+	if (ITER < (ARRAY)->val || ITER >= (ARRAY)->val + (ARRAY)->len) \
+		break; \
+	memmove (ITER, ITER + 1, ((ARRAY)->len - (ITER + 1 - (ARRAY)->val)) * sizeof((ARRAY)->val[0])); \
+	(ARRAY)->len--; \
+} while(0)
+
+#define array_pop_front(ARRAY, VAL) do { \
+	*VAL = (ARRAY)->val[0]; \
+	array_remove(ARRAY, (ARRAY)->val); \
+} while(0)
+
+#endif

--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -12115,7 +12115,7 @@ _set_config (Camera *camera, const char *confname, CameraWidget *window, GPConte
 								ret = translate_ptp_result (ret_ptp);
 							}
 						}
-						ptp_free_devicepropvalue (cursub->type, &propval);
+						ptp_free_propvalue (cursub->type, &propval);
 					}
 					ptp_free_devicepropdesc(&dpd);
 					if (ret != GP_OK) continue; /* see if we have another match */
@@ -12146,7 +12146,7 @@ _set_config (Camera *camera, const char *confname, CameraWidget *window, GPConte
 								ret = translate_ptp_result (ret_ptp);
 							}
 						}
-						ptp_free_devicepropvalue(cursub->type, &propval);
+						ptp_free_propvalue(cursub->type, &propval);
 					} else
 						gp_context_error (context, _("Parsing the value of widget '%s' / 0x%04x failed with %d."), _(cursub->label), cursub->propid, ret);
 					ptp_free_devicepropdesc(&dpd);
@@ -12266,7 +12266,7 @@ _set_config (Camera *camera, const char *confname, CameraWidget *window, GPConte
 					  _(label), propid, ret, _(ptp_strerror(ret, params->deviceinfo.VendorExtensionID)));
 			ret = GP_ERROR;
 		}
-		ptp_free_devicepropvalue (dpd.DataType, &propval);
+		ptp_free_propvalue (dpd.DataType, &propval);
 		ptp_free_devicepropdesc (&dpd);
 		if (mode == MODE_SINGLE_SET)
 			return GP_OK;

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -133,7 +133,18 @@ translate_ptp_result (uint16_t result)
 	case PTP_ERROR_IO:
 	case PTP_ERROR_DATA_EXPECTED:
 	case PTP_ERROR_RESP_EXPECTED:		return GP_ERROR_IO;
-	default:				return GP_ERROR;
+	default: {
+		/* If result is actually a GP_ERROR code (see gphoto2-port-result.h), then we simply pass it through as is.
+		 * This works because those two value ranges have no overlap:
+		 *   - PTP errors are either 0x0..., 0x2.... or 0xA....
+		 *   - GP errors (as uint16_t) are 0xF...
+		 */
+		int int_res = (int16_t)result;
+		if (-99 <= int_res && int_res <= 0)
+			return int_res;
+		else
+			return GP_ERROR;
+	}
 	}
 }
 

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -6009,9 +6009,7 @@ camera_trigger_canon_eos_capture (Camera *camera, GPContext *context)
 
 	/* Discard all collected events before starting the next capture. */
 	GP_LOG_D("discarding %d EOS events", params->eos_events.len);
-	for_each (PTPCanonEOSEvent*, pevt, params->eos_events)
-		ptp_free_eos_event (pevt);
-	free_array (&params->eos_events);
+	free_array_recusive (&params->eos_events, ptp_free_eos_event);
 
 	if (params->eos_camerastatus == 1)
 		return GP_ERROR_CAMERA_BUSY;

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -3218,7 +3218,7 @@ camera_exit (Camera *camera, GPContext *context)
 				if (camera->pl->checkevents) {
 					if ((exit_result = ptp_check_eos_events (params)) != PTP_RC_OK)
 						goto exitfailed;
-					GP_LOG_D ("missed %d EOS events", params->eos_events_len);
+					GP_LOG_D ("missed %d EOS events", params->eos_events.len);
 					camera->pl->checkevents = 0;
 				}
 				if (params->inliveview && ptp_operation_issupported(params, PTP_OC_CANON_EOS_TerminateViewfinder))
@@ -5998,10 +5998,8 @@ camera_trigger_canon_eos_capture (Camera *camera, GPContext *context)
 	ptp_check_eos_events (params);
 
 	/* Discard all collected events before starting the next capture. */
-	GP_LOG_D("discarding %d EOS events", params->eos_events_len);
-	free (params->eos_events);
-	params->eos_events = NULL;
-	params->eos_events_len = 0;
+	GP_LOG_D("discarding %d EOS events", params->eos_events.len);
+	free_array (&params->eos_events);
 
 	if (params->eos_camerastatus == 1)
 		return GP_ERROR_CAMERA_BUSY;
@@ -6620,7 +6618,7 @@ camera_wait_for_event (Camera *camera, int timeout,
 
 			CR (camera_keep_device_on (camera));
 
-			if (params->eos_events_len == 0)
+			if (params->eos_events.len == 0)
 				C_PTP_REP_MSG (ptp_check_eos_events (params), _("Canon EOS Get Changes failed"));
 
 			while (ptp_get_one_eos_event (params, &eos_event)) {

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2001-2005 Mariusz Woloszyn <emsi@ipartners.pl>
  * Copyright (C) 2003-2021 Marcus Meissner <marcus@jet.franken.de>
  * Copyright (C) 2005 Hubert Figuiere <hfiguiere@teaser.fr>
- * Copyright (C) 2009 Axel Waggershauser <awagger@web.de>
+ * Copyright (C) 2009-2024 Axel Waggershauser <awagger@web.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -1699,8 +1699,8 @@ static inline PTPDevicePropDesc*
 ptp_find_eos_devicepropdesc(PTPParams *params, uint32_t dpc)
 {
 	for (unsigned j=0; j < params->canon_props_len; j++)
-		if (params->canon_props[j].dpd.DevicePropCode == dpc)
-			return &params->canon_props[j].dpd;
+		if (params->canon_props[j].DevicePropCode == dpc)
+			return &params->canon_props[j];
 	return NULL;
 }
 
@@ -1714,12 +1714,12 @@ _lookup_or_allocate_canon_prop(PTPParams *params, uint32_t dpc)
 
 	unsigned j = params->canon_props_len;
 	params->canon_props = realloc(params->canon_props, sizeof(params->canon_props[0])*(j+1));
-	memset (&params->canon_props[j].dpd,0,sizeof(params->canon_props[j].dpd));
-	params->canon_props[j].dpd.DevicePropCode = dpc;
-	params->canon_props[j].dpd.GetSet = 1;
-	params->canon_props[j].dpd.FormFlag = PTP_DPFF_None;
+	memset (&params->canon_props[j],0,sizeof(params->canon_props[j]));
+	params->canon_props[j].DevicePropCode = dpc;
+	params->canon_props[j].GetSet = 1;
+	params->canon_props[j].FormFlag = PTP_DPFF_None;
 	params->canon_props_len = j+1;
-	return &params->canon_props[j].dpd;
+	return &params->canon_props[j];
 }
 
 #define PTP_CANON_SET_INFO( ENTRY, MSG, ...) \

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -1729,7 +1729,7 @@ _lookup_or_allocate_canon_prop(PTPParams *params, uint32_t dpc)
 	} while (0)
 
 static inline int
-ptp_unpack_EOS_events (PTPParams *params, const unsigned char* data, unsigned int datasize, PTPCanonEOSEvent **events)
+ptp_unpack_EOS_events (PTPParams *params, const unsigned char* data, unsigned int datasize, PTPCanonEOSEvents *events)
 {
 	int	i = 0, event_count = 0;
 	const unsigned char *curdata = data;
@@ -2540,7 +2540,8 @@ static unsigned int olcsizes[0x15][13] = {
 		free (e);
 		e = NULL;
 	}
-	*events = e;
+	events->val = e;
+	events->len = i;
 	return i;
 	#undef INDENT
 }

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2003-2019 Marcus Meissner <marcus@jet.franken.de>
  * Copyright (C) 2006-2008 Linus Walleij <triad@df.lth.se>
  * Copyright (C) 2007 Tero Saarni <tero.saarni@gmail.com>
- * Copyright (C) 2009 Axel Waggershauser <awagger@web.de>
+ * Copyright (C) 2009-2024 Axel Waggershauser <awagger@web.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/camlibs/ptp2/ptp-pack.c
+++ b/camlibs/ptp2/ptp-pack.c
@@ -24,6 +24,8 @@
 
 /* currently this file is included into ptp.c */
 
+#include "ptp.h" /* included here to help vscode editor find the symbols */
+
 #ifdef HAVE_LIMITS_H
 #include <limits.h>
 #endif

--- a/camlibs/ptp2/ptp-private.h
+++ b/camlibs/ptp2/ptp-private.h
@@ -141,8 +141,8 @@ have_eos_prop(PTPParams *params, uint16_t vendor, uint16_t prop) {
 	/* The special Canon EOS property set gets special treatment. */
 	if ((params->deviceinfo.VendorExtensionID != PTP_VENDOR_CANON) || (vendor != PTP_VENDOR_CANON))
 		return 0;
-	for (i=0;i<params->canon_props_len;i++)
-		if (params->canon_props[i].DevicePropCode == prop)
+	for (i=0;i<params->canon_props.len;i++)
+		if (params->canon_props.val[i].DevicePropCode == prop)
 			return 1;
 	return 0;
 }

--- a/camlibs/ptp2/ptp-private.h
+++ b/camlibs/ptp2/ptp-private.h
@@ -142,7 +142,7 @@ have_eos_prop(PTPParams *params, uint16_t vendor, uint16_t prop) {
 	if ((params->deviceinfo.VendorExtensionID != PTP_VENDOR_CANON) || (vendor != PTP_VENDOR_CANON))
 		return 0;
 	for (i=0;i<params->canon_props_len;i++)
-		if (params->canon_props[i].dpd.DevicePropCode == prop)
+		if (params->canon_props[i].DevicePropCode == prop)
 			return 1;
 	return 0;
 }

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -4640,8 +4640,7 @@ ptp_generic_getdevicepropdesc (PTPParams *params, uint32_t propcode, PTPDevicePr
 	PTPDevicePropDesc* dpd_in_cache = ptp_find_dpd_in_cache(params, propcode);
 
 	if (!dpd_in_cache) {
-		array_extend(&params->dpd_cache, 1);
-		dpd_in_cache = &params->dpd_cache.val[params->dpd_cache.len - 1];
+		array_push_back_empty(&params->dpd_cache, &dpd_in_cache);
 	}
 
 	if (dpd_in_cache->DataType != PTP_DTC_UNDEF) {

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -2092,9 +2092,7 @@ ptp_free_params (PTPParams *params)
 	}
 	free (params->canon_props);
 
-	for_each (PTPCanonEOSEvent*, pevt, params->eos_events)
-		ptp_free_eos_event (pevt);
-	free_array (&params->eos_events);
+	free_array_recusive (&params->eos_events, ptp_free_eos_event);
 
 	for (i=0;i<params->dpd_cache_len;i++)
 		ptp_free_devicepropdesc (&params->dpd_cache[i]);
@@ -5930,9 +5928,7 @@ ptp_free_object (PTPObject *ob)
 	if (!ob) return;
 
 	ptp_free_objectinfo (&ob->oi);
-	for_each (MTPObjectProp*, prop, ob->mtp_props)
-		ptp_free_object_prop(prop);
-	free_array (&ob->mtp_props);
+	free_array_recusive (&ob->mtp_props, ptp_free_object_prop);
 	ob->flags = 0;
 }
 

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2003-2019 Marcus Meissner <marcus@jet.franken.de>
  * Copyright (C) 2006-2008 Linus Walleij <triad@df.lth.se>
  * Copyright (C) 2007 Tero Saarni <tero.saarni@gmail.com>
- * Copyright (C) 2009 Axel Waggershauser <awagger@web.de>
+ * Copyright (C) 2009-2024 Axel Waggershauser <awagger@web.de>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -2066,7 +2066,7 @@ ptp_free_params (PTPParams *params)
 	free_array (&params->storageids);
 	free (params->events);
 	for (i=0;i<params->canon_props_len;i++) {
-		ptp_free_devicepropdesc (&params->canon_props[i].dpd);
+		ptp_free_devicepropdesc (&params->canon_props[i]);
 	}
 	free (params->canon_props);
 	free_array (&params->eos_events);

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -2087,11 +2087,8 @@ ptp_free_params (PTPParams *params)
 	free (params->objects);
 	free_array (&params->storageids);
 	free (params->events);
-	for (i=0;i<params->canon_props_len;i++) {
-		ptp_free_devicepropdesc (&params->canon_props[i]);
-	}
-	free (params->canon_props);
 
+	free_array_recusive (&params->canon_props, ptp_free_devicepropdesc);
 	free_array_recusive (&params->eos_events, ptp_free_eos_event);
 
 	for (i=0;i<params->dpd_cache_len;i++)

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -689,68 +689,24 @@ parse_9301_cmd_tree (PTPParams *params, xmlNodePtr node, PTPDeviceInfo *di)
 static int
 parse_9301_value (PTPParams *params, const char *str, uint16_t type, PTPPropValue *propval)
 {
+#define CASE(DTC, FMT, BITS) \
+		case DTC: { \
+			if (sscanf(str, FMT, &propval->BITS) != 1) { \
+				ptp_debug( params, "could not parse " #BITS " %s", str); \
+				return PTP_RC_GeneralError; \
+			} \
+			ptp_debug( params, "\t%d", propval->BITS); \
+			break; \
+		}
+
 	switch (type) {
-	case 6: { /*UINT32*/
-		unsigned int x;
-		if (!sscanf(str,"%08x", &x)) {
-			ptp_debug( params, "could not parse uint32 %s", str);
-			return PTP_RC_GeneralError;
-		}
-		ptp_debug( params, "\t%d", x);
-		propval->u32 = x;
-		break;
-	}
-	case 5: { /*INT32*/
-		int x;
-		if (!sscanf(str,"%08x", &x)) {
-			ptp_debug( params, "could not parse int32 %s", str);
-			return PTP_RC_GeneralError;
-		}
-		ptp_debug( params, "\t%d", x);
-		propval->i32 = x;
-		break;
-	}
-	case 4: { /*UINT16*/
-		unsigned int x;
-		if (!sscanf(str,"%04x", &x)) {
-			ptp_debug( params, "could not parse uint16 %s", str);
-			return PTP_RC_GeneralError;
-		}
-		ptp_debug( params, "\t%d", x);
-		propval->u16 = x;
-		break;
-	}
-	case 3: { /*INT16*/
-		int x;
-		if (!sscanf(str,"%04x", &x)) {
-			ptp_debug( params, "could not parse int16 %s", str);
-			return PTP_RC_GeneralError;
-		}
-		ptp_debug( params, "\t%d", x);
-		propval->i16 = x;
-		break;
-	}
-	case 2: { /*UINT8*/
-		unsigned int x;
-		if (!sscanf(str,"%02x", &x)) {
-			ptp_debug( params, "could not parse uint8 %s", str);
-			return PTP_RC_GeneralError;
-		}
-		ptp_debug( params, "\t%d", x);
-		propval->u8 = x;
-		break;
-	}
-	case 1: { /*INT8*/
-		int x;
-		if (!sscanf(str,"%02x", &x)) {
-			ptp_debug( params, "could not parse int8 %s", str);
-			return PTP_RC_GeneralError;
-		}
-		ptp_debug( params, "\t%d", x);
-		propval->i8 = x;
-		break;
-	}
-	case 65535: { /* string */
+	CASE(PTP_DTC_UINT8, "%02hhx", u8)
+	CASE(PTP_DTC_INT8, "%02hhx", i8)
+	CASE(PTP_DTC_UINT16, "%04hx", u16)
+	CASE(PTP_DTC_INT16, "%04hx", i16)
+	CASE(PTP_DTC_UINT32, "%08x", u32)
+	CASE(PTP_DTC_INT32, "%08x", i32)
+	case PTP_DTC_STR: {
 		int len;
 
 		/* ascii ptp string, 1 byte length, little endian 16 bit chars */
@@ -774,14 +730,12 @@ parse_9301_value (PTPParams *params, const char *str, uint16_t type, PTPPropValu
 		ptp_debug( params, "string %s not parseable!", str);
 		return PTP_RC_GeneralError;
 	}
-	case 7: /*INT64*/
-	case 8: /*UINT64*/
-	case 9: /*INT128*/
-	case 10: /*UINT128*/
 	default:
 		ptp_debug( params, "unhandled data type %d!", type);
 		return PTP_RC_GeneralError;
 	}
+#undef CASE
+
 	return PTP_RC_OK;
 }
 

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -4949,7 +4949,7 @@ int ptp_property_issupported	(PTPParams* params, uint16_t property);
 void ptp_free_params		(PTPParams *params);
 void ptp_free_objectpropdesc	(PTPObjectPropDesc*);
 void ptp_free_devicepropdesc	(PTPDevicePropDesc*);
-void ptp_free_devicepropvalue	(uint16_t, PTPPropValue*);
+void ptp_free_propvalue		(uint16_t, PTPPropValue*);
 void ptp_free_deviceinfo	(PTPDeviceInfo *);
 void ptp_free_objectinfo	(PTPObjectInfo *oi);
 void ptp_free_object		(PTPObject *oi);
@@ -4985,8 +4985,7 @@ ptp_render_property_value(PTPParams* params, uint16_t dpc,
 int ptp_render_ofc(PTPParams* params, uint16_t ofc, int spaceleft, char *txt);
 int ptp_render_mtp_propname(uint16_t propid, int spaceleft, char *txt);
 MTPObjectProp *ptp_get_new_object_prop_entry(MTPObjectProp **props, int *nrofprops);
-void ptp_destroy_object_prop(MTPObjectProp *prop);
-void ptp_destroy_object_prop_list(MTPObjectProp *props, int nrofprops);
+void ptp_free_object_prop(MTPObjectProp *prop);
 MTPObjectProp *ptp_find_object_prop_in_cache(PTPParams *params, uint32_t const handle, uint32_t const attribute_id);
 uint16_t ptp_remove_object_from_cache(PTPParams *params, uint32_t handle);
 uint16_t ptp_add_object_to_cache(PTPParams *params, uint32_t handle);

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1822,6 +1822,7 @@ struct _PTPDevicePropDesc {
 		PTPPropDescEnumForm	Enum;
 		PTPPropDescRangeForm	Range;
 	} FORM;
+	time_t			timestamp; /* This member is used for the dpd_cache management and not part of the PTP spec. */
 };
 typedef struct _PTPDevicePropDesc PTPDevicePropDesc;
 
@@ -3875,13 +3876,6 @@ struct _PTPObject {
 };
 typedef struct _PTPObject PTPObject;
 
-/* The Device Property Cache */
-struct _PTPDeviceProperty {
-	time_t			timestamp;
-	PTPDevicePropDesc	desc;
-};
-typedef struct _PTPDeviceProperty PTPDeviceProperty;
-
 struct _MTPPropertyDesc {
 	uint16_t	opc;
 	PTPObjectPropDesc	opd;
@@ -3980,7 +3974,7 @@ struct _PTPParams {
 	int			storagechanged;
 
 	/* PTP: Device Property Caching */
-	PTPDeviceProperty	*dpd_cache;
+	PTPDevicePropDesc	*dpd_cache;
 	unsigned int		dpd_cache_len;
 
 	/* PTP: Canon specific flags list */

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -74,6 +74,11 @@ static inline uint32_t _post_inc(uint32_t* o, int n)
 
 #define ARRAYSIZE(ARRAY) (sizeof(ARRAY) / sizeof(ARRAY[0]))
 
+#define move(dst, src) do { \
+	dst = src; \
+	memset(&(src), 0, sizeof(src)); \
+} while(0)
+
 /* The follow set of macros implements a generic array or list of TYPE.
  * This is basically a TYPE* pointer and a length integer. This structure
  * together with the typical use-cases repeats regularly throughout the
@@ -4943,6 +4948,7 @@ void ptp_free_propvalue		(uint16_t, PTPPropValue*);
 void ptp_free_deviceinfo	(PTPDeviceInfo *);
 void ptp_free_objectinfo	(PTPObjectInfo *oi);
 void ptp_free_object		(PTPObject *oi);
+void ptp_free_eos_event		(PTPCanonEOSEvent *);
 
 const char *ptp_strerror	(uint16_t ret, uint16_t vendor);
 void ptp_debug			(PTPParams *params, const char *format, ...)

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -127,7 +127,7 @@ static inline uint32_t _post_inc(uint32_t* o, int n)
 
 #define array_push_back(ARRAY, VAL) do { \
 	array_extend(ARRAY, 1); \
-	(ARRAY)->val[(ARRAY)->len++] = VAL; \
+	move((ARRAY)->val[(ARRAY)->len++], VAL); \
 } while(0)
 
 #define array_append_copy(DST, SRC) do { \
@@ -3984,8 +3984,7 @@ struct _PTPParams {
 	int			storagechanged;
 
 	/* PTP: Device Property Caching */
-	PTPDevicePropDesc	*dpd_cache;
-	unsigned int		dpd_cache_len;
+	PTPDevicePropDescs	dpd_cache;
 
 	/* PTP: Canon specific flags list */
 	PTPDevicePropDescs	canon_props;
@@ -4998,6 +4997,9 @@ void ptp_objects_sort (PTPParams *);
 uint16_t ptp_object_find (PTPParams *params, uint32_t handle, PTPObject **retob);
 uint16_t ptp_object_find_or_insert (PTPParams *params, uint32_t handle, PTPObject **retob);
 uint16_t ptp_list_folder (PTPParams *params, uint32_t storage, uint32_t handle);
+
+PTPDevicePropDesc* ptp_find_dpd_in_cache(PTPParams *params, uint32_t dpc);
+
 /* ptpip.c */
 void ptp_nikon_getptpipguid (unsigned char* guid);
 

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1827,9 +1827,9 @@ struct _PTPDevicePropDesc {
 	uint32_t		DevicePropCode;
 	uint16_t		DataType;
 	uint8_t			GetSet;
+	uint8_t			FormFlag;
 	PTPPropValue	DefaultValue;
 	PTPPropValue	CurrentValue;
-	uint8_t			FormFlag;
 	union	{
 		PTPPropDescEnumForm	Enum;
 		PTPPropDescRangeForm	Range;

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -31,6 +31,8 @@
 #include <iconv.h>
 #endif
 #include "libgphoto2/gphoto2-endian.h"
+#include <gphoto2/gphoto2-port-log.h>
+#include <gphoto2/gphoto2-port-result.h>
 #include "device-flags.h"
 
 #ifdef __cplusplus
@@ -102,8 +104,10 @@ static inline uint32_t _post_inc(uint32_t* o, int n)
 
 #define array_extend(ARRAY, LEN) do { \
 	(ARRAY)->val = realloc((ARRAY)->val, ((ARRAY)->len + (LEN)) * sizeof((ARRAY)->val[0])); \
-	if (!(ARRAY)->val) \
-		ptp_error(params, "PANIC: realloc failed"); \
+	if (!(ARRAY)->val) { \
+		GP_LOG_E ("Out of memory: 'realloc' of %ld bytes failed.", ((ARRAY)->len + (LEN)) * sizeof((ARRAY)->val[0])); \
+		return GP_ERROR_NO_MEMORY; \
+	} \
 } while(0)
 
 #define array_push_back(ARRAY, VAL) do { \

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -3925,6 +3925,7 @@ typedef struct _PanasonicLiveViewSize PanasonicLiveViewSize;
 #define PTP_DP_GETDATA          0x0002  /* receiving data */
 #define PTP_DP_DATA_MASK        0x00ff  /* data phase mask */
 
+typedef ARRAY_OF(PTPObject) PTPObjects;
 typedef ARRAY_OF(PTPContainer) PTPEvents;
 typedef ARRAY_OF(PTPCanonEOSEvent) PTPCanonEOSEvents;
 typedef ARRAY_OF(PTPDevicePropDesc) PTPDevicePropDescs;
@@ -3974,8 +3975,7 @@ struct _PTPParams {
 #endif
 
 	/* PTP: internal structures used by ptp driver */
-	PTPObject	*objects;
-	unsigned int	objects_len;
+	PTPObjects	objects;
 
 	PTPDeviceInfo	deviceinfo;
 

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -1959,10 +1959,6 @@ struct _PTPCanonEOSEvent {
 };
 typedef struct _PTPCanonEOSEvent PTPCanonEOSEvent;
 
-typedef struct _PTPCanon_Property {
-	PTPDevicePropDesc	dpd;
-} PTPCanon_Property;
-
 typedef struct _PTPCanonEOSDeviceInfo {
 	/* length */
 	uint32_t Events_len;
@@ -3978,7 +3974,7 @@ struct _PTPParams {
 	unsigned int		dpd_cache_len;
 
 	/* PTP: Canon specific flags list */
-	PTPCanon_Property	*canon_props;
+	PTPDevicePropDesc	*canon_props;
 	unsigned int		canon_props_len;
 	int			canon_viewfinder_on;
 	int			canon_event_mode;

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -146,12 +146,16 @@ static inline uint32_t _post_inc(uint32_t* o, int n)
 	} \
 } while(0)
 
-#define array_pop_front(ARRAY, VAL) do { \
-	if ((ARRAY)->len == 0) \
+#define array_remove(ARRAY, ITER) do { \
+	if (ITER < (ARRAY)->val || ITER >= (ARRAY)->val + (ARRAY)->len) \
 		break; \
-	*VAL = (ARRAY)->val[0]; \
-	memmove ((ARRAY)->val, (ARRAY)->val + 1, ((ARRAY)->len - 1) * sizeof((ARRAY)->val[0])); \
+	memmove (ITER, ITER + 1, ((ARRAY)->len - (ITER + 1 - (ARRAY)->val)) * sizeof((ARRAY)->val[0])); \
 	(ARRAY)->len--; \
+} while(0)
+
+#define array_pop_front(ARRAY, VAL) do { \
+	*VAL = (ARRAY)->val[0]; \
+	array_remove(ARRAY, (ARRAY)->val); \
 } while(0)
 
 /* TODO: with support for C23, we can improve the for_each macro by dropping the TYPE argument
@@ -3913,6 +3917,7 @@ typedef struct _PanasonicLiveViewSize PanasonicLiveViewSize;
 #define PTP_DP_GETDATA          0x0002  /* receiving data */
 #define PTP_DP_DATA_MASK        0x00ff  /* data phase mask */
 
+typedef ARRAY_OF(PTPContainer) PTPEvents;
 typedef ARRAY_OF(PTPCanonEOSEvent) PTPCanonEOSEvents;
 typedef ARRAY_OF(PTPDevicePropDesc) PTPDevicePropDescs;
 
@@ -3967,8 +3972,7 @@ struct _PTPParams {
 	PTPDeviceInfo	deviceinfo;
 
 	/* PTP: the current event queue */
-	PTPContainer	*events;
-	unsigned int	events_len;
+	PTPEvents	events;
 
 	/* Capture count for SDRAM capture style images */
 	unsigned int		capcnt;
@@ -4239,8 +4243,6 @@ uint16_t ptp_check_event (PTPParams *params);
 uint16_t ptp_check_event_queue (PTPParams *params);
 uint16_t ptp_wait_event (PTPParams *params);
 uint16_t ptp_add_event (PTPParams *params, PTPContainer *event);
-uint16_t ptp_add_events (PTPParams *params, PTPContainer *event, unsigned int count);
-uint16_t ptp_add_event_queue (PTPContainer **events, unsigned int *nrevents, PTPContainer *evt);
 int ptp_get_one_event (PTPParams *params, PTPContainer *evt);
 int ptp_get_one_event_by_type(PTPParams *params, uint16_t code, PTPContainer *event);
 uint16_t ptp_check_eos_events (PTPParams *params);

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -122,6 +122,7 @@ static inline uint32_t _post_inc(uint32_t* o, int n)
 		GP_LOG_E ("Out of memory: 'realloc' of %ld bytes failed.", ((ARRAY)->len + (LEN)) * sizeof((ARRAY)->val[0])); \
 		return GP_ERROR_NO_MEMORY; \
 	} \
+	memset((ARRAY)->val + (ARRAY)->len, 0, LEN); \
 } while(0)
 
 #define array_push_back(ARRAY, VAL) do { \
@@ -3865,7 +3866,6 @@ typedef void (* PTPDebugFunc) (void *data, const char *format, va_list args)
 ;
 
 typedef ARRAY_OF(MTPObjectProp) MTPObjectProps;
-typedef ARRAY_OF(PTPCanonEOSEvent) PTPCanonEOSEvents;
 
 struct _PTPObject {
 	uint32_t	oid;
@@ -3912,6 +3912,9 @@ typedef struct _PanasonicLiveViewSize PanasonicLiveViewSize;
 #define PTP_DP_SENDDATA         0x0001  /* sending data */
 #define PTP_DP_GETDATA          0x0002  /* receiving data */
 #define PTP_DP_DATA_MASK        0x00ff  /* data phase mask */
+
+typedef ARRAY_OF(PTPCanonEOSEvent) PTPCanonEOSEvents;
+typedef ARRAY_OF(PTPDevicePropDesc) PTPDevicePropDescs;
 
 struct _PTPParams {
 	/* device flags */
@@ -3985,8 +3988,7 @@ struct _PTPParams {
 	unsigned int		dpd_cache_len;
 
 	/* PTP: Canon specific flags list */
-	PTPDevicePropDesc	*canon_props;
-	unsigned int		canon_props_len;
+	PTPDevicePropDescs	canon_props;
 	int			canon_viewfinder_on;
 	int			canon_event_mode;
 

--- a/libgphoto2_port/gphoto2/gphoto2-port-result.h
+++ b/libgphoto2_port/gphoto2/gphoto2-port-result.h
@@ -40,6 +40,13 @@
  * \brief Out of memory
  */
 #define GP_ERROR_NO_MEMORY		-3
+/* FIXME: GP_ERROR_NO_MEMORY is used to communicate two completely differnt
+ * things, which have nothing to do with each other:
+ *  - the camera went out of memory because the storage space ran out, this
+ *    is totally "normal"
+ *  - a malloc on the host computer failed: this will completely interrupt
+ *    the functionality and likely crash the process soonish
+ */
 /**
  * \brief Error in the camera driver
  */

--- a/libgphoto2_port/vusb/vcamera.c
+++ b/libgphoto2_port/vusb/vcamera.c
@@ -344,7 +344,7 @@ typedef struct _PTPDevicePropDesc PTPDevicePropDesc;
 // Perhaps vcamera.c should be moved to camlibs/ptp2 for easier sharing
 // in the future.
 static void
-ptp_free_devicepropvalue(uint16_t dt, PTPPropValue* dpd)
+ptp_free_propvalue(uint16_t dt, PTPPropValue* dpd)
 {
 	if (dt == /* PTP_DTC_STR */ 0xFFFF) {
 		free(dpd->str);
@@ -358,18 +358,18 @@ ptp_free_devicepropdesc(PTPDevicePropDesc* dpd)
 {
 	uint16_t i;
 
-	ptp_free_devicepropvalue (dpd->DataType, &dpd->DefaultValue);
-	ptp_free_devicepropvalue (dpd->DataType, &dpd->CurrentValue);
+	ptp_free_propvalue (dpd->DataType, &dpd->DefaultValue);
+	ptp_free_propvalue (dpd->DataType, &dpd->CurrentValue);
 	switch (dpd->FormFlag) {
 	case /* PTP_DPFF_Range */ 0x01:
-		ptp_free_devicepropvalue (dpd->DataType, &dpd->FORM.Range.MinValue);
-		ptp_free_devicepropvalue (dpd->DataType, &dpd->FORM.Range.MaxValue);
-		ptp_free_devicepropvalue (dpd->DataType, &dpd->FORM.Range.StepSize);
+		ptp_free_propvalue (dpd->DataType, &dpd->FORM.Range.MinValue);
+		ptp_free_propvalue (dpd->DataType, &dpd->FORM.Range.MaxValue);
+		ptp_free_propvalue (dpd->DataType, &dpd->FORM.Range.StepSize);
 		break;
 	case /* PTP_DPFF_Enumeration */ 0x02:
 		if (dpd->FORM.Enum.SupportedValue) {
 			for (i=0;i<dpd->FORM.Enum.NumberOfValues;i++)
-				ptp_free_devicepropvalue (dpd->DataType, dpd->FORM.Enum.SupportedValue+i);
+				ptp_free_propvalue (dpd->DataType, dpd->FORM.Enum.SupportedValue+i);
 			free (dpd->FORM.Enum.SupportedValue);
 		}
 	}


### PR DESCRIPTION
More use of the new array abstraction in the ptp2 camlib and some minor cleanups along the way. The PTPParams struct is now completely converted to use the array macros. Also more preparation steps towards merging `dpd_cache` and `canon_props`.

There is a new `TODO` and a `FIXME` comment related to old/potential bugs.