### PR TITLE
Add PTP support for Pentax K-3 Mark III Monochrome

### DIFF
--- a/camlibs/ptp2/library.c
+++ b/camlibs/ptp2/library.c
@@ -2810,6 +2810,8 @@ static struct {
 
 	/* via email to gphoto-devel */
 	{"Pentax:KP (PTP Mode)",		0x25fb, 0x017f, 0},
+	/* Pentax K-3 Mark III Monochrome, USB setting: MTP */
+	{"Pentax:K-3 Mark III Monochrome (PTP Mode)", 0x25fb, 0x018f, 0},
 
 	{"Sanyo:VPC-C5 (PTP mode)",             0x0474, 0x0230, 0},
 	/* https://github.com/gphoto/libgphoto2/issues/497 */


### PR DESCRIPTION
Register the Pentax K-3 Mark III Monochrome USB ID with the existing PTP driver.

The camera enumerates as 25fb:018f when its USB setting is MTP. Without an explicit abilities-table entry, this USB ID is not associated with ptp2 during normal camera detection.

Validated on a K-3 Mark III Monochrome running firmware 2.11. The existing ptp2 driver reads the device and storage summary, receives FILEADDED events from the physical shutter, and downloads a complete DNG. The camera reports remote image capture as unsupported, so this change does not claim or enable remote capture.