### PR TITLE
updated for XT1, latest firmware 5.52, BULB with external shutter

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -515,6 +515,7 @@ camera_prepare_capture (Camera *camera, GPContext *context)
 
 		if (have_prop(camera, params->deviceinfo.VendorExtensionID, PTP_DPC_FUJI_PriorityMode)) {
 			propval.u16 = 0x0002;
+			//the line below causes camera to move from BULB to 30s, afterwards becomes unusable 
 			LOG_ON_PTP_E (ptp_setdevicepropvalue (params, PTP_DPC_FUJI_PriorityMode, &propval, PTP_DTC_UINT16));
 		}
 
@@ -1455,15 +1456,19 @@ static struct deviceproptableu16 whitebalance[] = {
 	{ N_("Fluorescent Lamp 1"),	0x8001, PTP_VENDOR_FUJI },
 	{ N_("Fluorescent Lamp 2"),	0x8002, PTP_VENDOR_FUJI },
 	{ N_("Fluorescent Lamp 3"),	0x8003, PTP_VENDOR_FUJI },
-	{ N_("Fluorescent Lamp 4"),	0x8004, PTP_VENDOR_FUJI },
-	{ N_("Fluorescent Lamp 5"),	0x8005, PTP_VENDOR_FUJI },
+//	{ N_("Fluorescent Lamp 4"),	0x8004, PTP_VENDOR_FUJI },
+//	{ N_("Fluorescent Lamp 5"),	0x8005, PTP_VENDOR_FUJI },
+	{ N_("Daylight"),	0x4, PTP_VENDOR_FUJI },
+	{ N_("Incandescent"),	0x6, PTP_VENDOR_FUJI },
 	{ N_("Shade"),			0x8006, PTP_VENDOR_FUJI },
 	{ N_("Choose Color Temperature"),0x8007, PTP_VENDOR_FUJI },
 	{ N_("Preset Custom 1"),	0x8008, PTP_VENDOR_FUJI },
 	{ N_("Preset Custom 2"),	0x8009, PTP_VENDOR_FUJI },
 	{ N_("Preset Custom 3"),	0x800a, PTP_VENDOR_FUJI },
-	{ N_("Preset Custom 4"),	0x800b, PTP_VENDOR_FUJI },
-	{ N_("Preset Custom 5"),	0x800c, PTP_VENDOR_FUJI },
+//	{ N_("Preset Custom 4"),	0x800b, PTP_VENDOR_FUJI },
+//	{ N_("Preset Custom 5"),	0x800c, PTP_VENDOR_FUJI },
+	{ N_("Underwater"),	0x8, PTP_VENDOR_FUJI },
+	{ N_("Auto"),	0x2, PTP_VENDOR_FUJI },
 
 	{ N_("Shade"),			0x8011, PTP_VENDOR_SONY },
 	{ N_("Cloudy"),			0x8010, PTP_VENDOR_SONY },
@@ -3087,10 +3092,12 @@ _put_Olympus_OMD_Bulb(CONFIG_PUT_ARGS)
 
 static struct deviceproptableu16 fuji_action[] = {
 	{ N_("Shoot"),			0x0304, 0 },
-	{ N_("Bulb On"),		0x0500, 0 },
-	{ N_("Bulb Off"),		0x000c, 0 },
+//	{ N_("Bulb On"),		0x0500, 0 },
+//	{ N_("Bulb Off"),		0x000c, 0 },
 	{ N_("AF"),			0x0200, 0 },
 	{ N_("Cancel AF"),		0x0004, 0 },
+	{ N_("Unknown"),		0x0104, 0 },
+
 /* D208 is some kind of control, likely bitmasked. reported like an enum.
  * 0x200 seems to mean focusing?
  * 0x208 capture?
@@ -6116,7 +6123,7 @@ static struct deviceproptablei16 fuji_shutterspeed[] = {
 GENERICI16TABLE(Fuji_ShutterSpeed,fuji_shutterspeed)
 
 static struct deviceproptableu32 fuji_new_shutterspeed[] = {
-	{ N_("bulb"),	0xffffffff, 0 },
+//	{ N_("bulb"),	0xffffffff, 0 },
 	{ "60m",	64000180, 0 },
 	{ "30m",	64000150, 0 },
 	{ "15m",	64000120, 0 },

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -9756,7 +9756,8 @@ camera_init (Camera *camera, GPContext *context)
 		break;
 	/* case PTP_VENDOR_SONY: setup already done in fixup_cached_deviceinfo */
 	case PTP_VENDOR_FUJI:
-		CR (camera_prepare_capture (camera, context));
+		//the line below causes camera to move from BULB to 30s, afterwards becomes unusable 
+		//CR (camera_prepare_capture (camera, context));
 		break;
 	case PTP_VENDOR_GP_SIGMAFP:
 		if (ptp_operation_issupported(params, 0x9035)) {


### PR DESCRIPTION
updated constants to reflect 5.52 xt1 firmware:
```
Exposure Time             (500d rw u32): Enumeration [244,307,387,488,615,775,976,1230,1550,1953,2460,3100,3906,4921,5524,6200,7812,9843,12401,15625,19686,24803,31250,39372,49606,62500,78745,99212,125000,157490,198425,250000,314980,396850,500000,629960,793700,1000000,1259921,1414213,2000000,2519842,3174802,4000000,5039684,6349604,8000000,10079368,12699208,16000000,20158736,25398416,32000000] value: 3.2e+02 sec (32000000)
White Balance             (5005 rw u16): Enumeration [2,4,6,8,32769,32770,32771,32774,32775,32776,32777,32778] value: Automatic (2)
[Unknown Property](fuji action?)        (d208 rw u16): Enumeration [260,512,4,772] value: 772
```
`camera_prepare_capture` in XT1 is breaking BULB exposition with external shutter, commented out