### PR TITLE
Fixed CHDK Live View Bitmap Desc Memset Target (Copy-Paste Bug)

### DIFF
--- a/camlibs/ptp2/chdk.c
+++ b/camlibs/ptp2/chdk.c
@@ -1335,7 +1335,7 @@ chdk_camera_capture_preview (Camera *camera, CameraFile *file, GPContext *contex
 
 	memset (&header, 0, sizeof (header));
 	memset (&vpd, 0, sizeof (vpd));
-	memset (&vpd, 0, sizeof (bmd));
+	memset (&bmd, 0, sizeof (bmd));
 
 	CR (camera_prepare_chdk_capture (camera, context));
 	C_PTP_REP_MSG (ptp_chdk_get_live_data (params, flags, &data, &size),


### PR DESCRIPTION
In chdk_camera_capture_preview(), the memset for bmd was incorrectly using &vpd as the target, leaving bmd uninitialized with stack garbage. This is a copy-paste error from the memset line above for vpd.