### PR TITLE
meson: Add missing version info

### DIFF
--- a/libgphoto2/libgphoto2.sym
+++ b/libgphoto2/libgphoto2.sym
@@ -105,6 +105,7 @@ gp_filesystem_get_file
 gp_filesystem_read_file
 gp_filesystem_get_folder
 gp_filesystem_get_info
+gp_filesystem_get_storageinfo
 gp_filesystem_list_files
 gp_filesystem_list_folders
 gp_filesystem_make_dir

--- a/libgphoto2/meson.build
+++ b/libgphoto2/meson.build
@@ -115,6 +115,22 @@ gphoto2_endian = configure_file(
 
 libgphoto2_private_headers += gphoto2_endian
 
+libgphoto2_link_args = []
+libgphoto2_link_deps = []
+
+if has_version_script
+  libgphoto2_version_script = custom_target(
+    'libgphoto2.ver',
+    output: 'libgphoto2.ver',
+    input: files('sym_to_ver.py', 'libgphoto2.sym'),
+    command: [python, '@INPUT0@', '@INPUT1@', '@OUTPUT@'],
+  )
+  libgphoto2_link_args += ['-Wl,--version-script=@0@'.format(
+    libgphoto2_version_script.full_path()
+  )]
+  libgphoto2_link_deps += [libgphoto2_version_script]
+endif
+
 libgphoto2_lib = library(
   'gphoto2',
   libgphoto2_sources,
@@ -134,7 +150,9 @@ libgphoto2_lib = library(
   ],
   c_args: [
     '-D_GPHOTO2_INTERNAL_CODE',
-  ]
+  ],
+  link_args: libgphoto2_link_args,
+  link_depends: libgphoto2_link_deps,
 )
 
 install_headers(

--- a/libgphoto2/sym_to_ver.py
+++ b/libgphoto2/sym_to_ver.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import sys
+
+input = open(sys.argv[1], 'r')
+output = open(sys.argv[2], 'w')
+
+print('{ global:', file=output)
+for line in input:
+    line = line.strip()
+    print(f'{line};', file=output)
+print('local: *; };', file=output)

--- a/libgphoto2_port/libgphoto2_port/meson.build
+++ b/libgphoto2_port/libgphoto2_port/meson.build
@@ -24,6 +24,17 @@ libgphoto2_port_private_headers = files(
   'compiletime-assert.h',
 )
 
+libgphoto2_port_link_args = []
+libgphoto2_port_link_deps = []
+
+if has_version_script
+  libgphoto2_port_version_script = files('libgphoto2_port.ver')[0]
+  libgphoto2_port_link_args += ['-Wl,--version-script=@0@'.format(
+    libgphoto2_port_version_script.full_path()
+  )]
+  libgphoto2_port_link_deps += [libgphoto2_port_version_script]
+endif
+
 libgphoto2_port_lib = library(
   'gphoto2_port',
   libgphoto2_port_sources,
@@ -40,6 +51,8 @@ libgphoto2_port_lib = library(
     intl_dep,
     config_dep,
   ],
+  link_args: libgphoto2_port_link_args,
+  link_depends: libgphoto2_port_link_deps,
 )
 
 install_headers(

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,8 @@ project('libgphoto2', 'c',
 
 i18n = import('i18n')
 pkg = import('pkgconfig')
+py = import('python')
+python = py.find_installation()
 
 libxml_req         = '>= 2.0'
 libcurl_req        = '>= 7.1'
@@ -151,6 +153,10 @@ add_project_arguments('-DLOCALEDIR="@0@"'.format (get_option('prefix') / get_opt
 if intl_dep.found()
   add_project_arguments('-DENABLE_NLS=1', language: 'c')
 endif
+
+has_version_script = cc.has_link_argument('-Wl,--version-script=@0@'.format(
+  meson.current_source_dir() / 'libgphoto2_port' / 'libgphoto2_port' / 'libgphoto2_port.ver'
+))
 
 libgphoto2_root_inc = include_directories('.')
 


### PR DESCRIPTION
Necessary for compatibility with the autotools+libtool-built libraries.

Also add the missing export of `gp_filesystem_get_storageinfo`.

---

I've tried to replicate what autotools does. I'm not sure the version script for `libgphoto2` is necessary (AFAICT libtool doesn't add any versions), but the one for `libgphoto2_port` is.

In any case, when comparing the products notice I noticed `gp_filesystem_get_storageinfo` was no longer exported, so I added it to `libgphoto2.sym`.