### PR TITLE
Fix Sony regression by removing ptp_is_vendor_extension_prop

### DIFF
--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -4620,9 +4620,6 @@ ptp_generic_getdevicepropdesc (PTPParams *params, uint32_t propcode, PTPDevicePr
 		ptp_free_devicepropdesc (dpd_in_cache);
 	}
 
-	if (!ptp_is_vendor_extension_prop(propcode))
-		goto generic;
-
 	if (	(params->deviceinfo.VendorExtensionID == PTP_VENDOR_CANON) &&
 		ptp_operation_issupported(params, PTP_OC_CANON_EOS_RequestDevicePropValue)
 	) {


### PR DESCRIPTION
A git bisect reveled that ptp_is_vendor_extension_prop introduced in https://github.com/gphoto/libgphoto2/commit/f5e51fd63b8b9d76bc5efbfd1f404e722a3b6e78 caused a regression for Sony cameras causing some of them to fail to capture completely.