### PR TITLE
Add image stabilization / SteadyShot setting for Sony cameras.

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -7288,10 +7288,16 @@ static struct deviceproptableu8 sony_sensorcrop[] = {
 GENERIC8TABLE(Sony_SensorCrop,sony_sensorcrop)
 
 static struct deviceproptableu8 sony_liveviewsettingeffect[] = {
-		{ N_("On"),  0x01, 0 },
-		{ N_("Off"), 0x02, 0 },
+	{ N_("On"),	0x01, 0 },
+	{ N_("Off"),	0x02, 0 },
 };
 GENERIC8TABLE(Sony_LiveViewSettingEffect,sony_liveviewsettingeffect)
+
+static struct deviceproptableu8 sony_image_stabilization[] = {
+	{ N_("Off"),	0x01, 0 },
+	{ N_("On"),	0x02, 0 },
+};
+GENERIC8TABLE(Sony_ImageStabilization,sony_image_stabilization)
 
 /* Sony specific, we need to wait for it settle (around 1 second), otherwise we get trouble later on */
 static int
@@ -11660,6 +11666,7 @@ static struct submenu capture_settings_menu[] = {
 	{ N_("HDMI Output Data Depth"),         "hdmioutputdatadepth",      PTP_DPC_NIKON_HDMIOutputDataDepth,      PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_HDMIDataDepth,           _put_Nikon_HDMIDataDepth },
 	{ N_("Face Detection"),                 "facedetection",            PTP_DPC_NIKON_FaceDetection,            PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_FaceDetection,           _put_Nikon_FaceDetection },
 	{ N_("Movie Servo AF"),                 "movieservoaf",             PTP_DPC_CANON_EOS_MovieServoAF,         PTP_VENDOR_CANON,   PTP_DTC_UINT32, _get_Canon_EOS_MovieServoAF,        _put_Canon_EOS_MovieServoAF },
+	{ N_("Image Stabilization"),            "imagestabilization",       PTP_DPC_SONY_ImageStabilization,        PTP_VENDOR_SONY,    PTP_DTC_UINT8,  _get_Sony_ImageStabilization,       _put_Sony_ImageStabilization },
 
 	{ 0,0,0,0,0,0,0 },
 };

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -7382,8 +7382,9 @@ ptp_get_property_description(PTPParams* params, uint32_t dpc)
 		const char *txt;
 	} ptp_device_properties_SONY[] = {
 		{PTP_DPC_WhiteBalance, N_("White Balance")},		/* 0x5005 */
-		{PTP_DPC_SONY_DPCCompensation, ("DOC Compensation")},	/* 0xD200 */
-		{PTP_DPC_SONY_DRangeOptimize, ("DRangeOptimize")},	/* 0xD201 */
+		{PTP_DPC_SONY_ImageStabilization, N_("Image Stabilization")},/* 0xD0D9 */
+		{PTP_DPC_SONY_DPCCompensation, N_("DOC Compensation")},	/* 0xD200 */
+		{PTP_DPC_SONY_DRangeOptimize, N_("DRangeOptimize")},	/* 0xD201 */
 		{PTP_DPC_SONY_ImageSize, N_("Image size")},		/* 0xD203 */
 		{PTP_DPC_SONY_ShutterSpeed, N_("Shutter speed")},	/* 0xD20D */
 		{PTP_DPC_SONY_ColorTemp, N_("Color temperature")},	/* 0xD20F */

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -3176,6 +3176,7 @@ typedef struct _PTPCanonEOSDeviceInfo {
 #define PTP_DPC_SONY_FocalDistanceUnitSetting		0xD006
 #define PTP_DPC_SONY_FocusModeSetting			0xD007
 
+#define PTP_DPC_SONY_ImageStabilization			0xD0D9
 #define PTP_DPC_SONY_DPCCompensation			0xD200
 #define PTP_DPC_SONY_DRangeOptimize			0xD201
 #define PTP_DPC_SONY_ImageSize				0xD203


### PR DESCRIPTION
Works with protocol 3 enabled cameras.  E.g. A7R5.