### PR TITLE
Sony A7 II&III: Live preview and capture then camera freezes

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -4994,9 +4994,13 @@ camera_sony_capture (Camera *camera, CameraCaptureType type, CameraFilePath *pat
 		if (ptp_get_one_event(params, &event)) {
 			GP_LOG_D ("during wait for image event.code=%04x Param1=%08x", event.Code, event.Param1);
 			if (event.Code == PTP_EC_Sony_ObjectAdded) {
-				newobject = event.Param1;
-				GP_LOG_D ("SONY ObjectAdded received, ending wait");
-				break;
+				if (params->deviceinfo.Model && !strncmp(params->deviceinfo.Model, "ILCE-7", 6)) {
+					GP_LOG_D ("SONY ObjectAdded received, waiting for poll flag");
+				} else {
+					newobject = event.Param1;
+					GP_LOG_D ("SONY ObjectAdded received, ending wait");
+					break;
+				}
 			}
 		}
 #endif


### PR DESCRIPTION
The bug is at least since 2.5.30 and persists in 2.5.31/head for Sony A7 III (and likely II AFAIR). Issue appears when Live preview is used together with capture image. The first capture passes but next one causes camera freeze/reboot. Bug is in event order evaluation which libgphoto is not familiar with. Note that surprisingly Sony A7 rIV which does not work with 2.5.30 (because of another issue fixed in main branch), does work without this patch in head. So event issue is likely only for III&II models.

Related issue was reported in https://github.com/gphoto/libgphoto2/issues/981