### PR TITLE
Fix spurious timeouts when reading from serial port

### DIFF
--- a/libgphoto2_port/serial/unix.c
+++ b/libgphoto2_port/serial/unix.c
@@ -523,7 +523,7 @@ gp_port_serial_read (GPPort *dev, char *bytes, int size)
 		timeout.tv_sec = (dev->timeout / 1000);
 
 		/* Any data available? */
-		if (!select (dev->pl->fd + 1, &readfs, NULL, NULL, &timeout))
+		if (dev->pl->cachep == dev->pl->cachee && !select (dev->pl->fd + 1, &readfs, NULL, NULL, &timeout))
 			return GP_ERROR_TIMEOUT;
 		if (!FD_ISSET (dev->pl->fd, &readfs))
 			return (GP_ERROR_TIMEOUT);


### PR DESCRIPTION
Imagine that 2 bytes are waiting to be read from the serial port, and we call `gp_port_serial_read()` with a buffer size of 1 to read one of those bytes. This logic is triggered, so 2 bytes get read from the wire:

https://github.com/gphoto/libgphoto2/blob/c908ed8871cf4a8ff6dc9a6757081f46785f3b88/libgphoto2_port/serial/unix.c#L574

After the call, 1 byte is delivered to the caller, and 1 byte remains in the cache.

Now we issue another 1 byte read. But since no bytes remain on the wire to be read, this call to `select()` blocks until the timeout expires, and we erroneously return `GP_ERROR_TIMEOUT` instead of delivering the remaining byte from the cache:

https://github.com/gphoto/libgphoto2/blob/c908ed8871cf4a8ff6dc9a6757081f46785f3b88/libgphoto2_port/serial/unix.c#L526

This patch fixes this so that a timeout is not issued if there are still bytes remaining in the cache to be read.