### PR TITLE
In `gp_file_set_data_and_size` free `file->data` only if allocated

### DIFF
--- a/libgphoto2/gphoto2-file.c
+++ b/libgphoto2/gphoto2-file.c
@@ -320,7 +320,7 @@ gp_file_set_data_and_size (CameraFile *file, char *data,
 
 	switch (file->accesstype) {
 	case GP_FILE_ACCESSTYPE_MEMORY:
-		free (file->data);
+		if (file->data) free (file->data);
 		file->data = (unsigned char*)data;
 		file->size = size;
 		break;


### PR DESCRIPTION
I've stumbled upon (what I think is) a bug, where I cannot use `gp_file_set_data_and_size` for newly created instances because of: `pointer being freed was not allocated`