### PR TITLE
Add color temperature, WB adjust for Olympus OMD

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -6290,6 +6290,7 @@ static struct deviceproptableu16 focusmodes[] = {
 	{ N_("Single-Servo AF"),0x8001, PTP_VENDOR_FUJI },
 	{ N_("Continuous-Servo AF"),0x8002, PTP_VENDOR_FUJI },
 
+	{ N_("Preset MF"),	0x8004, PTP_VENDOR_GP_OLYMPUS_OMD },
 	{ N_("C-AF"),		0x8002, PTP_VENDOR_GP_OLYMPUS_OMD },
 	{ N_("S-AF+MF"),	0x8001, PTP_VENDOR_GP_OLYMPUS_OMD },
 
@@ -11412,10 +11413,13 @@ static struct submenu image_settings_menu[] = {
 	{ N_("Color Temperature"),      "colortemperature",     PTP_DPC_CANON_EOS_ColorTemperature,     PTP_VENDOR_CANON,   PTP_DTC_UINT32, _get_INT,                       _put_INT },
 	{ N_("Color Temperature"),      "colortemperature",     PTP_DPC_FUJI_ColorTemperature,          PTP_VENDOR_FUJI,    PTP_DTC_UINT16, _get_INT,                       _put_INT },
 	{ N_("Color Temperature"),      "colortemperature",     PTP_DPC_SONY_ColorTemp,                 PTP_VENDOR_SONY,    PTP_DTC_UINT16, _get_INT,                       _put_INT },
+	{ N_("Color Temperature"),      "colortemperature",     PTP_DPC_OLYMPUS_ColorTemperature,       PTP_VENDOR_GP_OLYMPUS_OMD,    PTP_DTC_UINT16, _get_INT,             _put_INT },
 	{ N_("WhiteBalance"),           "whitebalance",         PTP_DPC_WhiteBalance,                   0,                  PTP_DTC_UINT16, _get_WhiteBalance,              _put_WhiteBalance },
 	{ N_("WhiteBalance"),           "whitebalance",         PTP_DPC_NIKON_1_WhiteBalance,           PTP_VENDOR_NIKON,   PTP_DTC_UINT8,  _get_Nikon_1_WhiteBalance,      _put_Nikon_1_WhiteBalance },
 	{ N_("WhiteBalance Adjust A"),  "whitebalanceadjusta",  PTP_DPC_CANON_EOS_WhiteBalanceAdjustA,  PTP_VENDOR_CANON,   PTP_DTC_INT32,  _get_Canon_EOS_WBAdjust,        _put_Canon_EOS_WBAdjust },
 	{ N_("WhiteBalance Adjust B"),  "whitebalanceadjustb",  PTP_DPC_CANON_EOS_WhiteBalanceAdjustB,  PTP_VENDOR_CANON,   PTP_DTC_INT32,  _get_Canon_EOS_WBAdjust,        _put_Canon_EOS_WBAdjust },
+	{ N_("WhiteBalance Adjust A"),  "whitebalanceadjusta",  PTP_DPC_OLYMPUS_WhiteBalanceAdjustA,    PTP_VENDOR_GP_OLYMPUS_OMD,   PTP_DTC_UINT16,  _get_INT,             _put_INT },
+	{ N_("WhiteBalance Adjust B"),  "whitebalanceadjustb",  PTP_DPC_OLYMPUS_WhiteBalanceAdjustB,    PTP_VENDOR_GP_OLYMPUS_OMD,   PTP_DTC_UINT16,  _get_INT,             _put_INT },
 	{ N_("WhiteBalance X A"),       "whitebalancexa",       PTP_DPC_CANON_EOS_WhiteBalanceXA,       PTP_VENDOR_CANON,   PTP_DTC_UINT32, _get_INT,                       _put_None },
 	{ N_("WhiteBalance X B"),       "whitebalancexb",       PTP_DPC_CANON_EOS_WhiteBalanceXB,       PTP_VENDOR_CANON,   PTP_DTC_UINT32, _get_INT,                       _put_None },
 	{ N_("Photo Effect"),           "photoeffect",          PTP_DPC_CANON_PhotoEffect,              PTP_VENDOR_CANON,   PTP_DTC_UINT16, _get_Canon_PhotoEffect,         _put_Canon_PhotoEffect },

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -3080,8 +3080,12 @@ typedef struct _PTPCanonEOSDeviceInfo {
 #define PTP_DPC_OLYMPUS_AspectRatio			0xD01B
 #define PTP_DPC_OLYMPUS_Shutterspeed			0xD01C
 #define PTP_DPC_OLYMPUS_WhiteBalance			0xD01E
+#define PTP_DPC_OLYMPUS_AFArea				0xD051
 #define PTP_DPC_OLYMPUS_LiveViewModeOM			0xD06D
 #define PTP_DPC_OLYMPUS_CaptureTarget			0xD0DC
+#define PTP_DPC_OLYMPUS_ColorTemperature		0xD00E
+#define PTP_DPC_OLYMPUS_WhiteBalanceAdjustA		0xD161
+#define PTP_DPC_OLYMPUS_WhiteBalanceAdjustB		0xD162
 
 /* unsure where these were from */
 #define PTP_DPC_OLYMPUS_ResolutionMode			0xD102


### PR DESCRIPTION
I added names/defines for a few of the unnamed settings of an OM-D E-M1 Mark 2.

There is still an issue with the WB adjust though: On the camera the range is ±7 however it gets reported as follows:

In my application: 
```
[…]
[RW] [whitebalanceadjusta] WhiteBalance Adjust A (Radio): Choices: ["65529", "65530", "65531", "65532", "65533", "65534", "65535", "0", "1", "2", "3", "4", "5", "6", "7", ] Value: "2"
[RW] [whitebalanceadjustb] WhiteBalance Adjust B (Radio): Choices: ["65529", "65530", "65531", "65532", "65533", "65534", "65535", "0", "1", "2", "3", "4", "5", "6", "7", ] Value: "65534"
[…]
```

In `gphoto2 --summary` (the one from the OS which doesn't have my changes in it):
```
[…]
Property 0xd161:(readwrite) (type=0x4) Enumeration [65529,65530,65531,65532,65533,65534,65535,0,1,2,3,4,5,6,7] value: 2
Property 0xd162:(readwrite) (type=0x4) Enumeration [65529,65530,65531,65532,65533,65534,65535,0,1,2,3,4,5,6,7] value: 65534
[…]
```

I tried setting the property to `PTP_DTC_UINT16` to also get the negative numbers, but that resulted in
`Type of property 'WhiteBalance Adjust A' expected: 0x0003 got: 0x0004`
in the log and the property still looking the same.

What's the best way to handle this? I assume there is a preferred way for this as I don't think this is the first time a quirk like this happens.