### PR TITLE
fix(ptp2): handle Apple iOS orphan root associations in folder listing

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -8059,6 +8059,38 @@ camera_summary (Camera* camera, CameraText* summary, GPContext *context)
 #undef APPEND_TXT
 }
 
+/*
+ * Apple iOS devices (via PTP) can return root-level association objects
+ * (month folders) from GetObjectHandles, but GetObjectInfo reports them
+ * with ParentObject = 0x00000001 instead of the expected root 0x00000000.
+ * Handle 0x00000001 is not present in the object cache, so the standard
+ * parent-child filter rejects all root-level entries, making the store
+ * appear empty.
+ *
+ * This is similar to the existing workaround for ParentObject == StorageID,
+ * but covers the case where Apple returns a different bogus parent value.
+ *
+ * Returns non-zero if the object should be treated as a root child despite
+ * its non-zero ParentObject.
+ */
+static int
+apple_orphan_root_association(PTPParams *params, uint32_t parent, PTPObject *ob)
+{
+	PTPObject	*parentob = NULL;
+
+	if (parent != PTP_HANDLER_ROOT)
+		return 0;
+	if (!params->deviceinfo.Manufacturer ||
+	    strcmp(params->deviceinfo.Manufacturer, "Apple Inc."))
+		return 0;
+	if (ob->oi.ObjectFormat != PTP_OFC_Association)
+		return 0;
+	if (!ob->oi.ParentObject || ob->oi.ParentObject == ob->oi.StorageID)
+		return 0;
+
+	return ptp_find_object_in_cache(params, ob->oi.ParentObject, &parentob) != PTP_RC_OK;
+}
+
 static uint32_t
 find_child (PTPParams *params, const char *path, uint32_t storage, uint32_t handle, PTPObject **retob)
 {
@@ -8077,7 +8109,8 @@ find_child (PTPParams *params, const char *path, uint32_t storage, uint32_t hand
 		PTPObject *ob;
 		if (PTP_RC_OK != ptp_object_want (params, *poid, PTPOBJECT_PARENTOBJECT_LOADED, &ob)) // refresh
 			continue; /* object might have been deleted but ObjectRemoved event not handled, yet */
-		if (ob->oi.ParentObject != handle)
+		if (ob->oi.ParentObject != handle &&
+		    !apple_orphan_root_association(params, handle, ob))
 			continue;
 
 		if (PTP_RC_OK != ptp_object_want (params, *poid, PTPOBJECT_OBJECTINFO_LOADED, &ob)) // refresh
@@ -8163,7 +8196,8 @@ generic_list_func (PTPParams *params, const char *folder, int is_directory, Came
 
 		/* If a filtered ptp_getobjecthandles in ptp_list_folder is not supported by the device,
 		 * we might end up having handles for all objects in 'handles', therefore we check the parent */
-		if ((ob->oi.ParentObject != parent))
+		if ((ob->oi.ParentObject != parent) &&
+		    !apple_orphan_root_association(params, parent, ob))
 			continue;
 
 		if (!(ob->flags & PTPOBJECT_OBJECTINFO_LOADED))

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -3283,6 +3283,33 @@ ptp_list_folder_eos (PTPParams *params, uint32_t storage, uint32_t handle, PTPOb
 	return PTP_RC_OK;
 }
 
+/*
+ * Apple iOS devices can report root-level association objects with a
+ * bogus ParentObject (e.g. 0x00000001) that is neither root (0x00000000)
+ * nor the StorageID. These objects are returned by GetObjectHandles but
+ * would be rejected by the standard root-folder cache filter because
+ * their ParentObject does not match 0.
+ *
+ * Returns non-zero if the object should be included as a root child.
+ */
+static int
+ptp_apple_orphan_root_association (PTPParams *params, uint32_t storage, PTPObject *ob)
+{
+	PTPObject	*parentob = NULL;
+
+	if (!params->deviceinfo.Manufacturer ||
+	    strcmp (params->deviceinfo.Manufacturer, "Apple Inc."))
+		return 0;
+	if (ob->oi.StorageID != storage)
+		return 0;
+	if (ob->oi.ObjectFormat != PTP_OFC_Association)
+		return 0;
+	if (!ob->oi.ParentObject || ob->oi.ParentObject == ob->oi.StorageID)
+		return 0;
+
+	return ptp_find_object_in_cache (params, ob->oi.ParentObject, &parentob) != PTP_RC_OK;
+}
+
 uint16_t
 ptp_list_folder (PTPParams *params, uint32_t storage, uint32_t handle, PTPObjectHandles *children) {
 	unsigned int		changed, last;
@@ -3304,7 +3331,9 @@ ptp_list_folder (PTPParams *params, uint32_t storage, uint32_t handle, PTPObject
 	 * assume the entries in the root folder can never change. */
 	if (!handle && children && params->objects.len != 0) {
 		for_each (PTPObject*, pob, params->objects)
-			if (pob->oi.ParentObject == 0 && pob->oi.StorageID == storage)
+			if (pob->oi.StorageID == storage &&
+			    (pob->oi.ParentObject == 0 ||
+			     ptp_apple_orphan_root_association (params, storage, pob)))
 				array_push_back(children, pob->oid);
 		return PTP_RC_OK;
 	}


### PR DESCRIPTION
## Summary
- Fix iPhone PTP import showing empty store by handling Apple iOS orphan root associations in folder listing

## Problem

Apple iOS devices connected via USB PTP can return root-level association objects (month folders like `202302_a`) from `GetObjectHandles`, but `GetObjectInfo` reports them with `ParentObject = 0x00000001` instead of the expected root `0x00000000`. Since handle `0x00000001` is not present in the object cache, all root-level entries are rejected by the parent-child filter, making the store appear completely empty.

## Changes

| File | Change |
|------|--------|
| `camlibs/ptp2/library.c` | Add `apple_orphan_root_association()` helper; apply it in `find_child()` and `generic_list_func()` to accept orphan root associations from Apple devices |
| `camlibs/ptp2/ptp.c` | Add `ptp_apple_orphan_root_association()` helper; apply it in `ptp_list_folder()` root-folder cache branch |

## Detection Logic

An object is treated as a root child despite its non-zero `ParentObject` when ALL of these are true:
- Device manufacturer is `"Apple Inc."`
- The query is for the root folder (parent = `0x00000000`)
- The object is an Association/Directory (`PTP_OFC_Association`)
- `ParentObject` is non-zero and not equal to `StorageID`
- `ParentObject` handle does not exist in the object cache

## Test Plan

- [x] Syntax check: `gcc -fsyntax-only` passes on both modified files
- [ ] Manual verification: connect iPhone via USB PTP and run `gphoto2 --list-folders` (requires hardware)
- [ ] Verify existing Apple PTP workaround (`ParentObject == StorageID`) still works
- [ ] Verify non-Apple devices are not affected (helper returns 0 early)

## Context

This is similar to the existing workaround for `ParentObject == StorageID` already in the codebase, but covers a different bogus parent value returned by newer iOS versions (26.5 on iPhone 16,2).

Fixes #1254
