### PR TITLE
ptp2/lib: Fix unchecked return value in delete_file_func

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -9140,8 +9140,7 @@ delete_file_func (CameraFilesystem *fs, const char *folder,
 	CR (find_storage_and_handle_from_path(params, folder, &storage, &handle));
 	handle = find_child(params, filename, storage, handle, NULL);
 
-	/* in some cases we return errors ... just ignore them for now */
-	LOG_ON_PTP_E (ptp_deleteobject(params, handle, 0));
+	C_PTP (ptp_deleteobject(params, handle, 0));
 
 	/* On some Canon firmwares, a DeleteObject causes a ObjectRemoved event
 	 * to be sent. At least on Digital IXUS II and PowerShot A85. But


### PR DESCRIPTION
The ptp_deleteobject() call was not checking its return value, which could cause the function to return success even when the delete operation failed.

Now properly check the return value and return GP_ERROR if the delete operation fails, ensuring errors are properly propagated to the caller.