### PR TITLE
Allow redirecting `gp_settings_{get,set}` to user defined functions

### DIFF
--- a/gphoto2/gphoto2-setting.h
+++ b/gphoto2/gphoto2-setting.h
@@ -28,6 +28,9 @@
 extern "C" {
 #endif /* __cplusplus */
 
+typedef int(*gp_settings_func)(char*,char*,char*,void*);
+void gp_setting_set_get_func (gp_settings_func func, void *userdata);
+void gp_setting_set_set_func (gp_settings_func func, void *userdata);
 int gp_setting_set (char *id, char *key, char *value);
 int gp_setting_get (char *id, char *key, char *value);
 

--- a/libgphoto2/gphoto2-setting.c
+++ b/libgphoto2/gphoto2-setting.c
@@ -61,6 +61,39 @@ static int save_settings (void);
 
 static int load_settings (void);
 
+static void *get_func_userdata = NULL;
+static void *set_func_userdata = NULL;
+static gp_settings_func custom_get_func = NULL;
+static gp_settings_func custom_set_func = NULL;
+
+/**
+ * \brief Set user defined function to get a gphoto setting.
+ * \param func The function to get the settings
+ * \param userdata userdata passed to func
+ *
+ * This function is expected to behave like gp_settings_get.
+ * To clear set func to NULL.
+ */
+void gp_setting_set_get_func (gp_settings_func func, void *userdata)
+{
+	custom_get_func = func;
+	get_func_userdata = userdata;
+}
+
+/**
+ * \brief Set user defined function to set a gphoto setting.
+ * \param func The function to set the settings
+ * \param userdata userdata passed to func
+ *
+ * This function is expected to behave like gp_settings_set.
+ * To clear set func to NULL.
+ */
+void gp_setting_set_set_func (gp_settings_func func, void *userdata)
+{
+	custom_set_func = func;
+	set_func_userdata = userdata;
+}
+
 /**
  * \brief Retrieve a specific gphoto setting.
  * \param id the frontend id of the caller
@@ -74,6 +107,9 @@ static int load_settings (void);
 int
 gp_setting_get (char *id, char *key, char *value)
 {
+	if (custom_get_func != NULL)
+		return custom_get_func(id, key, value, get_func_userdata);
+
 	int x;
 
 	C_PARAMS (id && key);
@@ -106,6 +142,9 @@ gp_setting_get (char *id, char *key, char *value)
 int
 gp_setting_set (char *id, char *key, char *value)
 {
+	if (custom_set_func != NULL)
+		return custom_set_func(id, key, value, set_func_userdata);
+
 	int x;
 
 	C_PARAMS (id && key);

--- a/libgphoto2/libgphoto2.sym
+++ b/libgphoto2/libgphoto2.sym
@@ -140,6 +140,8 @@ gp_list_sort
 gp_list_unref
 gp_message_codeset
 gp_result_as_string
+gp_setting_set_get_func
+gp_setting_set_set_func
 gp_setting_get
 gp_setting_set
 gp_widget_add_choice


### PR DESCRIPTION
This is useful for applications integrating libgphoto2 which provide their own way of storing user settings.

E.g. in my dayjob I use libgphoto in Qt based applications that use QSettings to store their preferences as storing the settings in the users HOME dir isn't always what we want.
There are cases where one application (and it's settings) are used by multiple user accounts on the same PC and per-user settings would be a problem for PTP/IP pairing as the device GUID is stored in the libgphoto2 settings.

I think merging this would require changing AGE/REVISION/CURRENT, right? I think only AGE needs to be adjusted but I don't quite get how that works