### PR TITLE
Fix incorrect PC mode when exising on OM-1

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -3315,13 +3315,9 @@ camera_exit (Camera *camera, GPContext *context)
 		case PTP_VENDOR_FUJI:
 			CR (camera_unprepare_capture (camera, context));
 			break;
-		case PTP_VENDOR_GP_OLYMPUS_OMD: {
-			PTPPropValue propval;
-
-			propval.u16 = 0;
-			CR (ptp_setdevicepropvalue (params, 0xD052, &propval, PTP_DTC_UINT16));
+		case PTP_VENDOR_GP_OLYMPUS_OMD:
+			ptp_olympus_exit_pc_mode (params);
 			break;
-		}
 		case PTP_VENDOR_GP_LEICA:
 			if (ptp_operation_issupported(params, PTP_OC_LEICA_LECloseSession)) {
 				if ((exit_result = ptp_leica_leclosesession (params)) != PTP_RC_OK)

--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -1304,8 +1304,13 @@ ptp_olympus_init_pc_mode (PTPParams* params)
 
 	ptp_debug (params,"PTP: (Olympus Init) switching to PC mode...");
 
+	params->olympus_camera_control_mode = 2;
+	ret = ptp_getdevicepropvalue (params, PTP_DPC_OLYMPUS_CameraControlMode, &propval, PTP_DTC_UINT16);
+	if (ret == PTP_RC_OK)
+		params->olympus_camera_control_mode = propval.u16;
+
 	propval.u16 = 1;
-	ret = ptp_setdevicepropvalue (params, 0xD052, &propval, PTP_DTC_UINT16);
+	ret = ptp_setdevicepropvalue (params, PTP_DPC_OLYMPUS_CameraControlMode, &propval, PTP_DTC_UINT16);
 	usleep(100000);
 
 	for(i = 0; i < 2; i++) {
@@ -1336,6 +1341,33 @@ ptp_olympus_init_pc_mode (PTPParams* params)
 	//gp_port_set_timeout (camera->port, timeout);
 	//ret=ptp_transaction(params, &ptp, PTP_DP_RESPONSEONLY, size, &data, NULL);
 	//free(data);
+	return ret;
+}
+
+uint16_t
+ptp_olympus_exit_pc_mode (PTPParams* params)
+{
+	uint16_t		ret;
+	PTPPropValue		propval;
+	PTPContainer		event;
+	int			i;
+
+	ptp_debug (params,"PTP: (Olympus Exit) leaving PC mode...");
+
+	propval.u16 = params->olympus_camera_control_mode;
+	if (!propval.u16)
+		propval.u16 = 2;
+
+	ret = ptp_setdevicepropvalue (params, PTP_DPC_OLYMPUS_CameraControlMode, &propval, PTP_DTC_UINT16);
+	usleep(100000);
+
+	for (i = 0; i < 2; i++) {
+		ptp_check_event (params);
+		if (ptp_get_one_event(params, &event))
+			break;
+		usleep(100000);
+	}
+
 	return ret;
 }
 

--- a/camlibs/ptp2/ptp.h
+++ b/camlibs/ptp2/ptp.h
@@ -4025,6 +4025,9 @@ struct _PTPParams {
 	struct timeval		starttime;
 	int			sony_mode_ver;
 
+	/* PTP: Olympus specifics */
+	uint16_t		olympus_camera_control_mode;
+
 	/* PTP: Wifi profiles */
 	uint8_t 	wifi_profiles_version;
 	uint8_t		wifi_profiles_number;
@@ -5135,6 +5138,7 @@ uint16_t ptp_olympus_omd_capture (PTPParams* params);
 uint16_t ptp_olympus_omd_bulbstart (PTPParams* params);
 uint16_t ptp_olympus_omd_bulbend (PTPParams* params);
 uint16_t ptp_olympus_init_pc_mode (PTPParams* params);
+uint16_t ptp_olympus_exit_pc_mode (PTPParams* params);
 uint16_t ptp_olympus_sdram_image (PTPParams* params, unsigned char **data, unsigned int *size);
 
 


### PR DESCRIPTION
OM-1 mk II (and I believe mk I but didn't test it yet) crashes on `gphoto2 --summary` with on-screen message 

> No Connection. Remove USB Cable

This fix resolved the issue using correct mode for the camera. Tested on OM-1 mk II