### PR TITLE
In `gp_file_clean` free `file->data` only if allocated

### DIFF
--- a/libgphoto2/gphoto2-file.c
+++ b/libgphoto2/gphoto2-file.c
@@ -715,7 +715,7 @@ gp_file_clean (CameraFile *file)
 
 	switch (file->accesstype) {
 	case GP_FILE_ACCESSTYPE_MEMORY:
-		free (file->data);
+		if (file->data) free (file->data);
 		file->data = NULL;
 		file->size = 0;
 		break;


### PR DESCRIPTION
Same as #1054, just for `gp_file_clean`