### PR TITLE
Object handling

### DIFF
--- a/camlibs/ptp2/array.h
+++ b/camlibs/ptp2/array.h
@@ -57,7 +57,12 @@
  *     #define for_each(PTR, ARRAY) for (typeof(ARRAY.val) PTR = ARRAY.val; PTR != ARRAY.val + ARRAY.len; ++PTR)
  */
 #define for_each(TYPE, PTR, ARRAY) \
-	for (TYPE PTR = ARRAY.val; PTR < ARRAY.val + ARRAY.len; ++PTR)
+	for (TYPE PTR = (ARRAY).val; PTR < (ARRAY).val + (ARRAY).len; ++PTR)
+
+#define array_init(ARRAY) do { \
+	(ARRAY)->val = 0; \
+	(ARRAY)->len = 0; \
+} while (0)
 
 #define free_array(ARRAY) do { \
 	free ((ARRAY)->val); \
@@ -87,7 +92,7 @@
 
 #define array_push_back(ARRAY, VAL) do { \
 	array_extend_capacity(ARRAY, 1); \
-	move((ARRAY)->val[(ARRAY)->len++], VAL); \
+	(ARRAY)->val[(ARRAY)->len++] = VAL; \
 } while(0)
 
 #define array_append_copy(DST, SRC) do { \

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -3410,7 +3410,7 @@ add_object_to_fs_and_path (Camera *camera, uint32_t handle, CameraFilePath *path
 	info.file.width		= ob->oi.ImagePixWidth;
 	info.file.height	= ob->oi.ImagePixHeight;
 	info.file.size		= ob->oi.ObjectSize;
-	info.file.mtime		= time(NULL);
+	info.file.mtime		= ob->oi.ModificationDate;
 
 	info.preview.fields = GP_FILE_INFO_TYPE |
 			GP_FILE_INFO_WIDTH | GP_FILE_INFO_HEIGHT |

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -3050,8 +3050,14 @@ ptp_error_func (void *data, const char *format, va_list args)
 static int
 is_mtp_capable(Camera *camera) {
 	PTPParams *params = &camera->pl->params;
-	if (params->deviceinfo.VendorExtensionID == PTP_VENDOR_MICROSOFT)
+	switch (params->deviceinfo.VendorExtensionID)
+	{
+	case PTP_VENDOR_CANON:
+	case PTP_VENDOR_MICROSOFT:
 		return 1;
+	default: break;
+	}
+
 	/* these are also lowercase. */
 	if (params->deviceinfo.Manufacturer && !strcmp(params->deviceinfo.Manufacturer,"motorola"))
 		return 1;

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -8508,7 +8508,7 @@ mtp_get_playlist_string(
 		contentlen += len+1;
 	}
 	if (!content)
-		C_MEM (content = malloc(1));
+		C_MEM (content = calloc(1, 1));
 	if (xcontent)
 		*xcontent = content;
 	else

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -7349,7 +7349,7 @@ handleregular:
 
 		CR (add_object_to_fs_and_path (camera, event.Param1, path, context));
 
-		C_PTP_REP (ptp_object_want (params, event.Param1, PTPOBJECT_OBJECTINFO_LOADED, &ob));
+		C_PTP (ptp_find_object_in_cache (params, event.Param1, &ob));
 
 		if (ob->oi.ObjectFormat == PTP_OFC_Association) { /* new folder! */
 			*eventtype = GP_EVENT_FOLDER_ADDED;
@@ -7402,7 +7402,7 @@ handleregular:
 		uint32_t	oldstorage, oldparent;
 		char		*oldfn;
 
-		C_PTP_REP (ptp_object_want (params, event.Param1, 0, &ob));
+		C_PTP (ptp_find_object_in_cache (params, event.Param1, &ob));
 		/* objectinfo might not even be loaded yet, but this could be 0 / NULL ... but the compare will trigger */
 		oldparent = ob->oi.ParentObject;
 		oldstorage = ob->oi.StorageID;
@@ -7415,7 +7415,7 @@ handleregular:
 
 		CR (add_object_to_fs_and_path (camera, event.Param1, path, context));
 
-		C_PTP_REP (ptp_object_want (params, event.Param1, PTPOBJECT_OBJECTINFO_LOADED, &ob));
+		C_PTP (ptp_find_object_in_cache (params, event.Param1, &ob));
 
 		/* did the location or name of the file changed in the filesystem? Then we can only reset the fs and refetch the layout */
 		if (	(oldparent != ob->oi.ParentObject) &&

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -6756,7 +6756,7 @@ camera_wait_for_event (Camera *camera, int timeout,
 					ptp_free_eos_event(&eos_event);
 					PTPObject	*ob;
 					if (	(eos_event.type == PTP_EOSEvent_ObjectInfoChanged) &&
-						(PTP_RC_OK != ptp_object_find (params, eos_event.u.object.Handle, &ob))
+						(PTP_RC_OK != ptp_find_object_in_cache (params, eos_event.u.object.Handle, &ob))
 					) {
 						GP_LOG_D ("not found in cache, assuming deleted already.");
 						break;
@@ -6937,7 +6937,7 @@ camera_wait_for_event (Camera *camera, int timeout,
 					/* if we have the object already loaded, no need to add it here */
 					/* but in dual mode capture at empty startup we can
 					 * encounter that the second image is not loaded */
-					if (PTP_RC_OK == ptp_object_find(params, event.Param1, &ob))
+					if (PTP_RC_OK == ptp_find_object_in_cache(params, event.Param1, &ob))
 						continue;
 #endif
 					ret = ptp_object_want (params, event.Param1, PTPOBJECT_OBJECTINFO_LOADED, &ob);
@@ -7193,7 +7193,7 @@ sonyout:
 
 				if (params->inliveview == 1 && *phandle == 0x80000001) /* Ignore preview image object handle while liveview is active */
 					continue;
-				if (PTP_RC_OK == ptp_object_find (params, *phandle, &ob)) /* already have it */
+				if (PTP_RC_OK == ptp_find_object_in_cache (params, *phandle, &ob)) /* already have it */
 					continue;
 				/* might be a just deleted entry , seen in https://github.com/gphoto/gphoto2/issues/456 */
 				memset (&oi,0,sizeof(oi));

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -8006,6 +8006,7 @@ find_child (PTPParams *params, const char *path, uint32_t storage, uint32_t hand
 static uint32_t
 folder_to_handle(PTPParams *params, const char *folder, uint32_t storage, uint32_t parent, PTPObject **retob)
 {
+	GP_LOG_D("(folder='%s', storage=0x%08x, parent=0x%08x)", folder, storage, parent);
 	if (retob) *retob = NULL;
 	if (!strlen(folder) || !strcmp(folder, "/")) {
 		/* was initially read, no need to reread */
@@ -8016,17 +8017,17 @@ folder_to_handle(PTPParams *params, const char *folder, uint32_t storage, uint32
 	if (folder[0] == '/')
 		folder++;
 
-	parent = find_child (params, folder, storage, parent, retob);
-	if (parent == PTP_HANDLER_SPECIAL) {
+	uint32_t child = find_child (params, folder, storage, parent, retob);
+	if (child == PTP_HANDLER_SPECIAL) {
 		GP_LOG_D("could not find (sub-)path '%s' below storage=%08x / handle=%08x", folder, storage, parent);
-		return parent;
+		return child;
 	}
 
-	const char *slash = strchr(folder, '/');
-	if (slash && slash[1] != 0)
-		return folder_to_handle(params, slash + 1, storage, parent, retob);
+	folder = strchr(folder, '/');
+	if (folder && folder[1] != 0)
+		return folder_to_handle(params, folder + 1, storage, child, retob);
 	else
-		return parent;
+		return child;
 }
 
 static int

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -9190,11 +9190,6 @@ delete_file_func (CameraFilesystem *fs, const char *folder,
 		while (ptp_get_one_event (params, &event)) {
 			if (event.Code == PTP_EC_ObjectRemoved)
 				break;
-			if (event.Code == PTP_EC_ObjectAdded) {
-				PTPObject *ob;
-
-				ptp_object_want (params, event.Param1, 0, &ob);
-			}
 		}
 		/* FIXME: need to handle folder additions during capture-image-and-download */
 	}

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -9312,7 +9312,7 @@ ptp_find_object_prop_in_cache(PTPParams *params, uint32_t const handle, uint32_t
 	PTPObject	*ob;
 	uint16_t	ret;
 
-	ret = ptp_object_find (params, handle, &ob);
+	ret = ptp_find_object_in_cache (params, handle, &ob);
 	if (ret != PTP_RC_OK)
 		return NULL;
 	for_each (MTPObjectProp*, prop, ob->mtp_props)
@@ -9327,8 +9327,7 @@ ptp_remove_object_from_cache(PTPParams *params, uint32_t handle)
 {
 	PTPObject	*ob;
 
-	CHECK_PTP_RC(ptp_object_find (params, handle, &ob));
-	/* remove object from object info cache */
+	CHECK_PTP_RC(ptp_find_object_in_cache (params, handle, &ob));
 	ptp_free_object (ob);
 	array_remove(&params->objects, ob);
 
@@ -9356,7 +9355,7 @@ ptp_objects_sort (PTPParams *params)
 
 /* Binary search in objects. Needs "objects" to be a sorted by oid!  */
 uint16_t
-ptp_object_find (PTPParams *params, uint32_t handle, PTPObject **retob)
+ptp_find_object_in_cache (PTPParams *params, uint32_t handle, PTPObject **retob)
 {
 	PTPObject	tmpob;
 
@@ -9369,7 +9368,7 @@ ptp_object_find (PTPParams *params, uint32_t handle, PTPObject **retob)
 
 /* Binary search in objects + insert if not found. Needs "objects" to be a sorted by oid!  */
 uint16_t
-ptp_object_find_or_insert (PTPParams *params, uint32_t handle, PTPObject **retob)
+ptp_find_or_insert_object_in_cache (PTPParams *params, uint32_t handle, PTPObject **retob)
 {
 	unsigned int 	begin, end, cursor;
 	unsigned int	insertat;
@@ -9442,7 +9441,7 @@ ptp_object_want (PTPParams *params, uint32_t handle, unsigned int want, PTPObjec
 		ptp_debug (params, "ptp_object_want: querying handle 0?\n");
 		return PTP_RC_GeneralError;
 	}
-	CHECK_PTP_RC(ptp_object_find_or_insert (params, handle, &ob));
+	CHECK_PTP_RC(ptp_find_or_insert_object_in_cache (params, handle, &ob));
 	*retob = ob;
 	/* Do we have all of it already? */
 	if ((ob->flags & want) == want)
@@ -9495,7 +9494,7 @@ ptp_object_want (PTPParams *params, uint32_t handle, unsigned int want, PTPObjec
 		if (ob->oi.ParentObject == ob->oi.StorageID) {
 			PTPObject *parentob;
 
-			if (ptp_object_find (params, ob->oi.ParentObject, &parentob) != PTP_RC_OK) {
+			if (ptp_find_object_in_cache (params, ob->oi.ParentObject, &parentob) != PTP_RC_OK) {
 				ptp_debug (params, "parent %08x of %s has same id as storage id. and no object found ... rewriting to 0.", ob->oi.ParentObject, ob->oi.Filename);
 				ob->oi.ParentObject = 0;
 			}

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -858,12 +858,11 @@ parse_9301_prop_tree (PTPParams *params, xmlNodePtr node, PTPDeviceInfo *di)
 
 		/* add to cache of device propdesc */
 		PTPDevicePropDesc* dpd_in_cache = ptp_find_dpd_in_cache(params, p);
-		if (!dpd_in_cache) {
-			array_push_back(&params->dpd_cache, dpd);
-		} else {
+		if (!dpd_in_cache)
+			array_push_back_empty(&params->dpd_cache, &dpd_in_cache);
+		else
 			ptp_free_devicepropdesc (dpd_in_cache);
-			move(*dpd_in_cache, dpd);
-		}
+		move(*dpd_in_cache, dpd);
 
 		next = xmlNextElementSibling (next);
 	}
@@ -4431,12 +4430,11 @@ _ptp_sony_getalldevicepropdesc (PTPParams* params, uint16_t opcode)
 			}
 		}
 
-		if (!dpd_in_cache) {
-			array_push_back(&params->dpd_cache, dpd);
-		} else {
+		if (!dpd_in_cache)
+			array_push_back_empty(&params->dpd_cache, &dpd_in_cache);
+		else
 			ptp_free_devicepropdesc (dpd_in_cache);
-			move(*dpd_in_cache, dpd);
-		}
+		move(*dpd_in_cache, dpd);
 #if 0
 		ptp_debug (params, "dpd.DevicePropCode %04x, readlen %d, getset %d", dpd.DevicePropCode, readlen, dpd.GetSet);
 		switch (dpd.DataType) {

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -4911,8 +4911,8 @@ uint16_t ptp_remove_object_from_cache(PTPParams *params, uint32_t handle);
 uint16_t ptp_add_object_to_cache(PTPParams *params, uint32_t handle);
 uint16_t ptp_object_want (PTPParams *, uint32_t handle, unsigned int want, PTPObject**retob);
 void ptp_objects_sort (PTPParams *);
-uint16_t ptp_object_find (PTPParams *params, uint32_t handle, PTPObject **retob);
-uint16_t ptp_object_find_or_insert (PTPParams *params, uint32_t handle, PTPObject **retob);
+uint16_t ptp_find_object_in_cache (PTPParams *params, uint32_t handle, PTPObject **retob);
+uint16_t ptp_find_or_insert_object_in_cache (PTPParams *params, uint32_t handle, PTPObject **retob);
 uint16_t ptp_list_folder (PTPParams *params, uint32_t storage, uint32_t handle);
 
 PTPDevicePropDesc* ptp_find_dpd_in_cache(PTPParams *params, uint32_t dpc);

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -4913,7 +4913,7 @@ uint16_t ptp_object_want (PTPParams *, uint32_t handle, unsigned int want, PTPOb
 void ptp_objects_sort (PTPParams *);
 uint16_t ptp_find_object_in_cache (PTPParams *params, uint32_t handle, PTPObject **retob);
 uint16_t ptp_find_or_insert_object_in_cache (PTPParams *params, uint32_t handle, PTPObject **retob);
-uint16_t ptp_list_folder (PTPParams *params, uint32_t storage, uint32_t handle);
+uint16_t ptp_list_folder (PTPParams *params, uint32_t storage, uint32_t handle, PTPObjectHandles *children);
 
 PTPDevicePropDesc* ptp_find_dpd_in_cache(PTPParams *params, uint32_t dpc);
 

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -4901,9 +4901,12 @@ ptp_render_property_value(PTPParams* params, uint16_t dpc,
 				PTPDevicePropDesc *dpd, unsigned int length, char *out);
 int ptp_render_ofc(PTPParams* params, uint16_t ofc, int spaceleft, char *txt);
 int ptp_render_mtp_propname(uint16_t propid, int spaceleft, char *txt);
-MTPObjectProp *ptp_get_new_object_prop_entry(MTPObjectProp **props, int *nrofprops);
 void ptp_free_object_prop(MTPObjectProp *prop);
+#if 0
+MTPObjectProp *ptp_get_new_object_prop_entry(MTPObjectProp **props, int *nrofprops);
 MTPObjectProp *ptp_find_object_prop_in_cache(PTPParams *params, uint32_t const handle, uint32_t const attribute_id);
+#endif
+
 uint16_t ptp_remove_object_from_cache(PTPParams *params, uint32_t handle);
 uint16_t ptp_add_object_to_cache(PTPParams *params, uint32_t handle);
 uint16_t ptp_object_want (PTPParams *, uint32_t handle, unsigned int want, PTPObject**retob);

--- a/libgphoto2/gphoto2-filesys.c
+++ b/libgphoto2/gphoto2-filesys.c
@@ -747,11 +747,10 @@ gp_filesystem_append (CameraFilesystem *fs, const char *folder,
 		CameraList	*xlist;
 		int ret;
 
-		ret = gp_list_new (&xlist);
-		if (ret != GP_OK) return ret;
+		CR (gp_list_new (&xlist));
 		ret = gp_filesystem_list_files (fs, folder, xlist, context);
 		gp_list_free (xlist);
-		if (ret != GP_OK) return ret;
+		CR (ret);
 	}
 	ret = internal_append (fs, f, filename, context);
 	if (ret == GP_ERROR_FILE_EXISTS) /* not an error here ... just in case we add files twice to the list */
@@ -1752,9 +1751,6 @@ gp_filesystem_read_file (CameraFilesystem *fs, const char *folder,
 			GPContext *context)
 {
 	int r;
-	const char	*xdata;
-	unsigned long	xsize;
-	CameraFile	*file;
 
 	C_PARAMS (fs && folder && filename && buf && size);
 	CC (context);
@@ -1769,7 +1765,13 @@ gp_filesystem_read_file (CameraFilesystem *fs, const char *folder,
 		return GP_ERROR_NOT_SUPPORTED;
 	}
 	return r;
+
+#if 0
 	/* fallback code */
+	const char	*xdata;
+	unsigned long	xsize;
+	CameraFile	*file;
+
 	CR (gp_file_new (&file));
 	CR (gp_filesystem_get_file (fs, folder, filename, type,
 				    file, context));
@@ -1790,6 +1792,7 @@ gp_filesystem_read_file (CameraFilesystem *fs, const char *folder,
 	memcpy (buf, xdata+offset, *size);
 	gp_file_unref (file);
 	return GP_OK;
+#endif
 }
 /**
  * \brief Set all filesystem related function pointers

--- a/libgphoto2/gphoto2-filesys.c
+++ b/libgphoto2/gphoto2-filesys.c
@@ -966,7 +966,6 @@ gp_filesystem_list_files (CameraFilesystem *fs, const char *folder,
 		CR (count = gp_list_count (list));
 		for (y = 0; y < count; y++) {
 			CR (gp_list_get_name (list, y, &name));
-			GP_LOG_D ("Added '%s'", name);
 			CR (internal_append (fs, f, name, context));
 		}
 		gp_list_reset (list);
@@ -976,8 +975,7 @@ gp_filesystem_list_files (CameraFilesystem *fs, const char *folder,
 
 	file = f->files;
 	while (file) {
-		GP_LOG_D (
-			"Listed '%s'", file->name);
+		/* GP_LOG_D ("Listed '%s'", file->name); */
 		CR (gp_list_append (list, file->name, NULL));
 		file = file->next;
 	}


### PR DESCRIPTION
This is a set of patches mainly working on the reduction of the use of `ptp_object_want()` and especially eliminating it from inside loops over the object cache, which can cause 'problems', since the function may modify said object cache.

This should fix the issue discussed [here](https://github.com/gphoto/libgphoto2/pull/1040#issuecomment-2419429446) for good.