### PR TITLE
derive _get_Canon_EOS_ZoomRange (PowerZoomPosition) range from device-reported PTP_DPFF_Enumeration

### DIFF
--- a/camlibs/ptp2/config.c
+++ b/camlibs/ptp2/config.c
@@ -1906,16 +1906,28 @@ static int
 _get_Canon_EOS_ZoomRange(CONFIG_GET_ARGS) {
 	float	f, t, b, s;
 
-/*
-	if (!(dpd->FormFlag & PTP_DPFF_Range))
-		return GP_ERROR;
-*/
 	gp_widget_new (GP_WIDGET_RANGE, _(menu->label), widget);
 	gp_widget_set_name (*widget,menu->name);
 	f = (float)dpd->CurrentValue.u32;
-	b = 0.0;
-	t = 1000.0;
-	s = 1.0;
+	if ((dpd->FormFlag & PTP_DPFF_Enumeration) && dpd->FORM.Enum.NumberOfValues) {
+		unsigned int j;
+
+		/* Some cameras (e.g. PowerShot SX740) report a single-entry
+		 * enumeration here that is really just the upper bound, not a
+		 * full list of legal positions. Treat 0 as the floor and take
+		 * the largest enumerated value as the ceiling either way. */
+		b = 0.0;
+		t = (float)dpd->FORM.Enum.SupportedValue[0].u32;
+		for (j=1; j<dpd->FORM.Enum.NumberOfValues; j++) {
+			float v = (float)dpd->FORM.Enum.SupportedValue[j].u32;
+			if (v > t) t = v;
+		}
+		s = 1.0;
+	} else {
+		b = 0.0;
+		t = 1000.0;
+		s = 1.0;
+	}
 	gp_widget_set_range (*widget, b, t, s);
 	gp_widget_set_value (*widget, &f);
 	return GP_OK;


### PR DESCRIPTION
# SX740 HS derive `zoom` range from device-reported value

`_get_Canon_EOS_ZoomRange()` always reported a hardcoded 0-1000 range for `zoom` widget, ignoring the camera's actual reported bounds. On a Canon PowerShot SX740 HS, this property is reported via `PTP_DPFF_Enumeration` with a single value representing the real max (`127`) — sending a value above 127 hangs the camera.

This derives the range from the largest `PTP_DPFF_Enumeration` value (floor `0`) when that form is present, falling back to the original 0-1000 bounds otherwise. 

Only the enumeration case is handled since that's the only form I can verify against real hardware; I did not touch  the `PTP_DPFF_Range` code path to avoid changing behavior for cameras I have no way to test.

Before:
```yaml
- name: zoom
  type: range
  value: 0.0
  begin: 0.0
  end: 1000.0
  step: 1.0
```
After:
```yaml
- name: zoom
  type: range
  value: 0.0
  begin: 0.0
  end: 127.0
  step: 1.0
```

Tested on a Canon PowerShot SX740 HS.
