### PR TITLE
Fix some memory leaks

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -7949,6 +7949,7 @@ static uint32_t
 find_child (PTPParams *params, const char *path, uint32_t storage, uint32_t handle, PTPObject **retob)
 {
 	uint16_t ret;
+	uint32_t found_child;
 
 	const char *slash = strchr (path, '/');
 	size_t filename_len = slash ? (size_t)(slash - path) : strlen(path);
@@ -7970,9 +7971,12 @@ find_child (PTPParams *params, const char *path, uint32_t storage, uint32_t hand
 		if (!strncmp (ob->oi.Filename, path, filename_len)) {
 			if (retob)
 				*retob = ob;
-			return *poid;
+			found_child = *poid;
+			free_array (&handles);
+			return found_child;
 		}
 	}
+	free_array (&handles);
 	/* else not found */
 	return PTP_HANDLER_SPECIAL;
 }

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -8083,6 +8083,7 @@ generic_list_func (PTPParams *params, const char *folder, int is_directory, Came
 	}
 
 	GP_LOG_D ("returning list with %d %s entries", gp_list_count(list), is_directory ? "directory" : "file");
+	free_array (&handles);
 
 	return GP_OK;
 }

--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -7256,9 +7256,8 @@ sonyout:
 		}  while (waiting_for_timeout (&back_off_wait, event_start, timeout));
 
 downloadomdfile:
-		C_MEM (path = calloc(1, sizeof(CameraFilePath)));
-
 		if (newobject != 0) {
+			C_MEM (path = calloc(1, sizeof(CameraFilePath)));
 			CR (add_object_to_fs_and_path (camera, newobject, path, context));
 
 			*eventtype = GP_EVENT_FILE_ADDED;

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -2093,6 +2093,7 @@ ptp_getstorageids (PTPParams* params, PTPStorageIDs* storageids)
 		if ((*psid & 0xffff) != 0) // filter out invalid storageIDs once instead of everywhere
 			array_push_back(storageids, *psid);
 
+	free_array (&all_ids);
 	return PTP_RC_OK;
 }
 


### PR DESCRIPTION
While working on things (in this case trigger capture support for Olympus OM-D) I usually run my tests with asan/ubsan enabled.
After I figured out how to get them to play nicely with `libtool`s dynamic loading/unloading (by building with `-DVALGRIND` so no unloading happens at the end) I finally managed to track down some memory leaks that I've seen quite a few times previously but didn't know where they happened apart from "inside libgphoto2".