### PR TITLE
Add support for Nikon Z50II camera

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -1782,6 +1782,9 @@ static struct {
 	/* Daniel Baertschi <daniel@avisec.ch> */
 	{"Nikon:Z50",                	  0x04b0, 0x0444, PTP_CAP|PTP_CAP_PREVIEW},
 
+    /* ArvinSpace <yanhui-180@163.com> */
+	{"Nikon:Z50_2",                	  0x04b0, 0x0455, PTP_CAP|PTP_CAP_PREVIEW},
+
 	/* Schreiber, Steve via Gphoto-devel */
 	{"Nikon:DSC D3500",		  0x04b0, 0x0445, PTP_CAP|PTP_CAP_PREVIEW},
 


### PR DESCRIPTION
添加对尼康Z50II的支持
- 已测试相机通过USB连接安卓和IOS系统
- 相机拍照及照片通过USB传输到手机