### PR TITLE
fix: normalize ParentObject 0xffffffff to 0 in ptp_object_want

### DIFF
--- a/camlibs/ptp2/ptp.c
+++ b/camlibs/ptp2/ptp.c
@@ -10024,6 +10024,11 @@ ptp_object_want (PTPParams *params, uint32_t handle, unsigned int want, PTPObjec
 		if (ob->oi.ParentObject == handle)
 			ob->oi.ParentObject = 0;
 
+		/* Some cameras (e.g. Ricoh GR III) report 0xffffffff for root-level
+		 * objects instead of 0x00000000. Normalize to root. */
+		if (ob->oi.ParentObject == PTP_HANDLER_SPECIAL)
+			ob->oi.ParentObject = 0;
+
 		/* Detect if the file is larger than 4GB ... indicator is size 0xffffffff ...
 		 * In that case explicitly request the MTP object proplist to get the right size */
 		if (ob->oi.ObjectSize == 0xffffffffUL) {


### PR DESCRIPTION
# Description
Some cameras (or at least the Ricoh GR III) return `0xffffffff` as the ParentObject for root-level objects instead of `0x00000000`. This causes the objects to be silently dropped by `generic_list_func`, `find_child`, and the object cache lookup — all of which check `ParentObject == 0` to identify root children.

This PR updates `ptp_object_want` by normalizing `ParentObject == PTP_HANDLER_SPECIAL` to 0. 

I'm admittedly pretty green here, but according to AI this should be safe because "`0xffffffff` is a reserved sentinel that no valid PTP object handle can equal".

This follows the same pattern as the existing EOS workaround at line 10024 (ParentObject == handle → 0) and the Apple iOS workaround at line 10045 (ParentObject == StorageID → 0).


# Testing
- Tested on Ricoh GR III (firmware 1.91, PTP mode over USB)
- `gphoto2 --list-folders` now correctly shows DCIM on SD card (was empty before)
- `gphoto2 --folder="/store_00010001/DCIM" --list-files` lists files correctly