### PR TITLE
ptp2: Support `camera_trigger_capture` for Olympus OM-D

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -6532,6 +6532,14 @@ camera_trigger_capture (Camera *camera, GPContext *context)
 		return translate_ptp_result(ptp_panasonic_capture(params));
 	}
 
+	if (	(params->deviceinfo.VendorExtensionID == PTP_VENDOR_GP_OLYMPUS_OMD) &&
+		ptp_operation_issupported(params, PTP_OC_OLYMPUS_OMD_Capture)
+	) {
+		C_PTP_REP(ptp_generic_no_data(params, PTP_OC_OLYMPUS_OMD_Capture, 1, 0x3));
+		C_PTP_REP(ptp_generic_no_data(params, PTP_OC_OLYMPUS_OMD_Capture, 1, 0x6));
+		return GP_OK;
+	}
+
 	if (!ptp_operation_issupported(params,PTP_OC_InitiateCapture)) {
 		gp_context_error(context, _("Sorry, your camera does not support generic capture"));
 		return GP_ERROR_NOT_SUPPORTED;


### PR DESCRIPTION
Previously only `camera_capture` (trigger capture and download) was supported. This simply uses the camera trigger code from that function in `camera_trigger_capture` also.

Tested with a OM-D E-M1.2