### PR TITLE
Fix silent doxygen rule

### DIFF
--- a/camlibs/Makefile.am
+++ b/camlibs/Makefile.am
@@ -197,7 +197,7 @@ all-mkf-camlibs: Makefile
 
 .PHONY: all-local
 all-local: all-cfg-camlibs all-mkf-camlibs
-	@if $(CMP) all-cfg-camlibs all-mkf-camlibs > /dev/null 2>&1; then :; else \
+	@if ! $(CMP) all-cfg-camlibs all-mkf-camlibs > /dev/null 2>&1; then \
 		echo "#"; \
 		for camlib in $$($(COMM) -23 all-cfg-camlibs all-mkf-camlibs); do \
 			echo "#   - '$${camlib}' camlib in 'configure.ac', but not in Makefiles."; \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -23,10 +23,19 @@ LOCAL_CLEAN =
 
 
 # FIXME: Depend on source files.
-DOXYGEN_STAMPS += $(HTML_APIDOC_DIR).stamp
-$(HTML_APIDOC_DIR).stamp: Doxyfile
-	$(AM_V_GEN)doxygen Doxyfile
-	@: > $@
+DOXYGEN_STAMPS += $(HTML_APIDOC_DIR).log
+$(HTML_APIDOC_DIR).log: Doxyfile
+	@if $(AM_V_P); then \
+	  echo "doxygen $<"; \
+	  doxygen $<; \
+	else \
+	  printf "  %-8s %s\n" DOXYGEN "$<"; \
+	  if ! doxygen $< > $@ 2>&1; then \
+	    cat $@; \
+	    rm -f $@; \
+	    exit 1; \
+	  fi; \
+	fi
 
 $(HTML_APIDOC_DIR).tar.gz: $(HTML_APIDOC_DIR).stamp
 	(cd $(DOXYGEN_OUTPUT_DIR) && $(AMTAR) chof - $(HTML_APIDOC_DIR) | GZIP=--best gzip -c) > $@

--- a/libgphoto2_port/gphoto-m4/gp-set.m4
+++ b/libgphoto2_port/gphoto-m4/gp-set.m4
@@ -150,7 +150,7 @@ AC_DEFUN_ONCE([_GP_SET_CHECK_INIT], [dnl
 AC_REQUIRE([_GP_SET_INIT])dnl
 gp_set_shfn_check ()
 {
-  if test -f "[$]1"; then :; else
+  if ! test -f "[$]1"; then
     AC_MSG_ERROR(["Error: set [$]1 has not been defined yet"])
   fi
 } # gp_set_shfn_check


### PR DESCRIPTION
Replace the use of doxygen `-q` argument by redirecting stdout and stderr to make silent rule builds work with doxygen older than release 1.9.2 which added `-q`.
